### PR TITLE
Fix devcontainer Python bytecode caching for cross-platform development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,14 @@
     "UV_CACHE_DIR": "/home/vscode/.cache/uv",
     // Copy instead of hardlinking due to separate volumes
     "UV_LINK_MODE": "copy",
-    // Put Python bytecode outisde the project, so it doesn't get synced to the host
-    "PYTHONPYCACHEPREFIX": "/home/vscode/.cache/pycache"
+    // Don't write .pyc files for project modules: avoids conflicts when the
+    // same source tree is run from both the container (Linux) and the host
+    // (macOS/Windows). Previously we used PYTHONPYCACHEPREFIX, but marimo
+    // mirrors its __marimo__/ output dir under that prefix too, hiding the
+    // notebook auto-export files. Pair with UV_COMPILE_BYTECODE so installed
+    // packages in .venv are still pre-compiled at install time.
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "UV_COMPILE_BYTECODE": "1"
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Description

Replace `PYTHONPYCACHEPREFIX` with `PYTHONDONTWRITEBYTECODE=1` in the devcontainer configuration to prevent `.pyc` file conflicts when the same source tree is accessed from both the container (Linux) and the host (macOS/Windows).

The previous approach using `PYTHONPYCACHEPREFIX` had an unintended side effect: marimo was mirroring its `__marimo__/` output directory under that prefix, which hid the notebook auto-export files. By switching to `PYTHONDONTWRITEBYTECODE`, we prevent bytecode generation for project modules entirely, avoiding these conflicts.

To maintain performance for installed packages, we pair this with `UV_COMPILE_BYTECODE=1` so that dependencies in `.venv` are still pre-compiled at install time.

## Checklist
- [ ] I've run `./go check` and all tests pass
- [ ] I've added documentation where appropriate
- [ ] I've tested my changes

## Copyright Dedication

I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.

From [Unlicence.org](https://unlicense.org/#unlicensing-contributions)

https://claude.ai/code/session_01PZEAQqwent3SaPRcP7Bsvi