### PR TITLE
Fix ty false positives in CI (Marimo notebooks, model tests, hooks)

### DIFF
--- a/docs/getting_started.py
+++ b/docs/getting_started.py
@@ -134,7 +134,7 @@ def options():
     app_type = mo.ui.radio(
         label='Apparatus',
         options=['local', 'modal'],
-        value=mo.cli_args().get('app', 'local'),
+        value=str(mo.cli_args().get('app', 'local')),
         inline=True,
     )
     run_button = mo.ui.run_button(

--- a/docs/gpt.py
+++ b/docs/gpt.py
@@ -399,19 +399,19 @@ def options():
     app_type = mo.ui.radio(
         label='Apparatus',
         options=['local', 'modal'],
-        value=mo.cli_args().get('app', 'local'),
+        value=str(mo.cli_args().get('app', 'local')),
         inline=True,
     )
     arch = mo.ui.radio(
         label='Architecture',
         options=['gpt', 'ngpt'],
-        value=mo.cli_args().get('arch', 'gpt'),
+        value=str(mo.cli_args().get('arch', 'gpt')),
         inline=True,
     )
     ngpt_variant = mo.ui.radio(
         label='nGPT variant',
         options=['crude', 'full'],
-        value=mo.cli_args().get('ngpt_variant', 'crude'),
+        value=str(mo.cli_args().get('ngpt_variant', 'crude')),
         inline=True,
     )
     run_button = mo.ui.run_button(

--- a/docs/gpt_sweep.py
+++ b/docs/gpt_sweep.py
@@ -389,7 +389,7 @@ def options():
     app_type = mo.ui.radio(
         label='Apparatus',
         options=['local', 'modal'],
-        value=mo.cli_args().get('app', 'local'),
+        value=str(mo.cli_args().get('app', 'local')),
         inline=True,
     )
     run_button = mo.ui.run_button(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,10 +143,3 @@ paths = [
     ".vulture-allowlist.py"
 ]
 sort_by_size = true
-
-[tool.pyrefly]
-project-includes = [
-    "**/*.py*",
-    "**/*.ipynb",
-]
-# verbose = true

--- a/src/experiment/training/module.py
+++ b/src/experiment/training/module.py
@@ -48,7 +48,7 @@ class GPTModule(L.LightningModule):
         return loss
 
     @override
-    def on_train_batch_end(self, *args):
+    def on_train_batch_end(self, outputs, batch, batch_idx):
         # Re-project every weight matrix onto the unit hypersphere (nGPT
         # constraint). A no-op for the baseline GPT.
         self.model.normalize_weights()

--- a/src/subline/subline.py
+++ b/src/subline/subline.py
@@ -125,10 +125,10 @@ class Subline:
             Element(text_elem, 'tspan', x=mid, text=token)
             pos += width
 
-    def plot(self, tokens: str | list[str], series: list[Series]):
+    def plot(self, tokens: str | Sequence[str], series: list[Series]):
         """Generate and display an SVG visualization of text metrics."""
-        if isinstance(tokens, str):
-            tokens = list(tokens)
+        # A bare string is split into characters; any other sequence is taken as-is.
+        tokens = list(tokens)
 
         # Split tokens into lines and calculate dimensions
         spans = self._get_token_spans(tokens)

--- a/tests/experiment/test_models.py
+++ b/tests/experiment/test_models.py
@@ -1,11 +1,14 @@
 """Model variants: every one runs, and nGPT keeps activations/weights on the sphere."""
 
+from typing import cast
+
 import pytest
 import torch
 from torch.nn import functional as F
 
 from experiment.config import ModelConfig
-from experiment.model import build_model
+from experiment.model import NGPT, build_model
+from experiment.model.ngpt import Block
 
 ARCHS = [
     {'architecture': 'gpt'},
@@ -43,11 +46,13 @@ def test_forward_shape_and_finite(arch):
 def test_hidden_state_stays_on_sphere(arch):
     """Every nGPT block must return unit-norm hidden states."""
     config = make_config(**arch)
-    model = build_model(config).eval()
+    # These tests are nGPT-only; cast past the `build_model` base return type so
+    # the type checker sees the concrete attributes (`build_model` -> LanguageModel).
+    model = cast(NGPT, build_model(config).eval())
     idx = torch.randint(0, config.vocab_size, (2, 16))
     enc = model.transformer.rotary_enc
     h = F.normalize(model.transformer.wte(idx), dim=-1)
-    for block in model.transformer.blocks:
+    for block in cast(list[Block], model.transformer.blocks):
         h = block(h, enc)
         norms = h.norm(dim=-1)
         torch.testing.assert_close(norms, torch.ones_like(norms), rtol=0, atol=1e-5)
@@ -56,7 +61,7 @@ def test_hidden_state_stays_on_sphere(arch):
 @pytest.mark.parametrize('arch', NGPT_ARCHS)
 def test_normalize_weights_projects_onto_sphere(arch):
     """After normalization, each matrix is a stack of unit vectors along its hidden axis."""
-    model = build_model(make_config(**arch)).eval()
+    model = cast(NGPT, build_model(make_config(**arch)).eval())
     # Perturb, then re-project.
     for p in model.parameters():
         p.data.add_(torch.randn_like(p))
@@ -67,7 +72,7 @@ def test_normalize_weights_projects_onto_sphere(arch):
         torch.testing.assert_close(norms, torch.ones_like(norms), rtol=0, atol=1e-5)
 
     unit(model.transformer.wte.weight, dim=1)
-    for block in model.transformer.blocks:
+    for block in cast(list[Block], model.transformer.blocks):
         unit(block.attn.qkv.weight, dim=1)
         unit(block.attn.proj.weight, dim=0)
         unit(block.mlp.fc.weight, dim=1)


### PR DESCRIPTION
## Why

CI's `Type checking` step (`./go types` → `ty check`) was failing on every recent run. Reproducing locally surfaced **22 diagnostics**, all of which the Marimo editor's language server silently tolerates. They fell into four groups — and contrary to first impressions, the Marimo notebooks were the *minority*:

| Count | Where | Root cause |
|---|---|---|
| 15 | `tests/experiment/test_models.py` | torch's `nn.Module.__getattr__` → `Tensor \| Module` |
| 5 | `docs/*.py` notebooks | `mo.cli_args().get()` return type vs `radio(value=)` |
| 1 | `docs/subline.py` → `src/subline` | `list` invariance |
| 1 | `src/experiment/training/module.py` | Lightning hook override (LSP) |

## What

Root-cause fixes, no rule suppression:

- **`test_models.py`** — `build_model()` is typed to return the base `LanguageModel`, so `model.transformer` collapsed to torch's `Tensor | Module` `__getattr__` fallback and cascaded. These tests are nGPT-only, so `cast(NGPT, …)` and `cast(list[Block], …blocks)` — the same idiom `ngpt.py` already uses, since `nn.ModuleList` yields bare `Module` when iterated. Pure `typing.cast`, runtime no-ops.
- **Notebooks** — `mo.cli_args().get(k, d)` is typed `str | int | float | list[...]` but `radio(value=)` wants `str | None`; wrapped the 5 sites in `str(...)`.
- **`subline.py`** — widened `plot(tokens: str | list[str])` to `Sequence[str]` (a `list[LiteralString]` isn't assignable to the invariant `list[str]`).
- **`module.py`** — gave `on_train_batch_end` its real `(outputs, batch, batch_idx)` signature instead of `*args`, which violated LSP vs Lightning's base.
- Removed a vestigial `[tool.pyrefly]` section (pyrefly isn't a dependency).

## Verification

`ty check`, `ruff check`, and `ruff format --check` all pass. The `test_models.py` edits are runtime-neutral casts, so test behaviour is unchanged.

> Note on the Marimo "cell dependencies aren't typed" friction: a Marimo `.py` notebook encodes cell dataflow as untyped function boundaries, so `ty` sees `Unknown` params (which *suppress* errors rather than create them). That costs coverage inside cells but wasn't causing the failures; the editor recovers it via its language server. Investigating whether `marimo export script` can give CI cross-cell type checking is tracked separately.

https://claude.ai/code/session_012vGgoj2LNJxDVkhWGwxCV4

---
_Generated by [Claude Code](https://claude.ai/code/session_012vGgoj2LNJxDVkhWGwxCV4)_