### PR TITLE
notes: design exploration for autonomous (agent-run) experiments

### DIFF
--- a/.claude/agents/experiment-doctor.md
+++ b/.claude/agents/experiment-doctor.md
@@ -23,6 +23,13 @@ keys invalidate.
   runs away.
 - Drive recovery with `bin/mini retry <exp>` (scope with `--key` where you can).
 - Poll with `status`/`logs`; never re-run just to check progress.
+- For a remote run, thread `--app <backend>` (e.g. `--app modal`) through
+  **every** command — tick verbs (`retry`/`cancel`) and read verbs
+  (`status`/`logs`) alike, or a read hits the wrong (local) control plane.
+- Watch cost: a re-run after a shared-helper edit can relaunch a large set, and
+  cancelling is cheap while a forgotten detached GPU run is not. Honor any budget
+  the caller gave; if a recovery's blast radius looks large, confirm before
+  ticking.
 
 ## When to hand back to the human / Opus
 

--- a/.claude/agents/experiment-monitor.md
+++ b/.claude/agents/experiment-monitor.md
@@ -6,26 +6,57 @@ model: haiku
 ---
 
 You run and watch one mi-ni experiment via `bin/mini`, addressed by its name.
-You do **one pass** per invocation and report back; cadence and escalation are
-the orchestrator's job, not yours. Depth lives in
+One invocation **drives that experiment toward completion within a bounded
+budget**, then reports. Depth lives in
 `.agents/skills/mi-ni/references/running.md` — read it if unsure.
+
+## Scope & backend
+
+- Operate **only** on the experiment name you were given. Never launch, retry,
+  or cancel any *other* experiment — even to "help" or to clean up.
+- For a remote run, thread `--app <backend>` (e.g. `--app modal`) through
+  **every** command — the tick verbs (`run` / `retry` / `cancel`) and the read
+  verbs (`status` / `results` / `logs`) alike. A read without it silently hits
+  the wrong (local) control plane and looks empty.
 
 ## Tick vs. read (cost rule)
 
 - `run` / `retry` / `cancel` **tick** the DAG: they launch or stop work and
   **cost money**.
-- `ls` / `status` / `results` / `logs` only **read**. Poll with `status` —
-  **never re-run to check progress.**
-- Never pass `--watch` (it blocks); one plain `run` advances a stage and returns.
+- `ls` / `status` / `results` / `logs` only **read**. Poll progress with
+  `status` — **never re-`run` to check progress** (that advances/relaunches).
 
-## Your pass
+## Driving to completion
 
-1. **Launch / advance** if asked to start or move forward: `bin/mini run <exp>`.
-2. **Poll**: `bin/mini status <exp>` (add `--app modal` for a remote run).
-3. **On a FAILED task**: `bin/mini logs <exp> <key>` and decide per the rules
-   below.
-4. **Done** (all DONE): report results location (`bin/mini results <exp>` /
+A subagent re-spawn is a cold start, so don't count on the orchestrator to
+re-invoke you for cadence — **drive within this one invocation**, but always
+bounded:
+
+1. **Launch / advance** with `bin/mini run <exp>` (one tick advances a stage).
+2. **Poll** with `bin/mini status <exp>` on an interval (every few seconds),
+   **not** by re-`run`ning. Stop when every task is settled, when you hit your
+   time/poll budget, or when something needs escalation.
+3. `--watch` is allowed **only** for a run you expect to finish quickly, and
+   **only with a timeout** (`timeout 180 bin/mini run <exp> --watch`) so it can't
+   block forever. For anything long, prefer launch + bounded `status` polling.
+4. **On a FAILED task**: `bin/mini logs <exp> <key>`, then apply the hotfix
+   rules below or escalate.
+5. **When all DONE**: report the results location (`bin/mini results <exp>` /
    `report.py`).
+6. If you hit the budget before it settles, return a **progress** report (not an
+   error) so the caller can wait or re-invoke.
+
+## Budget & stop conditions
+
+Experiments spend real money.
+
+- Honor any **budget or time cap** the caller gives. If none is given, treat the
+  job as **small**: one experiment, short timeouts, no speculative extra runs.
+- Make sure tasks are **bounded** (a `--timeout` / a role that sets one); a run
+  with no time bound can burn money indefinitely.
+- If a task overruns its expected time, or you see runaway relaunches /
+  unexpected cost, **`bin/mini cancel <exp>` first**, then report. Cancelling is
+  cheap; a forgotten detached GPU run is not.
 
 ## Hotfix rules — hard guardrails
 
@@ -44,10 +75,19 @@ killed by a re-run). So:
 Attempt a fix only when it is **local and obvious** (typo, bad path, wrong
 hyperparameter type) and fits rules 1–3.
 
