### PR TITLE
Add HF buckets storage feasibility study

### DIFF
--- a/research/artifact-store.md
+++ b/research/artifact-store.md
@@ -1,0 +1,217 @@
+# Content-addressed artifacts: a design sketch
+
+This builds on the [bucket benchmark](./hf-buckets.md) and the handles-not-paths
+frame from our threads. It's a sketch, not a spec: I want to show how a
+content-addressed `Store` slots into the *current* `memo` / `Ctx` / `Volume`
+shapes, and flag the places where the real code pushes back on the tidy version
+of the idea. Names and signatures are illustrative.
+
+## Where this slots in
+
+Four things in the current code make this a completion rather than a rewrite.
+
+The memo key is already content-addressed and experiment-name-independent:
+`fingerprint(fn, args, version)` in `memo.py` hashes the function's source and
+canonicalized args, so identical prep in two experiments produces the same key.
+The asymmetry the frame names is real: we hash *inputs* into a key but store
+*outputs* as paths. A result is `cloudpickle.dumps(result)` at
+`data_dir/_memo/<key>/result.pkl` (`MemoStore.result_dir`), so a returned `Path`
+pickles a location into a volume that may have evaporated.
+
+The transactional ordering we'd need mostly exists. `_taskworker.execute_task`
+writes `result.pkl`, calls `commit()`, then flips the record to `DONE` — its
+docstring already promises that "a poller never sees a settled state whose
+artifact hasn't been committed yet." We extend that promise from "the volume was
+flushed" to "the referenced blobs are durable."
+
+Steps reach ambient services through context variables, not arguments:
+`get_data_dir()` reads a `contextvars.ContextVar` set by `data_dir_context`. A
+`Store` handle can ride the same pattern, which matters because of the process
+boundary below.
+
+And the `Volume` is already the warm, local thing (`path`, `upload`, `download`).
+In this design it stops being the durable home and becomes a checkout cache.
+
+## The handle
+
+```python
+@dataclass(frozen=True)
+class Artifact:
+    sha256: str
+    size: int
+    name: str                       # logical name, carries the extension
+    media_type: str | None = None   # for serving; inferred from name if None
+    kind: Literal['file', 'tree'] = 'file'
+    children: tuple[Artifact, ...] = ()  # for kind='tree': a manifest
+```
+
+A handle is small, JSON-canonicalizable, and location-free. That last property is
+load-bearing twice over: it's what lets a result pickle durably, and it's what
+lets a *downstream* step's fingerprint stay stable. Today, passing a prep output
+into `train` as a path would (if paths were deterministic, which they aren't)
+fingerprint `train` by location; passing an `Artifact` fingerprints it by
+content. Content-addressing outputs stabilizes the keys of everything that
+consumes them.
+
+The `tree` kind is the answer to "few big files or many small ones," which in
+this repo is both: the shared tokenized corpus is a few medium files, but
+mech-interp activation caches are many small ones with random per-shard access. A
+tree is a manifest of child handles — each child its own CAS blob — so you get
+per-file dedup and can resolve one shard without pulling the set. The benchmark
+is what makes this practical: per-file commits parallelize (8 concurrent in 2.6s
+vs 15.4s serial), so a manifest's many small puts aren't the latency trap they'd
+be if commits serialized. I'd reach for `tree` over tarring a directory whenever
+random access or partial dedup matters; tar only when a directory is always read
+whole.
+
+## The store
+
+```python
+class Store(Protocol):
+    def has(self, sha256: str) -> bool: ...
+    def put(self, data: bytes | Path, *, name: str) -> Artifact: ...
+    def get(self, art: Artifact, dest: Path) -> Path: ...      # materialize
+    def publish(self, art: Artifact, path: str) -> str: ...    # named view -> URL
+```
+
+Swappable the way the apparatus is: `LocalStore` (a `cas/<sha256>` tree on disk,
+the boring default), `HFBucketStore` (the same layout in a bucket), an `R2Store`
+later. Handles don't change when the backend does. `put` is idempotent: hash
+first, and if `has(sha)` skip the upload — which makes re-runs and cross-step
+duplicates free, and is why uploading before committing the memo costs nothing on
+the second pass.
+
+`HFBucketStore` writes blobs to `cas/<sha256>` with `batch_bucket_files`, and
+gets Xet chunk-level dedup *underneath* the logical CAS for nothing — two
+checkpoints sharing frozen layers store once. Concurrent writes don't conflict,
+because buckets are mutable (a git-backed Datasets repo would 412 here). The cost
+is that immutability is ours to enforce: write-once-by-hash is a discipline, not
+a guarantee from the backend.
+
+## put and get, and the process boundary
+
+The frame wrote `ctx.put` / `ctx.get`, but `Ctx` lives in the *driver* (it runs
+`main(ctx)`, suspends on `Pending`, and never executes a step's body). The step
+runs in a separate worker — local subprocess or Modal function. So put/get called
+*inside a step* can't be methods on that `Ctx`. They follow the `get_data_dir`
+pattern instead:
+
+```python
+# inside a step body
+from mini.store import put, get
+
+def prepare_corpus(cfg) -> Artifact:
+    out = get_data_dir() / 'corpus'
+    tokenize(cfg, into=out)
+    return put(out, name='corpus.bin')   # hashed + uploaded before fn returns
+```
+
+`put`/`get` read a `store` context var that the worker enters alongside the data
+dir, so the wiring is one line in `execute_task`:
+
+```python
+with data_dir_context(store.data_dir), store_context(app.store), progress_context(...):
+    result = fn(*args)
+(result_dir / 'result.pkl').write_bytes(cloudpickle.dumps(result))  # holds handles
+commit(); store.update(key, state=RunState.DONE)                    # unchanged
+```
+
+Because `put` uploads synchronously inside `fn`, by the time `result.pkl` is
+written the blobs are already durable; the existing write → commit → DONE order
+then gives the invariant for free: if a memo says DONE, its bytes resolve. The
+driver side does need a resolve too — when `main` passes a returned `Artifact`
+into the next step, and when a report reads results back — so `get` is also a
+plain function backed by the same store, usable outside a worker.
+
+## Lazy resolve, concurrently
+
+`get` checks the warm volume for `cas/<sha>` first and pulls from the store only
+on a miss, materializing into the checkout cache. The benchmark's per-op floor
+(~2-3s) means resolving a tree's shards one at a time would serialize painfully,
+so the tree resolve fans out:
+
+```python
+def get_tree(t: Artifact, dest: Path) -> Path:
+    with ThreadPoolExecutor() as ex:
+        list(ex.map(lambda c: get(c, dest / c.name), t.children))
+    return dest
+```
+
+This is the only place `hf://`/fsspec belongs — on the resolve path, where
+fsspec's faster small-file reads (0.3s vs 2.7s for 1 KB) actually help, not as
+the filesystem itself.
+
+## Publishing to the web
+
+This is what the benchmark changed. A CAS blob at `cas/<sha>` serves as
+`application/octet-stream` — no extension, so a browser won't render it. The
+named view fixes that: `publish` does a server-side copy *by hash*
+(`batch_bucket_files(copy=...)`, ~instant, no bytes moved) to an extensioned
+path, and the bucket's resolve URL then sets `Content-Type` from that extension.
+
+```python
+url = store.publish(fig, f'reports/{exp}/loss.png')
+# -> https://huggingface.co/buckets/<ns>/<bucket>/resolve/reports/<exp>/loss.png
+#    served as image/png, Content-Disposition: inline
+```
+
+So one bucket is both the durable store and the asset host, and the report's
+heavy figures move out of Git LFS. I'd split by size at this boundary: KB-scale
+curves stay committed in Git (visible and diffable in the GitHub UI), anything
+large is published and referenced by URL. That clears all four LFS problems at
+once — writable from Claude Code Cloud, no 1 GB ceiling, shareable mid-flight,
+and the report source still readable on GitHub. Keep Pages as the front door;
+just have it pull large assets from the bucket.
+
+The caveat to design around: direct serving wants a public bucket. Keep `publish`
+separate from `put` and explicitly public-scoped, so the durable CAS can be
+private while only deliberately published views are world-readable. Don't let
+public exposure become a side effect of persisting a result.
+
+## Cross-experiment reuse needs one more thing
+
+Handles are necessary but not sufficient for the "corpus prepared three times"
+problem. They fix the artifact half: outputs land in a global CAS keyed by sha,
+so the bytes dedupe across experiments. But that only dedupes *storage* — B still
+recomputes the corpus to discover the sha, because the *memo lookup* is
+per-experiment. `MemoStore` is scoped by `data_dir` (local `.mini/<name>`, Modal
+volume `<name>`), so A's record for key `prepare-abc123` is invisible to B even
+though the key is identical.
+
+To skip the *compute*, the record that maps key → result (now a handle) has to be
+findable across experiments. The cleanest version, given the fingerprint is
+already name-independent: resolve DONE results through a shared,
+content-addressed result store keyed by fingerprint, with the per-experiment
+`MemoStore` demoted to a run's control plane (progress, heartbeats, the in-flight
+set). A step checks the shared store first; a hit anywhere means skip-and-resolve.
+I'd make this opt-in per step at first (`ctx.run(prepare, shared=True)`), because
+a global memo namespace raises trust questions — one experiment's bug shouldn't
+silently poison another's cache — that want more thought than the storage layer
+does.
+
+## What I'd build first
+
+1. `Artifact`, `LocalStore`, and contextvar `put`/`get`; `result.pkl` holds
+   handles. This alone kills the dangling-path bug within an experiment, with no
+   backend change and no network.
+2. `HFBucketStore` with the `cas/<sha>` layout and concurrent puts. Durable,
+   swappable, cross-process — the thing that makes an agent picking up work in
+   Claude Code Cloud actually safe.
+3. `publish` for reports and figures; move large assets off LFS, split small/large
+   at the Git boundary.
+4. Shared-scope memo resolution for cross-experiment compute reuse, once we've
+   decided how much to trust a shared namespace.
+
+## Open questions
+
+The trust model for shared memoization is the big one: opt-in per step versus
+global, and how a poisoned or stale entry gets invalidated across experiments
+that didn't produce it. Garbage collection is the next — a CAS only grows, and
+buckets bill per TB, so we need refcounting from live memos plus a sweep
+(mutability at least makes the delete cheap). Smaller: whether `Store` should be
+async to match `Volume`, or stay sync inside steps and lean on `hf_xet`'s internal
+parallelism; and the exact on-disk manifest format for `tree` artifacts.
+
+If this shape looks right, the obvious next step is a real `Store` protocol plus
+`LocalStore` and the `put`/`get` contextvar wiring — step 1 above — which is
+self-contained and testable without any bucket at all.

--- a/research/artifact-store.md
+++ b/research/artifact-store.md
@@ -69,10 +69,17 @@ whole.
 ```python
 class Store(Protocol):
     def has(self, sha256: str) -> bool: ...
-    def put(self, data: bytes | Path, *, name: str) -> Artifact: ...
-    def get(self, art: Artifact, dest: Path) -> Path: ...      # materialize
-    def publish(self, art: Artifact, path: str) -> str: ...    # named view -> URL
+    def put(self, data: bytes | Path, *, name: str) -> Artifact: ...   # immutable blob
+    def get(self, art: Artifact, dest: Path) -> Path: ...             # materialize
+    def publish(self, art: Artifact, path: str) -> str: ...           # named view -> URL
+    def set_ref(self, name: str, art: Artifact) -> None: ...          # mutable name -> sha
+    def get_ref(self, name: str) -> Artifact | None: ...
 ```
+
+The `cas/<sha>` blobs are immutable; `set_ref`/`get_ref` are a small mutable layer
+of names over them (the git objects-and-refs split). One ref layer covers three
+needs that recur below: checkpoint pointers, the cross-experiment by-name lookup,
+and `publish`'s named views.
 
 Swappable the way the apparatus is: `LocalStore` (a `cas/<sha256>` tree on disk,
 the boring default), `HFBucketStore` (the same layout in a bucket), an `R2Store`
@@ -168,6 +175,19 @@ separate from `put` and explicitly public-scoped, so the durable CAS can be
 private while only deliberately published views are world-readable. Don't let
 public exposure become a side effect of persisting a result.
 
+This revises a decision in flight. Issue #13 left it open whether a public bucket
+exposes a direct, CDN-backed file URL, and PR #21 picked a *dataset repo* for the
+publish tier on the assumption it doesn't ("a bucket exposes no public file
+URL"). The benchmark settles that question the other way, so the decisive reason
+for a repo is gone. What's left is narrower and real: a repo keeps git history and
+lets you pin a citation to `/resolve/<commit-sha>/`. A bucket is mutable with no
+history — but serving a content-addressed path (`cas/<sha>` through a named view)
+gives immutable *content* without git, so the residual trade is permanence and the
+dataset-viewer ecosystem versus running one backend instead of two. I'd let #21
+land as a working primitive but make `HFStore` backend-swappable (repo or bucket),
+so the publish tier and the deferred L2 working store can later collapse onto a
+single bucket rather than splitting across a repo and a bucket.
+
 ## Cross-experiment reuse needs one more thing
 
 Handles are necessary but not sufficient for the "corpus prepared three times"
@@ -184,10 +204,48 @@ already name-independent: resolve DONE results through a shared,
 content-addressed result store keyed by fingerprint, with the per-experiment
 `MemoStore` demoted to a run's control plane (progress, heartbeats, the in-flight
 set). A step checks the shared store first; a hit anywhere means skip-and-resolve.