-## Escalate by returning a report
+## Report back
 
-Stop and return — do **not** guess past the mandate — when: the fix isn't
-local/obvious; the same task fails again after a fix; the failure is in
+Your output is what the orchestrator relays, so always end with a report.
+
+**Success / progress** (the happy path):
+
+```
+{ experiment, state (all DONE | N running/pending), where it ran (backend +
+  hardware), results location or key values, rough cost/time sense }
+```
+
+**Escalation** — stop and return, do **not** guess past the mandate — when: the
+fix isn't local/obvious; the same task fails again after a fix; the failure is in
 experiment design or `mini` internals; or cost looks wrong (runaway relaunches).
 You cannot spawn other agents; escalation is just this report:
 

--- a/docs/gpt-sweep/experiment.py
+++ b/docs/gpt-sweep/experiment.py
@@ -10,9 +10,10 @@ in. Drive it on Modal L4s from the CLI; the companion ``report.py`` reads the
 durable results and renders them.
 
     # one data-prep run, then nine training runs, fanned out across L4s:
-    bin/mini run docs/gpt-sweep/experiment.py --app modal --gpu L4 --max-containers 9 --timeout 720
+    bin/mini run docs/gpt-sweep/experiment.py --app modal --max-containers 9
 
-Re-run to advance/resume — done cells are memo hits, so a crash heals by re-running
+The hardware is bound by role (see ``roles`` below): ``prep`` runs CPU-only, ``train``
+on L4s — so ``main`` names labels, not GPUs. Re-run to advance/resume — done cells are memo hits, so a crash heals by re-running
 and a failed cell is recovered with ``bin/mini retry gpt-sweep``. Adding an LR or
 architecture below and re-running launches only the new cells.
 """
@@ -123,8 +124,15 @@ def train_one(config, arch_label: str, lr_str: str) -> tuple:
 
 
 def main(ctx: Ctx) -> list[tuple]:
-    meta = ctx.run(prepare_data)  # CPU prep; suspends until done
-    return ctx.map(train_one, build_sweep(meta))  # GPU sweep that depends on prep
+    meta = ctx.run(prepare_data, role='prep')  # CPU prep; suspends until done
+    return ctx.map(train_one, build_sweep(meta), role='train')  # GPU sweep that depends on prep
 
 
-experiment = Experiment(name='gpt-sweep', main=main)
+experiment = Experiment(
+    name='gpt-sweep',
+    main=main,
+    roles={
+        'prep': {},  # CPU-only: data download + tokenize
+        'train': dict(gpu='L4', timeout=720),  # GPU sweep cells
+    },
+)

--- a/docs/role-demo/experiment.py
+++ b/docs/role-demo/experiment.py
@@ -1,0 +1,48 @@
+"""Minimal role-selection demo: prove a step's role routes it to the right hardware.
+
+No real work — each step just reports the GPU it landed on (via ``nvidia-smi``,
+which Modal injects into GPU containers). The ``probe`` role is CPU-only, ``gpu``
+asks for an L4, so on Modal the records show one step saw no GPU and the other an L4.
+
+    bin/mini run docs/role-demo/experiment.py --app modal
+    bin/mini results role-demo --app modal
+
+Note the ``label`` argument: the memo key is ``fingerprint(fn, args)`` and excludes
+the hardware, so calling the same fn with the same args twice would be a memo *hit*
+(both steps returning the first's result). The label keeps the two keys distinct.
+"""
+
+from __future__ import annotations
+
+from mini import Ctx, Experiment
+
+
+def probe_hardware(label: str) -> str:
+    """Report the GPU this task landed on, or 'cpu' if there's none."""
+    import shutil
+    import subprocess
+
+    if not shutil.which('nvidia-smi'):
+        return 'cpu'
+    out = subprocess.run(
+        ['nvidia-smi', '--query-gpu=name', '--format=csv,noheader'],
+        capture_output=True,
+        text=True,
+    )
+    return out.stdout.strip() or 'cpu'
+
+
+def main(ctx: Ctx) -> dict[str, str]:
+    on_cpu = ctx.run(probe_hardware, 'probe', role='probe')
+    on_gpu = ctx.run(probe_hardware, 'gpu', role='gpu')
+    return {'probe': on_cpu, 'gpu': on_gpu}
+
+
+experiment = Experiment(
+    name='role-demo',
+    main=main,
+    roles={
+        'probe': {},  # CPU-only
+        'gpu': dict(gpu='L4', timeout=120),
+    },
+)

--- a/src/mini/apparatus.py
+++ b/src/mini/apparatus.py
@@ -148,6 +148,17 @@ class Apparatus(ABC, Generic[V]):
 
         yield from _map_in_thread(self, fn, *iterables, kwargs=kwargs)
 
+    def w(self, **kwargs: Any) -> Apparatus:
+        """Return a variant of this apparatus with backend-native options applied.
+
+        Role resolution uses this to specialize one base apparatus per role
+        (``base.w(gpu='L4')``). The default ignores every option and returns
+        *self*: a backend with no extra knobs (e.g. local) runs every role on
+        the same compute, so a role table written for Modal still loads and runs
+        locally. ``ModalApparatus`` overrides this to merge ``@function`` kwargs.
+        """
+        return self
+
     @abstractmethod
     def before_each(self, hook: Callable[[], Any]) -> Apparatus:
         """

--- a/src/mini/experiment.py
+++ b/src/mini/experiment.py
@@ -10,11 +10,13 @@ notebook becomes a *report* that reads durable results.
 from __future__ import annotations
 
 import importlib.util
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
 if TYPE_CHECKING:
+    from mini.apparatus import Apparatus
     from mini.orchestration import Ctx
 
 __all__ = ['Experiment', 'load_experiment']
@@ -35,16 +37,37 @@ class Experiment:
     Multi-step (memoized; re-run to recover)::
 
         def main(ctx):
-            meta = ctx.run(prepare_data)                 # CPU prep
-            return ctx.map(train, [...], on=gpu)         # per-step compute
+            meta = ctx.run(prepare_data, role='prep')    # CPU prep
+            return ctx.map(train, [...], role='train')   # per-step compute
 
-        Experiment(name='pipeline', main=main)
+        Experiment(name='pipeline', main=main, roles={'train': dict(gpu='L4')})
+
+    Roles let ``main`` stay backend-agnostic: it names a *label* and the run-edge
+    binding (the ``roles`` table, applied to whatever ``--app`` built) supplies the
+    concrete hardware. The label is intrinsic to the work (``prep`` is CPU-shaped,
+    ``train`` is GPU-shaped); the kwargs are native to the backend (``.w()``), so a
+    table written for Modal still loads locally (local ``.w()`` ignores them).
     """
 
     name: str
     fn: Callable[..., Any] | None = None
     configs: Sequence[Any] | None = None
     main: Callable[[Ctx], Any] | None = None
+    roles: Mapping[str, dict[str, Any]] | Callable[[Apparatus], Mapping[str, Apparatus]] | None = None
+
+    def resolve_roles(self, base: Apparatus) -> dict[str, Apparatus]:
+        """Bind role labels to concrete apparatus variants of *base*.
+
+        A dict maps each label to ``.w()`` kwargs applied to *base* (the common
+        case); a callable receives *base* and returns the variants directly (for
+        per-role ``before_each`` / image / volume). ``None`` → no roles.
+        """
+        if self.roles is None:
+            return {}
+        if isinstance(self.roles, Mapping):
+            table = cast('Mapping[str, Mapping[str, Any]]', self.roles)
+            return {label: base.w(**kwargs) for label, kwargs in table.items()}
+        return dict(self.roles(base))
 
     def orchestration(self) -> Callable[[Ctx], Any]:
         """Return the ``main(ctx)`` DAG (single sweeps become a one-line map)."""

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -34,16 +34,30 @@ class Ctx:
     only runs once the result exists. For parallel fan-out use ``map``, which
     launches *all* missing tasks before suspending.
 
-    Each call runs on the tick's *apparatus* by default; pass ``on=`` to route a
-    step elsewhere (e.g. CPU prep, GPU training). The apparatus also supplies the
+    Each call runs on the tick's *apparatus* by default. Route a step elsewhere
+    with ``role=`` (a label the experiment's ``roles`` table binds to hardware —
+    the file-experiment path, since the CLI holds no apparatus handles) or ``on=``
+    (a concrete apparatus — the notebook path). The apparatus also supplies the
     per-step ``before_each`` hooks.
     """
 
-    def __init__(self, store: MemoStore, apparatus: Apparatus):
+    def __init__(self, store: MemoStore, apparatus: Apparatus, roles: dict[str, Apparatus] | None = None):
         self.store = store
         self.apparatus = apparatus
+        self.roles = roles or {}
         self.launched: list[str] = []
         self.pending: list[str] = []
+
+    def _route(self, on: Apparatus | None, role: str | None) -> Apparatus:
+        """Resolve which apparatus a step runs on: ``role`` label, ``on=``, or default."""
+        if on is not None and role is not None:
+            raise ValueError('pass either role= or on=, not both')
+        if role is not None:
+            if role not in self.roles:
+                known = ', '.join(sorted(self.roles)) or '(none defined)'
+                raise ValueError(f'unknown role {role!r}; defined roles: {known}')
+            return self.roles[role]
+        return on or self.apparatus
 
     def _classify(
         self, fn: Callable, args: tuple, version: str | None, app: Apparatus
@@ -62,8 +76,15 @@ class Ctx:
             state = RunState.RUNNING
         return key, state, to_launch
 
-    def run(self, fn: Callable, *args: Any, version: str | None = None, on: Apparatus | None = None) -> Any:
-        app = on or self.apparatus
+    def run(
+        self,
+        fn: Callable,
+        *args: Any,
+        version: str | None = None,
+        on: Apparatus | None = None,
+        role: str | None = None,
+    ) -> Any:
+        app = self._route(on, role)
         key, state, to_launch = self._classify(fn, args, version, app)
         if to_launch is not None:
             app.spawn_tasks(self.store, [to_launch])
@@ -73,9 +94,14 @@ class Ctx:
         raise Pending(f'waiting on {key}')
 
     def map(
-        self, fn: Callable, items: Sequence[Any], version: str | None = None, on: Apparatus | None = None
+        self,
+        fn: Callable,
+        items: Sequence[Any],
+        version: str | None = None,
+        on: Apparatus | None = None,
+        role: str | None = None,
     ) -> list[Any]:
-        app = on or self.apparatus
+        app = self._route(on, role)
         results: list[Any] = []
         batch: list[tuple[str, Callable, tuple, list]] = []
         for raw in items:
@@ -103,7 +129,7 @@ def tick(experiment: Experiment, apparatus: Apparatus) -> tuple[bool, Any]:
     on=)``.
     """
     store = apparatus.memo_store()
-    ctx = Ctx(store, apparatus)
+    ctx = Ctx(store, apparatus, experiment.resolve_roles(apparatus))
     try:
         result = experiment.orchestration()(ctx)
     except Pending as p:

--- a/tests/mini/test_orchestration.py
+++ b/tests/mini/test_orchestration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
 from mini.experiment import Experiment
 from mini.local_apparatus import LocalApparatus
@@ -176,6 +177,70 @@ def test_per_step_apparatus_uses_its_hooks(tmp_path: Path):
     assert _drive(Experiment(name='perstep', main=main), default) == [1]
     assert (data_dir / 'gpu_hook').exists()  # the on= apparatus's hook ran
     assert not (data_dir / 'default_hook').exists()  # the tick default's did not
+
+
+def test_role_routes_to_its_apparatus(tmp_path: Path):
+    """``role=`` binds a label to a ``.w()`` variant via the experiment's ``roles``
+    table — proven (like ``on=``) through each variant's ``before_each`` hook."""
+
+    def mark_prep():
+        from mini import get_data_dir
+
+        (get_data_dir() / 'prep_hook').touch()
+
+    def mark_train():
+        from mini import get_data_dir
+
+        (get_data_dir() / 'train_hook').touch()
+
+    def task(x):
+        return x
+
+    data_dir = tmp_path / 'roles'
+
+    def roles(base: LocalApparatus) -> dict[str, LocalApparatus]:
+        # callable form: lets each role attach its own hook (local has no .w knobs)
+        return {'prep': base.before_each(mark_prep), 'train': base.before_each(mark_train)}
+
+    def main(ctx):
+        ctx.run(task, 0, role='prep')
+        return ctx.map(task, [(1,)], role='train')
+
+    exp = Experiment(name='roles', main=main, roles=roles)
+    assert _drive(exp, LocalApparatus('roles', data_dir=data_dir)) == [1]
+    assert (data_dir / 'prep_hook').exists() and (data_dir / 'train_hook').exists()
+
+
+def test_role_kwargs_table_applies_w(tmp_path: Path):
+    """The dict form maps a label to ``.w()`` kwargs; the base apparatus's ``.w``
+    interprets them (local ignores GPU knobs, so the same table runs locally)."""
+    captured: dict[str, Any] = {}
+
+    class RecordingLocal(LocalApparatus):
+        def w(self, **kwargs):  # local has no native knobs; record + no-op
+            captured.update(kwargs)
+            return self
+
+    def task(x):
+        return x
+
+    exp = Experiment(name='wtab', main=lambda ctx: ctx.map(task, [(1,)], role='train'), roles={'train': dict(gpu='L4')})
+    assert _drive(exp, RecordingLocal('wtab', data_dir=tmp_path / 'wtab')) == [1]
+    assert captured == {'gpu': 'L4'}
+
+
+def test_unknown_role_and_role_on_conflict_raise(tmp_path: Path):
+    from mini.orchestration import Ctx
+
+    app = LocalApparatus('routing', data_dir=tmp_path / 'routing')
+    ctx = Ctx(app.memo_store(), app, roles={'train': app})
+
+    import pytest
+
+    with pytest.raises(ValueError, match='unknown role'):
+        ctx.run(lambda: None, role='gpu')
+    with pytest.raises(ValueError, match='not both'):
+        ctx.run(lambda: None, on=app, role='train')
 
 
 def test_ctx_spawns_via_the_apparatus(tmp_path: Path):

--- a/todo.md
+++ b/todo.md
@@ -115,10 +115,22 @@ experiment:
   → subprocess per task; `ModalApparatus` → detached Modal spawn). `on=` now routes
   *compute*, not just hooks. Records went behind a `RecordStore` (local JSON /
   `modal.Dict`).