-I'd make this opt-in per step at first (`ctx.run(prepare, shared=True)`), because
-a global memo namespace raises trust questions — one experiment's bug shouldn't
-silently poison another's cache — that want more thought than the storage layer
-does.
+
+Issue #22 takes this further than I'd first proposed, and I think it's right. I'd
+floated opt-in-per-step (`shared=True`) out of caution about a global namespace;
+#22 instead scopes the store to the *project* and tags records by experiment. That
+answers my own worry: one project is one trust domain, so cross-experiment cache
+poisoning is just your own bug to fix. The opt-in caution really belongs at the
+cross-*project* boundary, not within a project. The cost #22 names is genuine and
+sits in the control plane, not the CAS: `cancel`, `retry`, and budget teardown
+must become tag-scoped, or a single `mini status` on an over-budget experiment
+cancels every experiment's in-flight tasks. Worth solving alongside the storage
+change, since they land together.
+
+## Checkpoints are a different category
+
+Mid-task checkpoints — the periodic state a long step writes so it can resume
+after a hard crash — are not step outputs, and shouldn't enter the handle graph.
+They're mutable and superseded on the next write, so content-addressing them pays
+the per-op floor repeatedly and churns the CAS with blobs obsolete minutes later.
+The giveaway is that resume needs to find "the latest checkpoint for this step" by
+a stable *name*, not by a hash you only learn after writing it.
+
+So checkpoints want the volume, not the CAS — with one correction. mini commits
+the Modal volume once at the step boundary (`execute_task` is called with
+`commit=volume.commit`), not mid-task, so a hard kill can lose everything written
+since the last background flush. If a checkpoint is expensive to recompute, call
+`volume.commit()` explicitly right after writing it rather than trusting
+auto-commit timing. Volume-based resume then works whenever the same durable named
+volume is re-mounted, which covers crash-and-retry in the same project on the same
+backend (and, under #22's project-scoped volume, across experiments in the
+project).
+
+It breaks in exactly the case this whole design exists for: a cross-process
+handoff where the volume isn't shared — close the laptop, an agent resumes in the
+Cloud, or local hands off to Modal. There the checkpoint has to live in the
+durable store. That points at a gap in the sketch above: the store wants a small
+*mutable ref layer* (`name → sha`) over the immutable `cas/<sha>` blobs — the git
+objects-and-refs split. One ref layer serves three needs: a `refs/checkpoints/<step>`
+pointer that resume overwrites, the named `publish` views, and the
+cross-experiment by-name lookup. A checkpoint becomes an explicit
+`checkpoint(path, name)` that updates a ref, distinct from the immutable `put`.
+Xet's chunk dedup makes each upload incremental rather than a full copy, but the
+latency floor still says: keep the cadence coarse, and default to the volume.
 
 ## What I'd build first
 
@@ -199,19 +257,25 @@ does.
    Claude Code Cloud actually safe.
 3. `publish` for reports and figures; move large assets off LFS, split small/large
    at the Git boundary.
-4. Shared-scope memo resolution for cross-experiment compute reuse, once we've
-   decided how much to trust a shared namespace.
+4. Project-scoped memo resolution for cross-experiment compute reuse (issue #22),
+   with the control-plane operations tag-scoped so budget teardown can't cancel a
+   sibling experiment's tasks.
 
 ## Open questions
 
-The trust model for shared memoization is the big one: opt-in per step versus
-global, and how a poisoned or stale entry gets invalidated across experiments
-that didn't produce it. Garbage collection is the next — a CAS only grows, and
-buckets bill per TB, so we need refcounting from live memos plus a sweep
-(mutability at least makes the delete cheap). Smaller: whether `Store` should be
-async to match `Volume`, or stay sync inside steps and lean on `hf_xet`'s internal
-parallelism; and the exact on-disk manifest format for `tree` artifacts.
+The trust model for shared memoization is the big one, though #22 narrows it: with
+project scoping the question moves to the cross-*project* boundary — how a poisoned
+or stale entry would be invalidated across projects that didn't produce it.
+Garbage collection is the next, and it's already issue #15 — a CAS only grows, and
+buckets bill per TB, so we need refcounting from live memos plus a sweep. The
+backend matters here: a bucket has server-side `rm`, while a Modal `Dict` (the
+control plane) has only `clear()`, no per-key delete, which shapes what tag-scoped
+cleanup can do. Smaller: whether `Store` should be async to match `Volume`, or stay
+sync inside steps and lean on `hf_xet`'s internal parallelism; and the exact
+on-disk manifest format for `tree` artifacts.
 
+These connect to work in flight: #13 (publish tiers), #21 (`HFStore`, the publish
+primitive), #22 (project-scoped store and cross-experiment reuse), and #15 (GC).
 If this shape looks right, the obvious next step is a real `Store` protocol plus
 `LocalStore` and the `put`/`get` contextvar wiring — step 1 above — which is
 self-contained and testable without any bucket at all.