-- **Role labels for file-based experiments.** `on=apparatus` only works from a
-  notebook (which holds apparatus handles); a file experiment loaded by the CLI
-  has none. Plan: abstract *role* labels (`ctx.map(..., role='gpu')`) that the
-  driver/CLI maps to concrete apparatuses, so `main` stays backend-agnostic.
+- ~~**Role labels for file-based experiments.**~~ **Done.** `ctx.run/map(...,
+  role='gpu')` names a label; `Experiment(roles=...)` binds it. The common form is a
+  table `{label: .w()-kwargs}` applied to whatever `--app` built (`resolve_roles`);
+  a callable `(base) -> {label: apparatus}` is the escape hatch for per-role
+  `before_each`/image. Backend-native knobs stay typed in code (not CLI strings),
+  and the same table runs locally — `Apparatus.w` defaults to a no-op so local
+  ignores Modal's `gpu=`. `role=`/`on=` are mutually exclusive; an undefined role
+  raises. All roles share one volume by construction (`.w()`/`clone` keep `_volume`),
+  so heterogeneous hardware still sees the same storage. Verified live on Modal
+  (`docs/role-demo`: probe→cpu, gpu→L4).
+  - *Deferred (separate primitive):* **run presets / parameterized `main`** — bundle
+    {config overrides + role tier} under one name (`smoke` vs `full`) so the same DAG
+    runs at different sizes. This is *not* roles: batch size / steps are
+    hyperparameters (config, already swept + memoized), and since the memo key
+    excludes hardware, a size bump must change the config, not just the GPU. `main`
+    currently takes only `ctx`, so passing a preset in is the missing piece.
 - **Capture compute-environment metadata in the run/task records** (what it
   actually ran on) — separate from backend selection above.
 


### PR DESCRIPTION
Analysis + validated proof-of-concept for letting an agent launch,
monitor, and report on mi-ni experiments across short-lived processes
(Claude Code on the web). Core idea: split the run lifecycle into
durable submit/poll/gather phases rather than one blocking generator.

- notes/agentic-experiments.md: diagnosis (lifecycle is fused to one
  process), proposed src/mini changes, experiment-structure split
  (definition vs report), and a concrete Run/status/gather API.
- notes/agentic_poc.py: local-compute PoC proving the decoupling —
  detached workers, polling from fresh processes, durable failure
  surfacing — reusing mini's emit_progress with only the sink swapped.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C31PCTQ6eEvnn9P9BnCqa5