--- a/research/hf-buckets.md
+++ b/research/hf-buckets.md
@@ -1,0 +1,155 @@
+# Hugging Face buckets as experiment storage
+
+A quick feasibility study, not a decision. I measured I/O latency for Hugging
+Face buckets and compared them to a Modal Volume, to see whether a
+`HFBucketVolume` could sit behind an `Apparatus`. The numbers look workable, but
+how we'd integrate it is still open. Treat everything here as provisional.
+
+## What a bucket is
+
+A bucket is its own repo type on the Hub, addressed as
+`hf://buckets/<namespace>/<name>`, distinct from dataset and model repos. It is
+Xet-backed, mutable, and has no git history: you overwrite in place and there
+are no commits to rebase or conflict. The Python API exposes it through
+`HfApi.batch_bucket_files`, `download_bucket_files`, and `sync_bucket`; the
+`hf` CLI mirrors these as `hf buckets ...` and `hf sync`. The same content is
+also reachable over `fsspec` via `HfFileSystem` (`hf://buckets/...`).
+
+I ran the tests against the public bucket `z0u/mi-ni-store`. The token we use is
+fine-grained and scoped to that one bucket, which is a nice property: a leaked
+token can't touch the rest of the namespace.
+
+## The shape of the latency
+
+Every bucket read or write pays a fixed cost of roughly two to three seconds
+before any bytes move. That floor is request latency, not transfer: the Xet
+handshake, content-addressing negotiation, and the commit each cost a round
+trip. Above the floor, throughput sat around 8–20 MB/s on writes and 10–35 MB/s
+on reads, with enough run-to-run variance (Xet warm-up, I think) that I wouldn't
+quote a single figure.
+
+| Payload | From this container (HfApi) | From a Modal worker |
+| --- | --- | --- |
+| 1 KB | write 1.8s / read 2.7s | write 2.4s / read 2.2s |
+| 1 MB | write 2.1s / read 2.1s | write 3.3s / read 3.0s |
+| 16 MB | write 2.9s / read 2.3s | write 4.8s / read 3.9s |
+| 64 MB | write 7.3s / read 3.9s | write 8.5s / read 6.5s |
+
+Reading through `HfFileSystem` was consistently faster than the bucket download
+API for small files (around 0.3s versus 2.7s for 1 KB), probably because it
+skips the temp-file plumbing and streams directly. For writes the two were
+comparable.
+
+## Buckets versus a Modal Volume
+
+The contrast is stark, and it's the crux of any design. A Modal Volume is a
+local mount inside the function: reads and writes hit local disk and cost
+microseconds to milliseconds. You pay only at the boundaries, when you `commit()`
+to publish or `reload()` to see other workers' writes. A bucket charges the
+two-to-three-second round trip on every operation.
+
+| Operation | Modal Volume | HF bucket |
+| --- | --- | --- |
+| In-function read/write (16 MB) | ~0.02–0.03s | ~3–5s |
+| Publish / commit (16 MB) | commit ~6.3s | write ~3–5s |
+| See remote changes | reload ~0.2–0.5s | read ~2–4s |
+
+So for data touched repeatedly inside a worker, the Volume wins by orders of
+magnitude. For a one-shot publish or fetch, the two are roughly even: a bucket
+write (~3s) is in the same range as a Volume commit (~2.3s fixed, more with
+size). Where the bucket pulls ahead is reach: it has a public URL and lives
+outside Modal, so it can serve data to a browser, a notebook, or another
+machine. A Modal Volume can't.
+
+## Batching, or concurrency
+
+Naive per-file writes are slow because each commit pays the full floor: eight
+separate commits ran in 15.4s, about 1.7s each. The obvious fix is to batch many
+files into one commit (eight files in 1.97s). The less obvious fix is to keep
+the separate commits but issue them concurrently, which I tested: eight
+concurrent commits finished in 2.59s, nearly matching the single batched commit.
+
+That tells me the floor is latency we can overlap, not a server-side lock. It
+works because buckets are mutable: concurrent commits don't fight over a shared
+parent the way they would on a git-backed repo, where you'd hit conflicts and be
+forced to batch lower down. So workers can write results independently, without a
+coordination step. Batching is still tidier and atomic when the files are already
+in hand, so I'd reach for it first and use concurrency for results that arrive
+piecemeal.
+
+For bulk directory moves, `hf sync` does the sensible thing. Pushing 101 files
+(17 MB) took 5.1s, a no-op re-sync took 1.1s (it diffs on size and mtime), and a
+fresh download took 5.7s. That's the natural fit for syncing a Volume to or from
+a bucket.
+
+## A possible HFBucketVolume
+
+If we add this as a `Volume`, the interface fits: `path` for the local working
+directory, and `upload` / `download` mapping onto `batch_bucket_files`,
+`sync_bucket`, or `HfFileSystem`. The interesting question is caching.
+
+The expensive thing is the round trip, so a cache that avoids re-fetching is the
+real win. My current guess is that the cache should be pluggable rather than a
+Modal Volume hard-wired behind every bucket. Within a single function, ephemeral
+local disk (or `HF_HOME`, where the Xet client already caches chunks) reads just
+as fast as a Volume would, and avoids the Volume's own commit and reload
+overhead. A Modal Volume earns its place only when many workers or runs would
+otherwise cold-download the same data: point the cache at a shared Volume and
+they share one warm copy. So I'd sketch it as `HFBucketVolume(cache=...)`,
+defaulting to local disk, with a Modal Volume as an opt-in warm cache. The bucket
+stays the source of truth; the cache is just an accelerator.
+
+There's a third option I tested but would not lead with: mounting the bucket as
+a filesystem with [hf-mount](https://github.com/huggingface/hf-mount). It works,
+and feels fast (a 1 KB write's `close()` returned in 0.8s, a read in 0.25s),
+because writes buffer locally and flush asynchronously. That asynchrony is also
+the catch: writes are only eventually durable (a two-second flush debounce),
+cross-client visibility lags by about ten seconds, and it needs `/dev/fuse` plus
+`CAP_SYS_ADMIN`. I got it running here as root; I doubt it runs inside an ordinary
+Modal function. A neat option for interactive exploration, less so for checkpoint
+correctness.
+
+## Serving figures
+
+A bucket can serve images with the right content type, which makes it appealing
+for published notebook assets. A resolve URL like
+`https://huggingface.co/buckets/z0u/mi-ni-store/resolve/figs/plot.png` returns a
+302 to a signed CDN URL that carries `response-content-type` set from the file
+extension, with `Content-Disposition: inline`. I confirmed the mapping across
+formats: `.png` to `image/png`, `.svg` to `image/svg+xml`, `.html` to
+`text/html`, and an extensionless `.bin` falling back to
+`application/octet-stream`. So `<img src=".../resolve/figs/plot.png">` renders
+inline. The type is inferred from the extension, so files need honest names, and
+there's a redirect hop that matters little for display.
+
+## On obstore
+
+I looked at whether [obstore](https://github.com/developmentseed/obstore) buys us
+anything, since it's faster than fsspec for the stores it supports. It doesn't
+support Hugging Face: only S3, GCS, and Azure. The only way to bridge is through
+fsspec, which forfeits the native-Rust speed that makes obstore worth using. And
+we don't lose much by skipping it, because `hf_xet` already does parallel chunked
+transfer natively under `HfApi`. obstore would only matter if mi-ni also targeted
+S3, GCS, or Azure directly.
+
+## Open questions
+
+A few things to settle before committing to this:
+
+- Where the cache should live by default, and whether the Modal-Volume-as-cache
+  path is worth the extra moving parts.
+- Whether `upload` / `download` should prefer `sync_bucket` (rsync-like, good for
+  directories) or `batch_bucket_files` (atomic, good for known file sets), and
+  how that interacts with memoized results.
+- How durability expectations map onto the bucket's commit model, especially if
+  we ever consider the hf-mount path.
+
+## Reproducing
+
+Two environment details cost me time and are worth recording. Bucket I/O needs
+`*.xethub.hf.co` on the egress allow-list; without it, metadata calls to
+`huggingface.co` succeed while every byte transfer hangs on a 403. Serving
+figures additionally needs the CDN host (`*.cdn.hf.co`). And Modal's gRPC client
+builds its TLS context from certifi alone, so behind a TLS-inspecting proxy it
+needs the system CA folded in; `mini._tls.ensure_grpc_trusts_system_ca` already
+does this.


### PR DESCRIPTION
Benchmarks Hugging Face buckets against a Modal Volume for experiment
storage: per-operation latency, throughput, batching vs concurrent
commits, hf sync, hf-mount, and serving figures over resolve URLs.
Sketches a possible HFBucketVolume with a pluggable cache, and records
the environment gotchas (Xet allow-list, Modal gRPC TLS). Framed as
speculative; integration is still open.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qr62vrv7FU4bMn3ELSZJWj