### PR TITLE
Content-addressed artifact store with cross-experiment sharing and HF publishing

### DIFF
--- a/.agents/skills/mi-ni/SKILL.md
+++ b/.agents/skills/mi-ni/SKILL.md
@@ -24,6 +24,7 @@ src/mini/
 
 - **Author** a memoized experiment — the `main(ctx)` DAG, repo layout, and cache-friendly design: [authoring.md](./references/authoring.md). Key internals in [memoization.md](./references/memoization.md).
 - **Run & monitor** one from the CLI — the wake-loop, recovery, hotfix safety, and how to delegate/schedule a long run: [running.md](./references/running.md).
+- **Store & share large outputs** — return `Artifact` handles instead of volume paths, share artifacts across experiments by name, and publish figures to a URL: [storage.md](./references/storage.md).
 
 To keep cost down, delegate launching and babysitting to the `experiment-monitor` subagent (it escalates to `experiment-doctor`); see running.md.
 

--- a/.agents/skills/mi-ni/references/authoring.md
+++ b/.agents/skills/mi-ni/references/authoring.md
@@ -52,6 +52,25 @@ re-run" loop fast and honest:
   passing `version='v2'`. Editing a project helper a task calls also invalidates
   it; library/framework churn does not.
 
+## Returning large outputs
+
+A step's result holds the *small* thing (metrics, a handle). For *large* bytes —
+an activation cache, an eval dump, a figure — don't return a volume `Path` (it
+pickles a location that may evaporate). `put` them into the content-addressed
+store and return the `Artifact` handle instead:
+
+```python
+from mini.store import put
+
+def extract(cfg) -> dict:
+    art = put(get_data_dir() / 'acts', name='activations')  # handle, not a path
+    return {'cfg': cfg.id, 'activations': art}
+```
+
+The store is **project-scoped**, so one experiment can hand an artifact to
+another by name (`set_ref`/`get_ref`) with no recompute. Full semantics — trees,
+publishing figures to a URL, the Modal caveat — in [storage.md](./storage.md).
+
 ## Routing steps to compute
 
 Compute is an execution choice, not part of the definition. A file experiment

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -71,25 +71,32 @@ See `docs/acts` (producer) and `docs/probe` (consumer) for a runnable pair.
 
 ## Choosing the backend (local vs. Hugging Face bucket)
 
-One env var picks the durable backend; nothing in experiment or report code
+The backend is configuration, not code — nothing in an experiment or report
 changes:
 
-- **Unset** → `LocalStore`, a `cas/<sha>` tree on disk under `.mini/store`. The
-  boring default; no network. Project-wide sharing works *locally*.
-- **`MINI_STORE_BUCKET=<namespace>/<bucket>`** (plus `HF_TOKEN`) → `HFStore`, the
-  same layout over a Xet-backed Hugging Face bucket. Now the durable store is
-  shared across *machines and backends*: a Modal worker `put`s a blob, and a
-  local report or another experiment `get`s it back — no shared Volume. The local
-  dir demotes to a warm cache (`.mini/store-cache/hf`).
+- **No bucket configured** → `LocalStore`, a `cas/<ab>/<sha>` tree under
+  `.mini/store`. The default; no network. Project-wide sharing works *locally*.
+- **A bucket configured** → `HFStore`, the same layout over a Xet-backed Hugging
+  Face bucket, shared across *machines and backends*: a Modal worker `put`s a
+  blob; a local report or another experiment `get`s it back, no shared Volume.
+  The local dir demotes to a warm cache (`.mini/store-cache/hf`).
 
-`mini run --app modal` forwards the bucket + token into the worker (via a Modal
-Secret), so the remote step writes to the same bucket. Bucket I/O needs
-`*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the network egress allow-list.
+Set the bucket once in `pyproject.toml` so it travels with the repo (set in one
+place, not three):
 
-Auth: `./go auth` logs you into Hugging Face alongside Modal/WandB (a fine-grained
-token with read+write to the bucket). The token is cached by `hf`; the store and
-the Modal Secret both pick it up from there, so you don't need `HF_TOKEN` exported
-— only `MINI_STORE_BUCKET` set to select the bucket.
+```toml
+[tool.mini]
+store-bucket = "your-namespace/your-bucket"
+```
+
+`MINI_STORE_BUCKET` overrides it for a one-off shell or CI. `mini run --app modal`
+forwards the resolved bucket + token into the worker via a Modal Secret. Bucket
+I/O needs `*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the egress
+allow-list.
+
+Auth: `./go auth` logs into Hugging Face (a fine-grained token with read+write to
+the bucket). `hf` caches it; the store and the Modal Secret read it from there, so
+`HF_TOKEN` need not be exported — the bucket name isn't a secret, only the token.
 
 ## Publishing to the web
 

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -1,0 +1,98 @@
+# Artifacts and the content-addressed store
+
+A memo result is the *small* thing — a dict of metrics, a handle. The *large*
+bytes a step produces (an activation cache, an eval dump, a figure) belong in the
+**artifact store**, not in the result and not as a bare volume `Path`.
+
+Returning a `Path` pickles a *location* into the result, and that location lives
+in a volume that may have evaporated by the time another process, another
+experiment, or a report reads the result back. Instead, a step `put`s its bytes
+and returns an `Artifact` — a small, location-free handle (a sha, a size, a
+name).
+
+```python
+from mini import get_data_dir
+from mini.store import put, get, get_ref, set_ref, publish
+
+def extract(cfg) -> dict:
+    cache = get_data_dir() / 'acts'
+    run_model(cfg, into=cache)
+    art = put(cache, name='activations')   # hashed into the store; handle returned
+    return {'cfg': cfg.id, 'activations': art}
+```
+
+`put`/`get` resolve an **ambient store** the worker enters around the step — the
+same pattern as `get_data_dir()`. They work inside any step with no plumbing;
+outside a step (a notebook/report), get the store from the apparatus:
+`store = LocalApparatus(NAME).store()` and call `store.get(...)` directly.
+
+## Why a handle, not a path
+
+- **Durable results.** A handle carries no location, so the result pickles
+  durably and resolves from anywhere that can reach the store.
+- **Stable downstream keys.** Passing a `Path` into the next step fingerprints it
+  by location; passing an `Artifact` fingerprints it by *content*, so a
+  consumer's memo key only moves when the bytes actually change.
+- **Dedup for free.** Blobs are keyed by content (`cas/<sha256>`), so identical
+  bytes coincide and `put` is idempotent (hash first, skip if present).
+
+## Files and trees
+
+`put(bytes | Path, name=...)`. A directory becomes a **tree** artifact: each file
+is its own blob (so a directory of many small shards dedups per-file and resolves
+one shard without pulling the set), and the handle carries the manifest. `name`
+is the logical name — carry the extension; it sets the served media type.
+
+`get(art, dest)` materializes a file to `dest`, or a tree into the directory
+`dest` (children resolve concurrently). Reach for a tree when random access or
+partial dedup matters; otherwise a single file is fine.
+
+## The store is project-scoped (sharing across experiments)
+
+Unlike the memo store and volume (one per experiment), the artifact store is
+**one per project** — it sits a `store/` beside the experiment volumes. So an
+artifact one experiment produces is visible to every experiment in the project,
+content-addressed.
+
+A small mutable **ref** layer names views over the immutable blobs (the git
+objects-and-refs split). That's how one experiment hands an asset to another by a
+stable name, without the consumer knowing the producer's memo key:
+
+```python
+# producer experiment
+set_ref(f'activations/{dataset}', art)
+
+# consumer experiment — no recompute, no shared volume
+art = get_ref(f'activations/{dataset}')
+local = get(art, get_data_dir() / 'acts-in')
+```
+
+See `docs/acts` (producer) and `docs/probe` (consumer) for a runnable pair.
+
+> **Note — Modal.** The artifact CAS rides the experiment's Modal Volume, so
+> cross-experiment sharing on Modal currently works only within one experiment's
+> Volume; a project-scoped Volume (issue #22) lifts that. Locally, sharing is
+> project-wide today.
+
+## Publishing to the web
+
+`publish(art, path)` exposes a blob at a named, extensioned path and returns a
+URL — for reports and figures that need to render in a browser (the extension
+drives the served `Content-Type`). It's deliberately separate from `put` and the
+only outward-facing verb, so persisting a result never publishes it as a side
+effect. Do it in the **report**, where assets go out:
+
+```python
+url = store.publish(fig_png, f'reports/{exp}/loss.png')
+```
+
+`LocalStore` returns a `file://` URL (the published view lives under the project
+store). A web-reachable backend (a Hugging Face bucket) returns an `https://`
+resolve URL for the same handle — not yet implemented; see `todo.md`.
+
+## Checkpoints are different
+
+Mid-step checkpoints (periodic state for crash-resume) are *not* step outputs:
+they're mutable and superseded, and resume finds "the latest for this step" by a
+stable name, not a content hash. Keep those on the volume (`get_data_dir()`), not
+in the CAS.

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -69,10 +69,23 @@ local = get(art, get_data_dir() / 'acts-in')
 
 See `docs/acts` (producer) and `docs/probe` (consumer) for a runnable pair.
 
-> **Note — Modal.** The artifact CAS rides the experiment's Modal Volume, so
-> cross-experiment sharing on Modal currently works only within one experiment's
-> Volume; a project-scoped Volume (issue #22) lifts that. Locally, sharing is
-> project-wide today.
+## Choosing the backend (local vs. Hugging Face bucket)
+
+One env var picks the durable backend; nothing in experiment or report code
+changes:
+
+- **Unset** → `LocalStore`, a `cas/<sha>` tree on disk under `.mini/store`. The
+  boring default; no network. Project-wide sharing works *locally*.
+- **`MINI_STORE_BUCKET=<namespace>/<bucket>`** (plus `HF_TOKEN`) → `HFStore`, the
+  same layout over a Xet-backed Hugging Face bucket. Now the durable store is
+  shared across *machines and backends*: a Modal worker `put`s a blob, and a
+  local report or another experiment `get`s it back — no shared Volume. The local
+  dir demotes to a warm cache (`.mini/store-cache/hf`).
+
+`mini run --app modal` forwards `MINI_STORE_BUCKET` + `HF_TOKEN` into the worker
+(via a Modal Secret), so the remote step writes to the same bucket. Bucket I/O
+needs `*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the network egress
+allow-list. Add `HF_TOKEN` to your auth the way you add Modal/WandB.
 
 ## Publishing to the web
 
@@ -87,8 +100,13 @@ url = store.publish(fig_png, f'reports/{exp}/loss.png')
 ```
 
 `LocalStore` returns a `file://` URL (the published view lives under the project
-store). A web-reachable backend (a Hugging Face bucket) returns an `https://`
-resolve URL for the same handle — not yet implemented; see `todo.md`.
+store). With `MINI_STORE_BUCKET` set, `HFStore` returns a real `https://` resolve
+URL for the same handle — the publish is a server-side copy *by xet hash* (no
+bytes moved) to an extensioned path, and the bucket serves it with a
+`Content-Type` from that extension. The bucket is **public**, so `publish` is the
+deliberate outward step; the durable CAS only goes public because we share one
+bucket for now (a separate private store + public publish bucket is a later
+split — see `todo.md`).
 
 ## Checkpoints are different
 

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -82,10 +82,14 @@ changes:
   local report or another experiment `get`s it back — no shared Volume. The local
   dir demotes to a warm cache (`.mini/store-cache/hf`).
 
-`mini run --app modal` forwards `MINI_STORE_BUCKET` + `HF_TOKEN` into the worker
-(via a Modal Secret), so the remote step writes to the same bucket. Bucket I/O
-needs `*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the network egress
-allow-list. Add `HF_TOKEN` to your auth the way you add Modal/WandB.
+`mini run --app modal` forwards the bucket + token into the worker (via a Modal
+Secret), so the remote step writes to the same bucket. Bucket I/O needs
+`*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the network egress allow-list.
+
+Auth: `./go auth` logs you into Hugging Face alongside Modal/WandB (a fine-grained
+token with read+write to the bucket). The token is cached by `hf`; the store and
+the Modal Secret both pick it up from there, so you don't need `HF_TOKEN` exported
+— only `MINI_STORE_BUCKET` set to select the bucket.
 
 ## Publishing to the web
 

--- a/docs/acts/experiment.py
+++ b/docs/acts/experiment.py
@@ -1,0 +1,64 @@
+"""
+Extract a stand-in activation cache and share it project-wide by name.
+
+This is the *producer* half of a cross-experiment artifact-sharing demo (the
+*consumer* is ``docs/probe``). A real interpretability run would cache a model's
+per-layer activations — a few big files, or many small per-shard ones. Here we
+synthesize a tiny deterministic stand-in so the *storage* path runs end to end
+without a GPU or a large download.
+
+The single step writes the cache to its volume, then ``put``s it into the
+**project-scoped** content-addressed store as a *tree* artifact (one blob per
+shard, deduped by content) and publishes a named ref. Because the store is keyed
+by content and scoped to the project — not to this experiment — a *different*
+experiment can resolve the exact same bytes by that name, with no recompute and
+no shared volume:
+
+    bin/mini run docs/acts/experiment.py --watch
+    bin/mini run docs/probe/experiment.py --watch   # reuses what this produced
+
+The step returns the :class:`~mini.store.Artifact` *handle* (a sha + size + name,
+no location), so it pickles durably into the memo result and a downstream step's
+memo key fingerprints it by content rather than by a path that may evaporate.
+"""
+
+from __future__ import annotations
+
+from mini import Ctx, Experiment, get_data_dir
+from mini.store import put, set_ref
+
+DATASET = 'tiny-shakespeare'
+N_LAYERS, N_NEURONS, N_TOKENS = 4, 16, 256
+
+
+def extract_activations(dataset: str) -> dict:
+    """Synthesize a per-layer activation cache, store it, and share it by name."""
+    import hashlib
+
+    import numpy as np
+
+    # A *stable* seed (Python's str hash is per-process randomized) so the same
+    # dataset yields byte-identical shards — the precondition for the content
+    # hashes to coincide across runs, processes, and experiments.
+    seed = int.from_bytes(hashlib.sha256(dataset.encode()).digest()[:4], 'big')
+    rng = np.random.default_rng(seed)
+    cache = get_data_dir() / 'activations'
+    cache.mkdir(parents=True, exist_ok=True)
+    for layer in range(N_LAYERS):
+        acts = rng.standard_normal((N_TOKENS, N_NEURONS)).astype('float32')
+        np.save(cache / f'layer_{layer:02d}.npy', acts)
+
+    # One handle for the whole directory: each shard is its own CAS blob, so an
+    # identical cache anywhere in the project coincides, and a consumer can pull
+    # one shard without the set.
+    art = put(cache, name=f'{dataset}-activations')
+    # Name it so another experiment can find it without knowing our memo key.
+    set_ref(f'activations/{dataset}', art)
+    return {'dataset': dataset, 'artifact': art, 'shards': len(art.children), 'bytes': art.size}
+
+
+def main(ctx: Ctx) -> dict:
+    return ctx.run(extract_activations, DATASET)
+
+
+experiment = Experiment(name='acts', main=main)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Index:
 
 - [Getting started](./getting_started.py)
 - [Pipeline: a memoized, multi-step experiment](./pipeline/report.py)
+- [Probe: reusing another experiment's artifacts via the shared store](./probe/report.py)
 - [Themed (light/dark) plots](./themed.py)
 - [Sparkline text annotations](./subline_demo.py)
 - [nanoGPT and nGPT demo](./gpt.py)

--- a/docs/probe/experiment.py
+++ b/docs/probe/experiment.py
@@ -32,9 +32,7 @@ def probe_activations(dataset: str) -> dict:
 
     art = get_ref(f'activations/{dataset}')
     if art is None:
-        raise FileNotFoundError(
-            f'no activation cache published for {dataset!r} — run docs/acts/experiment.py first'
-        )
+        raise FileNotFoundError(f'no activation cache published for {dataset!r} — run docs/acts/experiment.py first')
 
     # Pull the shared tree into this step's volume (a warm checkout); the bytes
     # come from the project store, not from a recomputed prep.

--- a/docs/probe/experiment.py
+++ b/docs/probe/experiment.py
@@ -1,0 +1,61 @@
+"""
+Probe a shared activation cache produced by another experiment.
+
+This is the *consumer* half of the artifact-sharing demo. It does **not** extract
+activations itself — it resolves the cache that ``docs/acts`` published by name
+from the project-scoped store, then computes a small interpretability summary
+(per-neuron mean activation, per layer). The reuse is the whole point: B reads
+A's bytes straight from the content-addressed store — no recompute, no shared
+volume, across the experiment boundary.
+
+    bin/mini run docs/acts/experiment.py  --watch    # produce the cache first
+    bin/mini run docs/probe/experiment.py --watch    # then probe it
+
+The companion ``report.py`` reads this experiment's durable result, renders the
+summary as a figure, and *publishes* the figure to a shareable URL — the report
+is where assets go out to the web, distinct from the durable store the step writes.
+"""
+
+from __future__ import annotations
+
+from mini import Ctx, Experiment, get_data_dir
+from mini.store import get, get_ref, put
+
+DATASET = 'tiny-shakespeare'
+
+
+def probe_activations(dataset: str) -> dict:
+    """Resolve the shared cache by name, summarize it, and store the summary."""
+    import json
+
+    import numpy as np
+
+    art = get_ref(f'activations/{dataset}')
+    if art is None:
+        raise FileNotFoundError(
+            f'no activation cache published for {dataset!r} — run docs/acts/experiment.py first'
+        )
+
+    # Pull the shared tree into this step's volume (a warm checkout); the bytes
+    # come from the project store, not from a recomputed prep.
+    local = get(art, get_data_dir() / 'acts-in')
+    per_layer_means = {
+        shard.stem: np.load(shard).mean(axis=0).round(4).tolist()  # per-neuron mean
+        for shard in sorted(local.glob('*.npy'))
+    }
+
+    summary = {'dataset': dataset, 'source_sha': art.sha256, 'per_layer_means': per_layer_means}
+    asset = put(json.dumps(summary).encode(), name=f'{dataset}-neuron-means.json')
+    return {
+        'dataset': dataset,
+        'source_sha': art.sha256,  # proof we read A's exact bytes
+        'n_layers': len(per_layer_means),
+        'summary': asset,
+    }
+
+
+def main(ctx: Ctx) -> dict:
+    return ctx.run(probe_activations, DATASET)
+
+
+experiment = Experiment(name='probe', main=main)

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -100,7 +100,8 @@ def _(artifacts, means, result):
         im = ax.imshow(grid, aspect='auto', cmap='RdBu', vmin=-0.3, vmax=0.3)
         ax.set(xlabel='neuron', ylabel='layer', yticks=range(len(means)), title='Mean activation per neuron')
         fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
-        fig.tight_layout()
+        # No tight_layout(): the base style enables constrained_layout, which
+        # handles the colorbar; calling both clashes the layout engines.
         return fig
 
     html = _plot()

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -1,0 +1,128 @@
+import marimo
+
+__generated_with = '0.23.3'
+app = marimo.App(width='medium', auto_download=['html'])
+
+with app.setup(hide_code=True):
+    import json
+
+    import marimo as mo  # noqa: F401
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from mini import LocalApparatus, RunState
+    from mini.vis import themed
+
+    # The report reads results by experiment *name*, the same key the CLI uses.
+    NAME = 'probe'
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    # Probe report
+
+    This notebook is a **report**, not the experiment. The experiment in
+    [`experiment.py`](./experiment.py) resolves an activation cache that a
+    *different* experiment ([`docs/acts`](../acts/experiment.py)) published to the
+    project-scoped artifact store, summarizes it, and stores the summary as a
+    durable artifact. Run both from the command line:
+
+    ```bash
+    bin/mini run docs/acts/experiment.py  --watch
+    bin/mini run docs/probe/experiment.py --watch
+    ```
+
+    Here we read the durable summary back through its handle, render it, and
+    **publish** the figure to a shareable URL — the report is where assets go out
+    to the web, distinct from the content-addressed store the step writes to.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    # Read-only: the apparatus gives us both the memo store (the result record)
+    # and the artifact store (the bytes the result points at). Neither ticks the
+    # DAG, so the report can't relaunch work.
+    app_ = LocalApparatus(NAME)
+    store, artifacts = app_.memo_store(), app_.store()
+    done = [r for r in store.records() if r.get('fn') == 'probe_activations' and r.get('state') == RunState.DONE]
+    result = store.result(done[0]['key']) if done else None
+    return artifacts, result, store
+
+
+@app.cell(hide_code=True)
+def _(result, store):
+    mo.stop(
+        result is None,
+        mo.md(
+            'Nothing to report yet. Produce the cache, then probe it:\n\n'
+            '```bash\nbin/mini run docs/acts/experiment.py --watch\n'
+            'bin/mini run docs/probe/experiment.py --watch\n```'
+        ),
+    )
+    mo.md(
+        f'Probed **{result["dataset"]}** across **{result["n_layers"]}** layers, '
+        f'reading activation bytes `{result["source_sha"][:12]}…` straight from the '
+        'shared store — no recompute.'
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(artifacts, result):
+    mo.stop(result is None)
+    # Resolve the durable summary artifact (its handle rode along in the result).
+    import tempfile
+    from pathlib import Path
+
+    dest = Path(tempfile.mkdtemp()) / result['summary'].name
+    summary = json.loads(artifacts.get(result['summary'], dest).read_text())
+    means = {layer: np.array(vals) for layer, vals in summary['per_layer_means'].items()}
+    return (means,)
+
+
+@app.cell(hide_code=True)
+def _(artifacts, means, result):
+    mo.stop(result is None)
+
+    @themed(
+        alt_text=(
+            'A heatmap of mean activation per neuron (x-axis) for each layer (y-axis) of the '
+            'stand-in activation cache. Values cluster near zero, as expected for a synthesized '
+            'standard-normal stand-in, with small layer-to-layer variation.'
+        )
+    )
+    def _plot() -> plt.Figure:
+        grid = np.vstack([means[layer] for layer in sorted(means)])
+        fig, ax = plt.subplots(figsize=(6, 3))
+        im = ax.imshow(grid, aspect='auto', cmap='RdBu', vmin=-0.3, vmax=0.3)
+        ax.set(xlabel='neuron', ylabel='layer', yticks=range(len(means)), title='Mean activation per neuron')
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+        fig.tight_layout()
+        return fig
+
+    html = _plot()
+
+    # Publish a standalone PNG of the figure to a shareable URL. Locally this is a
+    # file:// URL under the project store; a web-reachable backend (e.g. an HF
+    # bucket) returns an https:// resolve URL for the same handle — see todo.md.
+    from io import BytesIO
+
+    grid = np.vstack([means[layer] for layer in sorted(means)])
+    fig, ax = plt.subplots(figsize=(6, 3))
+    ax.imshow(grid, aspect='auto', cmap='RdBu', vmin=-0.3, vmax=0.3)
+    ax.set_axis_off()
+    buf = BytesIO()
+    fig.savefig(buf, format='png', dpi=150, bbox_inches='tight')
+    plt.close(fig)
+    asset = artifacts.put(buf.getvalue(), name=f'{result["dataset"]}-neuron-means.png')
+    url = artifacts.publish(asset, f'reports/probe/{result["dataset"]}-neuron-means.png')
+
+    mo.md(f'{html}\n\nPublished figure: [`{url}`]({url})')
+    return
+
+
+if __name__ == '__main__':
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ pages = [
     "markdown>=3",
 ]
 
+[tool.mini]
+# The project's Hugging Face bucket for the content-addressed artifact store
+# (see .agents/skills/mi-ni/references/storage.md). Committed here so it's set
+# once and shared by every checkout, Modal worker, and CI run — the bucket name
+# is not a secret (the token lives in the env / `hf` cache). Override per-shell
+# with MINI_STORE_BUCKET. Unset → the store stays local (no network).
+# store-bucket = "your-namespace/your-bucket"
+
 [tool.uv]
 # Dependency cooldown to mitigate risk of supply chain attacks.
 # https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "datasets>=3.0.0",  # Hugging Face Datasets
     "equinox>=0.13",  # neural networks as JAX pytrees
     "ftfy>=6.3.1",  # text cleaning for NLP tasks
+    "huggingface-hub[hf-xet]>=1.19",
     "imageio-ffmpeg>=0.6.0",  # for video support in matplotlib
     "jax>=0.6",  # accelerated array computing and program transformation
     "jaxtyping>=0.2.38",
@@ -130,6 +131,7 @@ ignore_names = [
     "visit_*",
     "do_*",
     "test_*",
+    "pytestmark",
     "setUp",
     "tearDown"
 ]

--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -29,6 +29,20 @@ if uv run wandb status 2>/dev/null | grep -q '"api_key": null'; then
 fi
 echo "✅ WandB authenticated"
 
+# Hugging Face — fine-grained token for the artifact store bucket (see the mi-ni
+# storage reference). Reads/writes the project's content-addressed store and
+# serves published figures. `hf` caches the token, and both the store and the
+# Modal worker pick it up from there.
+if ! uv run hf auth whoami &>/dev/null; then
+    show_url "https://huggingface.co/settings/tokens/new?tokenType=fineGrained&tokenName=mi-ni+store"
+    echo "Create a fine-grained token with read & write access to your store bucket"
+    echo "(under 'Repositories', select the bucket), then paste it below."
+    read -rsp 'Token: ' hf_token
+    echo
+    uv run hf auth login --token "$hf_token"
+fi
+echo "✅ Hugging Face authenticated"
+
 # Claude Code
 if ! claude auth status &>/dev/null; then
     claude auth login

--- a/src/mini/__init__.py
+++ b/src/mini/__init__.py
@@ -5,6 +5,7 @@ from mini.modal_apparatus import ModalApparatus
 from mini.experiment import Experiment, load_experiment
 from mini.orchestration import MISSING, Ctx, MemoError, Pending, TaskFailed, tick
 from mini.runs import RunState
+from mini.store import Artifact, LocalStore, Store, store_context
 from mini.volume import get_data_dir
 
 __all__ = [
@@ -15,6 +16,10 @@ __all__ = [
     'emit_progress',
     'emit_metrics',
     'get_data_dir',
+    'Artifact',
+    'Store',
+    'LocalStore',
+    'store_context',
     'Experiment',
     'load_experiment',
     'RunState',

--- a/src/mini/_taskworker.py
+++ b/src/mini/_taskworker.py
@@ -17,10 +17,13 @@ from typing import Any, Callable
 
 import cloudpickle
 
+from contextlib import nullcontext
+
 from mini._queues import EndOfQueue
 from mini.memo import MemoStore
 from mini.progress import progress_context
 from mini.runs import RunState, compute_env
+from mini.store import LocalStore, Store, store_context, store_root_for
 from mini.volume import data_dir_context
 
 
@@ -59,6 +62,7 @@ def execute_task(
     args: tuple,
     hooks: list,
     commit: Callable[[], None] | None = None,
+    artifacts: Store | None = None,
 ) -> None:
     """Run one memoized call and persist its result/state — backend-agnostic.
 
@@ -69,6 +73,12 @@ def execute_task(
     *commit* is called after the result/error is written to the I/O plane and
     *before* the record flips to DONE/FAILED — so a poller never sees a settled
     state whose artifact hasn't been committed yet (the Modal Volume needs this).
+
+    *artifacts* binds the content-addressed :class:`~mini.store.Store` as ambient
+    for ``mini.store.put`` / ``get`` inside the step. Because ``put`` uploads
+    synchronously, by the time the result is written its handles already resolve —
+    so the existing write → commit → DONE order extends from "the volume flushed"
+    to "the referenced blobs are durable" for free.
     """
     result_dir = store.result_dir(key)
     result_dir.mkdir(parents=True, exist_ok=True)
@@ -76,7 +86,11 @@ def execute_task(
     # Record what we actually ran on (host/GPU/…), captured here in the worker.
     store.update(key, state=RunState.RUNNING, heartbeat_at=time.time(), env=compute_env())
     try:
-        with data_dir_context(store.data_dir), progress_context(key, key, queue=sink, emission_interval=0.2):
+        with (
+            data_dir_context(store.data_dir),
+            store_context(artifacts) if artifacts is not None else nullcontext(),
+            progress_context(key, key, queue=sink, emission_interval=0.2),
+        ):
             for hook in reversed(hooks):
                 hook()
             result = fn(*args)
@@ -102,7 +116,10 @@ def run_task(data_dir: Path, key: str) -> None:
     """Local subprocess entry: read the staged call from disk and run it."""
     store = MemoStore(data_dir)
     fn, args, hooks = store.read_call(key)
-    execute_task(store, key, fn, args, hooks)
+    # Project-scoped artifact store sits beside the experiment's data dir, so a
+    # blob put here resolves from any experiment in the project (and from reports).
+    artifacts = LocalStore(store_root_for(data_dir))
+    execute_task(store, key, fn, args, hooks, artifacts=artifacts)
 
 
 def main() -> None:

--- a/src/mini/_taskworker.py
+++ b/src/mini/_taskworker.py
@@ -23,7 +23,7 @@ from mini._queues import EndOfQueue
 from mini.memo import MemoStore
 from mini.progress import progress_context
 from mini.runs import RunState, compute_env
-from mini.store import LocalStore, Store, store_context, store_root_for
+from mini.store import Store, default_store, store_context, store_root_for
 from mini.volume import data_dir_context
 
 
@@ -116,9 +116,10 @@ def run_task(data_dir: Path, key: str) -> None:
     """Local subprocess entry: read the staged call from disk and run it."""
     store = MemoStore(data_dir)
     fn, args, hooks = store.read_call(key)
-    # Project-scoped artifact store sits beside the experiment's data dir, so a
-    # blob put here resolves from any experiment in the project (and from reports).
-    artifacts = LocalStore(store_root_for(data_dir))
+    # Project-scoped artifact store sits beside the experiment's data dir (or the
+    # shared HF bucket, if MINI_STORE_BUCKET is set), so a blob put here resolves
+    # from any experiment in the project (and from reports).
+    artifacts = default_store(store_root_for(data_dir))
     execute_task(store, key, fn, args, hooks, artifacts=artifacts)
 
 

--- a/src/mini/apparatus.py
+++ b/src/mini/apparatus.py
@@ -178,9 +178,9 @@ class Apparatus(ABC, Generic[V]):
         Both the apparatus (here, for reports) and the worker enter this around a
         step, so ``mini.store.put`` / ``get`` resolve against the same store.
         """
-        from mini.store import LocalStore, store_root_for
+        from mini.store import default_store, store_root_for
 
-        return LocalStore(store_root_for(self.volume.path))
+        return default_store(store_root_for(self.volume.path))
 
     @abstractmethod
     def memo_store(self) -> MemoStore:

--- a/src/mini/apparatus.py
+++ b/src/mini/apparatus.py
@@ -14,6 +14,7 @@ from mini.volume import Volume
 
 if TYPE_CHECKING:
     from mini.memo import MemoStore
+    from mini.store import Store
 
 P = ParamSpec('P')
 R = TypeVar('R')
@@ -165,6 +166,21 @@ class Apparatus(ABC, Generic[V]):
     # Unlike map/amap (blocking launch + monitor + collect for notebooks), the
     # memoized path splits the lifecycle across short-lived processes: tick
     # stages each call and spawn_tasks launches it detached.
+
+    def store(self) -> Store:
+        """Return the content-addressed artifact :class:`~mini.store.Store` for this backend.
+
+        Distinct from :meth:`memo_store` (the per-experiment control plane): the
+        artifact store is **project-scoped**, so blobs and named refs are shared
+        across experiments — content-addressed, so identical bytes coincide. The
+        default sits a ``store/`` beside the experiment's volume (the project
+        root); ``ModalApparatus`` overrides it to read blobs back off the Volume.
+        Both the apparatus (here, for reports) and the worker enter this around a
+        step, so ``mini.store.put`` / ``get`` resolve against the same store.
+        """
+        from mini.store import LocalStore, store_root_for
+
+        return LocalStore(store_root_for(self.volume.path))
 
     @abstractmethod
     def memo_store(self) -> MemoStore:

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -1,0 +1,137 @@
+"""
+Hugging Face bucket backend for the artifact :class:`~mini.store.Store`.
+
+A bucket (``hf://buckets/<namespace>/<name>``) is a Xet-backed, mutable repo with
+no git history — so concurrent writers don't conflict and immutability is ours to
+enforce by writing once per content hash. We lay the same ``cas/<sha256>`` /
+``refs/`` / ``published/`` structure over it as :class:`~mini.store.LocalStore`,
+so an :class:`~mini.store.Artifact` handle resolves identically whichever backend
+produced it.
+
+Three properties make this the durable, shareable tier:
+
+- **One bucket per project** → ``has(sha)`` is a cross-experiment hit, so a blob
+  one experiment uploads is skipped (not re-uploaded) by another, and Xet dedups
+  the chunks underneath for free.
+- **Reachable everywhere** — from a Modal worker, a local report, or a browser —
+  so it retires the per-experiment-Volume limitation for *artifacts* (the Volume
+  becomes an optional warm cache, not the source of truth).
+- **Web-serving for free** — :meth:`publish` server-side-copies a blob *by xet
+  hash* (no bytes moved) to an extensioned path, and the bucket's resolve URL
+  then serves it with a ``Content-Type`` inferred from that extension.
+
+Blobs are warm-cached into a local :class:`~mini.store.LocalStore` so a re-read
+(or a re-``put`` of known bytes) skips the network. The bucket stays the source
+of truth; the cache is just an accelerator.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from mini.store import Artifact, LocalStore, Store, _hash_file, _tree_sha
+
+__all__ = ['HFStore']
+
+# Buckets need ``*.xethub.hf.co`` (byte transfer) and, for serving, ``*.cdn.hf.co``
+# on the network egress allow-list; metadata-only calls to ``huggingface.co`` work
+# without them but every transfer hangs on a 403. See research/hf-buckets.md.
+
+
+class HFStore(Store):
+    """A :class:`~mini.store.Store` backed by a Hugging Face bucket via ``HfApi``."""
+
+    def __init__(self, bucket: str, *, cache: LocalStore, token: str | None = None):
+        self.bucket = bucket
+        self._cache = cache  # local warm checkout, keyed by sha (a LocalStore)
+        self._token = token or os.environ.get('HF_TOKEN')
+        self._api: Any = None
+
+    @property
+    def api(self) -> Any:
+        if self._api is None:
+            from huggingface_hub import HfApi
+
+            self._api = HfApi(token=self._token)
+        return self._api
+
+    # -- existence / cache ----------------------------------------------------
+
+    def _remote_has(self, path: str) -> bool:
+        try:
+            return any(True for _ in self.api.get_bucket_paths_info(self.bucket, [path]))
+        except Exception:  # missing path / transient read — treat as absent
+            return False
+
+    def has(self, sha256: str) -> bool:
+        return self._cache.has(sha256) or self._remote_has(f'cas/{sha256}')
+
+    def _cache_blob(self, sha256: str, src: Path) -> None:
+        if not self._cache.has(sha256):
+            self._cache._write_blob(sha256, src)
+
+    # -- blobs ----------------------------------------------------------------
+
+    def _write_blob(self, sha256: str, src: Path) -> None:
+        # Reached only on a cache+remote miss (the base ``put`` checks ``has``
+        # first); Xet still dedups the chunks if the bytes happen to exist.
+        self.api.batch_bucket_files(self.bucket, add=[(str(src), f'cas/{sha256}')])
+        self._cache_blob(sha256, src)
+
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        blob = self._cache._blob_path(sha256)
+        if not blob.exists():  # pull once into the warm cache, then serve locally
+            self._cache.cas.mkdir(parents=True, exist_ok=True)
+            self.api.download_bucket_files(self.bucket, files=[(f'cas/{sha256}', str(blob))])
+        shutil.copyfile(blob, dest)
+
+    def _put_tree(self, src: Path, *, name: str) -> Artifact:
+        """Hash every shard locally, then upload the missing ones in **one** commit.
+
+        Batching matters here: each bucket commit pays a ~2-3s round trip, so a
+        per-shard upload would serialize that floor across the whole tree.
+        """
+        children: list[Artifact] = []
+        add: list[tuple[str, str]] = []
+        for p in sorted(q for q in src.rglob('*') if q.is_file()):
+            sha, size = _hash_file(p)
+            children.append(Artifact(sha256=sha, size=size, name=p.relative_to(src).as_posix()))
+            if not self._cache.has(sha):
+                add.append((str(p), f'cas/{sha}'))
+            self._cache_blob(sha, p)
+        if add:
+            self.api.batch_bucket_files(self.bucket, add=add)  # one round trip for the set
+        kids = tuple(children)
+        return Artifact(sha256=_tree_sha(kids), size=sum(c.size for c in kids), name=name, kind='tree', children=kids)
+
+    # -- refs -----------------------------------------------------------------
+
+    def _write_ref(self, name: str, payload: str) -> None:
+        self.api.batch_bucket_files(self.bucket, add=[(payload.encode(), f'refs/{name}.json')])
+
+    def _read_ref(self, name: str) -> str | None:
+        path = f'refs/{name}.json'
+        if not self._remote_has(path):
+            return None
+        tmp = Path(tempfile.mkdtemp()) / 'ref.json'
+        self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
+        return tmp.read_text()
+
+    # -- publish --------------------------------------------------------------
+
+    def publish(self, art: Artifact, path: str) -> str:
+        if art.kind == 'tree':
+            raise ValueError('publish a single file (resolve a tree first, or publish its children)')
+        info = list(self.api.get_bucket_paths_info(self.bucket, [f'cas/{art.sha256}']))
+        if not info:
+            raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
+        # Server-side copy *by xet hash*: a metadata op, no bytes moved. The
+        # extensioned destination is what makes the resolve URL serve a real
+        # Content-Type (a bare cas/<sha> has none).
+        dest = f'published/{path}'
+        self.api.batch_bucket_files(self.bucket, copy=[('bucket', self.bucket, info[0].xet_hash, dest)])
+        return f'https://huggingface.co/buckets/{self.bucket}/resolve/{dest}'

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -33,7 +33,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from mini.store import Artifact, LocalStore, Store, _hash_file, _tree_sha
+from mini.store import Artifact, LocalStore, Store, _cas_key, _hash_file, _tree_sha
 
 __all__ = ['HFStore']
 
@@ -62,13 +62,18 @@ class HFStore(Store):
     # -- existence / cache ----------------------------------------------------
 
     def _remote_has(self, path: str) -> bool:
+        # A missing path is "absent" (return False); an auth/permission/network
+        # failure must *not* masquerade as absent — that would silently trigger a
+        # re-upload (and hide a misconfigured token), so let those propagate.
+        from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+
         try:
             return any(True for _ in self.api.get_bucket_paths_info(self.bucket, [path]))
-        except Exception:  # missing path / transient read — treat as absent
+        except EntryNotFoundError, RepositoryNotFoundError:
             return False
 
     def has(self, sha256: str) -> bool:
-        return self._cache.has(sha256) or self._remote_has(f'cas/{sha256}')
+        return self._cache.has(sha256) or self._remote_has(_cas_key(sha256))
 
     def _cache_blob(self, sha256: str, src: Path) -> None:
         if not self._cache.has(sha256):
@@ -79,14 +84,14 @@ class HFStore(Store):
     def _write_blob(self, sha256: str, src: Path) -> None:
         # Reached only on a cache+remote miss (the base ``put`` checks ``has``
         # first); Xet still dedups the chunks if the bytes happen to exist.
-        self.api.batch_bucket_files(self.bucket, add=[(str(src), f'cas/{sha256}')])
+        self.api.batch_bucket_files(self.bucket, add=[(str(src), _cas_key(sha256))])
         self._cache_blob(sha256, src)
 
     def _read_blob(self, sha256: str, dest: Path) -> None:
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
-            self._cache.cas.mkdir(parents=True, exist_ok=True)
-            self.api.download_bucket_files(self.bucket, files=[(f'cas/{sha256}', str(blob))])
+            blob.parent.mkdir(parents=True, exist_ok=True)
+            self.api.download_bucket_files(self.bucket, files=[(_cas_key(sha256), str(blob))])
         shutil.copyfile(blob, dest)
 
     def _put_tree(self, src: Path, *, name: str) -> Artifact:
@@ -101,7 +106,7 @@ class HFStore(Store):
             sha, size = _hash_file(p)
             children.append(Artifact(sha256=sha, size=size, name=p.relative_to(src).as_posix()))
             if not self._cache.has(sha):
-                add.append((str(p), f'cas/{sha}'))
+                add.append((str(p), _cas_key(sha)))
             self._cache_blob(sha, p)
         if add:
             self.api.batch_bucket_files(self.bucket, add=add)  # one round trip for the set
@@ -117,16 +122,17 @@ class HFStore(Store):
         path = f'refs/{name}.json'
         if not self._remote_has(path):
             return None
-        tmp = Path(tempfile.mkdtemp()) / 'ref.json'
-        self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
-        return tmp.read_text()
+        with tempfile.TemporaryDirectory() as d:  # cleaned up, unlike a bare mkdtemp
+            tmp = Path(d) / 'ref.json'
+            self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
+            return tmp.read_text()
 
     # -- publish --------------------------------------------------------------
 
     def publish(self, art: Artifact, path: str) -> str:
         if art.kind == 'tree':
             raise ValueError('publish a single file (resolve a tree first, or publish its children)')
-        info = list(self.api.get_bucket_paths_info(self.bucket, [f'cas/{art.sha256}']))
+        info = list(self.api.get_bucket_paths_info(self.bucket, [_cas_key(art.sha256)]))
         if not info:
             raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
         # Server-side copy *by xet hash*: a metadata op, no bytes moved. The

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -33,6 +33,8 @@ from mini.modal_volume import ModalVolume
 from mini.progress import ProgressMessage, progress_context
 from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
+from mini.runs import data_root
+from mini.store import Artifact, LocalStore, Store
 from mini.volume import data_dir_context
 
 log = logging.getLogger(__name__)
@@ -150,6 +152,65 @@ class ModalMemoStore(MemoStore):
             return '(no logs)'
 
 
+class ModalVolumeStore(Store):
+    """Client-side artifact :class:`~mini.store.Store` that reads blobs off the Volume.
+
+    The remote worker writes the CAS *under* the mounted Volume (``store/cas/<sha>``)
+    and commits it; this reads those blobs back from the client (a report, or
+    ``ctx.run`` resolving a handle into the next step) with no running function,
+    caching each blob into a local :class:`~mini.store.LocalStore` so a re-read is
+    free. Read-only: producing artifacts happens *in* a step (on the worker), and a
+    report that wants to publish a Modal-produced asset resolves it here, then
+    ``put``/``publish``es through the local project store.
+    """
+
+    def __init__(self, volume: ModalVolume, cache: Any):
+        self._volume = volume
+        self._cache = cache  # a LocalStore checkout cache (warm copies, keyed by sha)
+
+    def _read_volume_bytes(self, rel: str) -> bytes:
+        return b''.join(self._volume._modal_volume.read_file(rel))
+
+    def has(self, sha256: str) -> bool:
+        if self._cache.has(sha256):
+            return True
+        try:
+            self._read_volume_bytes(f'store/cas/{sha256}')
+            return True
+        except FileNotFoundError, modal.exception.NotFoundError:
+            return False
+
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        import shutil
+
+        blob = self._cache._blob_path(sha256)
+        if not blob.exists():  # pull once into the warm cache, then serve locally
+            data = self._read_volume_bytes(f'store/cas/{sha256}')
+            self._cache.cas.mkdir(parents=True, exist_ok=True)
+            tmp = blob.with_name(f'{sha256}.tmp')
+            tmp.write_bytes(data)
+            tmp.replace(blob)
+        shutil.copyfile(blob, dest)
+
+    def _read_ref(self, name: str) -> str | None:
+        try:
+            return self._read_volume_bytes(f'store/refs/{name}.json').decode()
+        except FileNotFoundError, modal.exception.NotFoundError:
+            return None
+
+    def _write_blob(self, sha256: str, src: Path) -> None:
+        raise NotImplementedError('ModalVolumeStore is read-only on the client; put() runs inside a step')
+
+    def _write_ref(self, name: str, payload: str) -> None:
+        raise NotImplementedError('ModalVolumeStore is read-only on the client; set_ref() runs inside a step')
+
+    def publish(self, art: Artifact, path: str) -> str:
+        raise NotImplementedError(
+            'publish a Modal-produced asset by resolving it (get) into a local path, '
+            'then put()/publish() through the local project store'
+        )
+
+
 def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, mount_point: str) -> None:
     """Remote entry: run one memoized call on Modal and persist its result/state.
 
@@ -163,11 +224,17 @@ def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, m
     from mini._taskworker import execute_task
     from mini.memo import MemoStore
     from mini.modal_apparatus import ModalRecordStore
+    from mini.store import LocalStore
 
     fn, args, hooks = _cp.loads(blob)
     store = MemoStore(Path(mount_point), records=ModalRecordStore.from_name(dict_name))
     volume = _modal.Volume.from_name(volume_name)
-    execute_task(store, key, fn, args, hooks, commit=volume.commit)
+    # The artifact CAS lives *under* the mounted Volume (so the worker's blobs are
+    # committed with the result and the client can read them back). It rides the
+    # experiment's Volume, so cross-experiment sharing on Modal waits on the
+    # project-scoped Volume (#22); within an experiment, put/get work end to end.
+    artifacts = LocalStore(Path(mount_point) / 'store')
+    execute_task(store, key, fn, args, hooks, commit=volume.commit, artifacts=artifacts)
 
 
 class ModalApparatus(Apparatus[ModalVolume]):
@@ -257,6 +324,17 @@ class ModalApparatus(Apparatus[ModalVolume]):
     @override
     def memo_store(self) -> MemoStore:
         return ModalMemoStore(self.volume, ModalRecordStore.from_name(self._dict_name))
+
+    @override
+    def store(self) -> Store:
+        """Read artifacts back off the Volume, warm-caching into a local checkout.
+
+        The cache is project-scoped on the client (``.mini/store-cache/<app>``);
+        the source of truth is ``store/`` on this experiment's Modal Volume.
+        """
+        assert self.app.name  # guaranteed by __init__ (a named App is required)
+        cache = LocalStore(data_root() / 'store-cache' / self.app.name)
+        return ModalVolumeStore(self.volume, cache)
 
     def _memo_worker(self) -> modal.Function:
         """Register (once) and return the generic remote worker for memo tasks.

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -220,8 +220,12 @@ def _hf_store_secret() -> modal.Secret | None:
     shared bucket. Absent, the worker falls back to the Volume-backed store.
     """
     bucket = os.environ.get(STORE_BUCKET_ENV)
-    token = os.environ.get('HF_TOKEN')
-    if not (bucket and token):
+    if not bucket:
+        return None
+    from huggingface_hub import get_token
+
+    token = os.environ.get('HF_TOKEN') or get_token()  # env, or the cached `hf auth login`
+    if not token:
         return None
     return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
 

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import secrets
 import time
 from contextlib import asynccontextmanager, nullcontext
@@ -35,7 +34,7 @@ from mini.progress import ProgressMessage, progress_context
 from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
 from mini.runs import data_root
-from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, default_store
+from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, _cas_key, _hf_token, default_store, store_bucket
 from mini.volume import data_dir_context
 
 log = logging.getLogger(__name__)
@@ -156,7 +155,7 @@ class ModalMemoStore(MemoStore):
 class ModalVolumeStore(Store):
     """Client-side artifact :class:`~mini.store.Store` that reads blobs off the Volume.
 
-    The remote worker writes the CAS *under* the mounted Volume (``store/cas/<sha>``)
+    The remote worker writes the CAS *under* the mounted Volume (``store/cas/ab/<sha>``)
     and commits it; this reads those blobs back from the client (a report, or
     ``ctx.run`` resolving a handle into the next step) with no running function,
     caching each blob into a local :class:`~mini.store.LocalStore` so a re-read is
@@ -176,7 +175,7 @@ class ModalVolumeStore(Store):
         if self._cache.has(sha256):
             return True
         try:
-            self._read_volume_bytes(f'store/cas/{sha256}')
+            self._read_volume_bytes(f'store/{_cas_key(sha256)}')
             return True
         except FileNotFoundError, modal.exception.NotFoundError:
             return False
@@ -186,8 +185,8 @@ class ModalVolumeStore(Store):
 
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
-            data = self._read_volume_bytes(f'store/cas/{sha256}')
-            self._cache.cas.mkdir(parents=True, exist_ok=True)
+            data = self._read_volume_bytes(f'store/{_cas_key(sha256)}')
+            blob.parent.mkdir(parents=True, exist_ok=True)
             tmp = blob.with_name(f'{sha256}.tmp')
             tmp.write_bytes(data)
             tmp.replace(blob)
@@ -215,16 +214,15 @@ class ModalVolumeStore(Store):
 def _hf_store_secret() -> modal.Secret | None:
     """A Modal Secret carrying the HF bucket config into the worker, if configured.
 
-    When ``MINI_STORE_BUCKET`` (and ``HF_TOKEN``) are set locally, forward them into
-    the remote container's env so the worker's ``default_store`` resolves to the
-    shared bucket. Absent, the worker falls back to the Volume-backed store.
+    When a bucket is configured (``[tool.mini] store-bucket`` or the env override)
+    and a token is available, forward both into the remote container's env so the
+    worker's ``default_store`` resolves to the shared bucket. Absent either, the
+    worker falls back to the Volume-backed store.
     """
-    bucket = os.environ.get(STORE_BUCKET_ENV)
+    bucket = store_bucket()
     if not bucket:
         return None
-    from huggingface_hub import get_token
-
-    token = os.environ.get('HF_TOKEN') or get_token()  # env, or the cached `hf auth login`
+    token = _hf_token()  # env, or the cached `hf auth login`
     if not token:
         return None
     return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
@@ -348,12 +346,14 @@ class ModalApparatus(Apparatus[ModalVolume]):
     def store(self) -> Store:
         """The artifact store for reads on the client (reports, ``ctx`` resolves).
 
-        With ``MINI_STORE_BUCKET`` set, that's the shared HF bucket the worker
-        wrote to — so artifacts read back the same everywhere, no Volume needed.
-        Otherwise it's a read-through over this experiment's Modal Volume,
-        warm-caching into a local checkout (``.mini/store-cache/<app>``).
+        With a bucket configured *and* a token available, that's the shared HF
+        bucket the worker wrote to — so artifacts read back the same everywhere, no
+        Volume needed. Otherwise it's a read-through over this experiment's Modal
+        Volume, warm-caching into a local checkout (``.mini/store-cache/<app>``).
+        The token gate mirrors ``_hf_store_secret``: with no token the worker writes
+        to the Volume, so the client must read from there too (not an empty bucket).
         """
-        if os.environ.get(STORE_BUCKET_ENV):
+        if store_bucket() and _hf_token():
             return default_store(data_root() / 'store')
         assert self.app.name  # guaranteed by __init__ (a named App is required)
         cache = LocalStore(data_root() / 'store-cache' / self.app.name)

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import secrets
 import time
 from contextlib import asynccontextmanager, nullcontext
@@ -34,7 +35,7 @@ from mini.progress import ProgressMessage, progress_context
 from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
 from mini.runs import data_root
-from mini.store import Artifact, LocalStore, Store
+from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, default_store
 from mini.volume import data_dir_context
 
 log = logging.getLogger(__name__)
@@ -211,6 +212,20 @@ class ModalVolumeStore(Store):
         )
 
 
+def _hf_store_secret() -> modal.Secret | None:
+    """A Modal Secret carrying the HF bucket config into the worker, if configured.
+
+    When ``MINI_STORE_BUCKET`` (and ``HF_TOKEN``) are set locally, forward them into
+    the remote container's env so the worker's ``default_store`` resolves to the
+    shared bucket. Absent, the worker falls back to the Volume-backed store.
+    """
+    bucket = os.environ.get(STORE_BUCKET_ENV)
+    token = os.environ.get('HF_TOKEN')
+    if not (bucket and token):
+        return None
+    return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
+
+
 def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, mount_point: str) -> None:
     """Remote entry: run one memoized call on Modal and persist its result/state.
 
@@ -224,16 +239,16 @@ def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, m
     from mini._taskworker import execute_task
     from mini.memo import MemoStore
     from mini.modal_apparatus import ModalRecordStore
-    from mini.store import LocalStore
+    from mini.store import default_store
 
     fn, args, hooks = _cp.loads(blob)
     store = MemoStore(Path(mount_point), records=ModalRecordStore.from_name(dict_name))
     volume = _modal.Volume.from_name(volume_name)
-    # The artifact CAS lives *under* the mounted Volume (so the worker's blobs are
-    # committed with the result and the client can read them back). It rides the
-    # experiment's Volume, so cross-experiment sharing on Modal waits on the
-    # project-scoped Volume (#22); within an experiment, put/get work end to end.
-    artifacts = LocalStore(Path(mount_point) / 'store')
+    # With MINI_STORE_BUCKET set (passed in via a Modal Secret), put/get hit the
+    # shared HF bucket — so another experiment, local or remote, reads these bytes
+    # back with no shared Volume. Otherwise the CAS rides *under* the mounted
+    # Volume (committed with the result), per-experiment until #22's project Volume.
+    artifacts = default_store(Path(mount_point) / 'store')
     execute_task(store, key, fn, args, hooks, commit=volume.commit, artifacts=artifacts)
 
 
@@ -327,11 +342,15 @@ class ModalApparatus(Apparatus[ModalVolume]):
 
     @override
     def store(self) -> Store:
-        """Read artifacts back off the Volume, warm-caching into a local checkout.
+        """The artifact store for reads on the client (reports, ``ctx`` resolves).
 
-        The cache is project-scoped on the client (``.mini/store-cache/<app>``);
-        the source of truth is ``store/`` on this experiment's Modal Volume.
+        With ``MINI_STORE_BUCKET`` set, that's the shared HF bucket the worker
+        wrote to — so artifacts read back the same everywhere, no Volume needed.
+        Otherwise it's a read-through over this experiment's Modal Volume,
+        warm-caching into a local checkout (``.mini/store-cache/<app>``).
         """
+        if os.environ.get(STORE_BUCKET_ENV):
+            return default_store(data_root() / 'store')
         assert self.app.name  # guaranteed by __init__ (a named App is required)
         cache = LocalStore(data_root() / 'store-cache' / self.app.name)
         return ModalVolumeStore(self.volume, cache)
@@ -358,6 +377,8 @@ class ModalApparatus(Apparatus[ModalVolume]):
                     **fn_kwargs.get('volumes', {}),
                     str(self._volume.path): self._volume._modal_volume,
                 }
+            if secret := _hf_store_secret():  # forward HF bucket creds so put/get hit the shared store
+                fn_kwargs['secrets'] = [*fn_kwargs.get('secrets', []), secret]
             self._memo_fn = self.app.function(serialized=True, **fn_kwargs)(_modal_task_entry)
         return self._memo_fn
 

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -45,6 +45,7 @@ import contextvars
 import hashlib
 import json
 import mimetypes
+import os
 import shutil
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -65,7 +66,13 @@ __all__ = [
     'set_ref',
     'get_ref',
     'store_root_for',
+    'default_store',
+    'STORE_BUCKET_ENV',
 ]
+
+# Env var naming the project's Hugging Face bucket. Set it (alongside HF_TOKEN)
+# to make the durable/publish tier the shared bucket; unset, the store is local.
+STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
 
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
 
@@ -282,6 +289,23 @@ def store_root_for(data_dir: Path | str) -> Path:
     under its own cwd lands on the same store.
     """
     return Path(data_dir).parent / 'store'
+
+
+def default_store(root: Path | str) -> Store:
+    """The project store for a given local *root* — bucket-backed if configured.
+
+    When ``MINI_STORE_BUCKET`` is set the durable store is the shared Hugging Face
+    bucket (with *root* demoted to a local warm cache); otherwise it's a
+    :class:`LocalStore` rooted at *root*. One switch flips every put/get/publish —
+    in a step, a report, or a worker — from on-disk to shared-and-web-reachable.
+    """
+    root = Path(root)
+    bucket = os.environ.get(STORE_BUCKET_ENV)
+    if bucket:
+        from mini.hf_store import HFStore
+
+        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'))
+    return LocalStore(root)
 
 
 class LocalStore(Store):

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -230,9 +230,7 @@ class Store(ABC):
 
     def _put_tree(self, src: Path, *, name: str) -> Artifact:
         children = tuple(
-            self._put_file(p, name=str(p.relative_to(src).as_posix()))
-            for p in sorted(src.rglob('*'))
-            if p.is_file()
+            self._put_file(p, name=str(p.relative_to(src).as_posix())) for p in sorted(src.rglob('*')) if p.is_file()
         )
         sha = _tree_sha(children)
         size = sum(c.size for c in children)

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -44,9 +44,11 @@ from __future__ import annotations
 import contextvars
 import hashlib
 import json
+import logging
 import mimetypes
 import os
 import shutil
+import tomllib
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -67,14 +69,17 @@ __all__ = [
     'get_ref',
     'store_root_for',
     'default_store',
+    'store_bucket',
     'STORE_BUCKET_ENV',
 ]
 
-# Env var naming the project's Hugging Face bucket. Set it (alongside HF_TOKEN)
-# to make the durable/publish tier the shared bucket; unset, the store is local.
+# Env var naming the project's Hugging Face bucket — an *override* for the
+# `[tool.mini] store-bucket` committed in pyproject.toml (see `store_bucket`).
 STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
 
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +136,17 @@ class Artifact:
             kind=d.get('kind', 'file'),
             children=tuple(cls.from_dict(c) for c in d.get('children', ())),
         )
+
+
+def _cas_key(sha256: str) -> str:
+    """A blob's path within the store, sharded by a two-char prefix (``cas/ab/abcd…``).
+
+    Git and Git-LFS both fan blobs out under a short prefix dir so the CAS never
+    becomes one flat directory of thousands of entries — slow to list on disk and
+    unwieldy in a bucket's web UI. One level of two hex chars (256 buckets) is
+    plenty at our scale; the full sha still names the file, so it stays the id.
+    """
+    return f'cas/{sha256[:2]}/{sha256}'
 
 
 def _hash_bytes(data: bytes) -> str:
@@ -289,25 +305,79 @@ def store_root_for(data_dir: Path | str) -> Path:
     return Path(data_dir).parent / 'store'
 
 
+def _project_config() -> dict:
+    """``[tool.mini]`` from the nearest ``pyproject.toml`` walking up from cwd, or ``{}``.
+
+    Read lazily off the live cwd (like :func:`~mini.runs.data_root`) so a ``chdir``
+    — or a test in a tmp dir — resolves the right project, and nothing parses TOML
+    at import time.
+    """
+    cwd = Path.cwd().resolve()
+    for d in (cwd, *cwd.parents):
+        pp = d / 'pyproject.toml'
+        if pp.exists():
+            try:
+                return tomllib.loads(pp.read_text()).get('tool', {}).get('mini', {})
+            except OSError, tomllib.TOMLDecodeError:
+                return {}
+    return {}
+
+
+def store_bucket() -> str | None:
+    """The configured Hugging Face bucket (``namespace/name``), or ``None`` for local.
+
+    Resolution order: the ``MINI_STORE_BUCKET`` env var first (so CI or a one-off
+    shell can override), else ``[tool.mini] store-bucket`` in ``pyproject.toml`` —
+    so the project's default *travels with the repo*, set once and shared by every
+    checkout, Modal worker, and CI run rather than re-set in three places. The
+    bucket name isn't a secret; the token still lives in the env / ``hf`` cache.
+    """
+    return os.environ.get(STORE_BUCKET_ENV) or _project_config().get('store-bucket')
+
+
+def _hf_token() -> str | None:
+    """The Hugging Face token from the env or the ``hf auth login`` cache, or ``None``."""
+    if tok := os.environ.get('HF_TOKEN'):
+        return tok
+    try:
+        from huggingface_hub import get_token
+
+        return get_token()
+    except Exception:
+        return None
+
+
 def default_store(root: Path | str) -> Store:
     """The project store for a given local *root* — bucket-backed if configured.
 
-    When ``MINI_STORE_BUCKET`` is set the durable store is the shared Hugging Face
-    bucket (with *root* demoted to a local warm cache); otherwise it's a
-    :class:`LocalStore` rooted at *root*. One switch flips every put/get/publish —
-    in a step, a report, or a worker — from on-disk to shared-and-web-reachable.
+    When a bucket is configured (:func:`store_bucket`) *and* a Hugging Face token is
+    available, the durable store is the shared bucket (with *root* demoted to a
+    local warm cache); otherwise it's a :class:`LocalStore` rooted at *root*. One
+    switch flips every put/get/publish — in a step, a report, or a worker — from
+    on-disk to shared-and-web-reachable.
+
+    A configured bucket with *no* token (someone trying the repo in Codespaces, or
+    a fresh checkout before ``./go auth``) falls back to the local store with a
+    warning rather than failing mid-run — the bucket name travels with the repo,
+    but using it needs auth the trier doesn't have yet.
     """
     root = Path(root)
-    bucket = os.environ.get(STORE_BUCKET_ENV)
-    if bucket:
+    bucket = store_bucket()
+    if bucket and (token := _hf_token()):
         from mini.hf_store import HFStore
 
-        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'))
+        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'), token=token)
+    if bucket:
+        log.warning(
+            'store-bucket %r is configured but no Hugging Face token was found — using the local '
+            'store instead. Run `./go auth` (or set HF_TOKEN) to read/write the shared bucket.',
+            bucket,
+        )
     return LocalStore(root)
 
 
 class LocalStore(Store):
-    """A ``cas/<sha256>`` blob tree on local disk, with file-backed refs and views.
+    """A ``cas/<ab>/<sha256>`` blob tree on local disk, with file-backed refs and views.
 
     The boring default: no network, immutability enforced by write-once-by-hash.
     ``publish`` copies a blob to ``published/<path>`` and returns a ``file://`` URL
@@ -317,19 +387,18 @@ class LocalStore(Store):
 
     def __init__(self, root: Path | str):
         self.root = Path(root)
-        self.cas = self.root / 'cas'
         self.refs = self.root / 'refs'
         self.published = self.root / 'published'
 
     def _blob_path(self, sha256: str) -> Path:
-        return self.cas / sha256
+        return self.root / _cas_key(sha256)
 
     def has(self, sha256: str) -> bool:
         return self._blob_path(sha256).exists()
 
     def _write_blob(self, sha256: str, src: Path) -> None:
-        self.cas.mkdir(parents=True, exist_ok=True)
         dest = self._blob_path(sha256)
+        dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():  # immutable: another writer won the race; bytes are identical by hash
             return
         tmp = dest.with_name(f'{sha256}.tmp.{src.stat().st_ino}')

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -1,0 +1,397 @@
+"""
+Content-addressed artifact storage for experiments.
+
+A step's *result* (the small thing a memo record holds) and its *artifacts* (the
+large bytes a result points at) want different homes. Today a step that writes a
+file returns a ``Path``, which pickles a *location* into the result — and that
+location lives in a volume that may have evaporated by the time another process,
+another experiment, or a report reads the result back.
+
+This module fixes the asymmetry. A step ``put``s its bytes into a content-addressed
+store and returns an :class:`Artifact` — a small, location-free *handle* (a sha,
+a size, a logical name). The handle pickles durably into the result, and anyone
+holding it can ``get`` the bytes back from the store regardless of where they run.
+
+Two properties make this more than a tidy file copy:
+
+- **The store is project-scoped, not experiment-scoped.** Blobs are keyed by
+  content (``cas/<sha256>``), so identical bytes coincide and distinct bytes
+  diverge — across experiments, for free. A small mutable *ref* layer
+  (``name -> Artifact``) names views over the immutable blobs (the git
+  objects-and-refs split), which is how one experiment hands an asset to another
+  by a stable name (:func:`set_ref` / :func:`get_ref`).
+- **Handles stabilize downstream keys.** Passing a ``Path`` into the next step
+  would fingerprint it by location; passing an ``Artifact`` fingerprints it by
+  content, so a consumer's memo key only moves when the bytes actually change.
+
+Steps reach the store the way they reach the data dir — through a context var the
+worker enters — so ``from mini.store import put, get`` works inside any step::
+
+    from mini.store import put, get_ref
+
+    def extract_features(cfg) -> Artifact:
+        cache = get_data_dir() / 'acts'
+        run_model(cfg, into=cache)
+        return put(cache, name='activations')   # hashed into the store; handle returned
+
+The backend is swappable behind :class:`Store`. :class:`LocalStore` (a ``cas/``
+tree on disk) is the boring default and needs no network; a bucket- or repo-backed
+store for web-reachable :meth:`~Store.publish` slots in behind the same handle.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+import json
+import mimetypes
+import shutil
+from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, Literal
+
+__all__ = [
+    'Artifact',
+    'Store',
+    'LocalStore',
+    'get_store',
+    'store_context',
+    'put',
+    'get',
+    'publish',
+    'set_ref',
+    'get_ref',
+    'store_root_for',
+]
+
+_CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
+
+
+# ---------------------------------------------------------------------------
+# The handle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """A small, location-free handle to immutable bytes in a :class:`Store`.
+
+    It carries enough to *resolve* the bytes (``sha256``) and to *serve* them
+    (``name`` carries the extension; ``media_type`` overrides the guess) without
+    carrying *where* they live — which is what lets it pickle durably into a
+    result and fingerprint a downstream step by content rather than path.
+
+    ``kind='tree'`` is a manifest: ``children`` are themselves artifacts (each its
+    own blob), so a directory of many small files dedups per-file and resolves one
+    child without pulling the set. A tree's own ``sha256`` hashes its manifest, so
+    two identical directories still coincide.
+    """
+
+    sha256: str
+    size: int
+    name: str
+    media_type: str | None = None
+    kind: Literal['file', 'tree'] = 'file'
+    children: tuple[Artifact, ...] = field(default_factory=tuple)
+
+    @property
+    def content_type(self) -> str:
+        """The MIME type to serve this as — explicit ``media_type`` or guessed from ``name``."""
+        if self.media_type:
+            return self.media_type
+        guessed, _ = mimetypes.guess_type(self.name)
+        return guessed or 'application/octet-stream'
+
+    def to_dict(self) -> dict:
+        """A JSON-canonical dict (recurses into ``children``) for ref storage."""
+        d: dict = {'sha256': self.sha256, 'size': self.size, 'name': self.name, 'kind': self.kind}
+        if self.media_type:
+            d['media_type'] = self.media_type
+        if self.children:
+            d['children'] = [c.to_dict() for c in self.children]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Artifact:
+        return cls(
+            sha256=d['sha256'],
+            size=d['size'],
+            name=d['name'],
+            media_type=d.get('media_type'),
+            kind=d.get('kind', 'file'),
+            children=tuple(cls.from_dict(c) for c in d.get('children', ())),
+        )
+
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    h = hashlib.sha256()
+    size = 0
+    with path.open('rb') as f:
+        while chunk := f.read(_CHUNK):
+            h.update(chunk)
+            size += len(chunk)
+    return h.hexdigest(), size
+
+
+def _tree_sha(children: tuple[Artifact, ...]) -> str:
+    """A stable content id for a manifest: hash the sorted ``(name, sha)`` pairs."""
+    manifest = '\n'.join(f'{c.name}\t{c.sha256}' for c in sorted(children, key=lambda c: c.name))
+    return _hash_bytes(manifest.encode())
+
+
+# ---------------------------------------------------------------------------
+# The store
+# ---------------------------------------------------------------------------
+
+
+class Store(ABC):
+    """A content-addressed blob store with a small mutable ref layer.
+
+    Backends implement the four blob/ref primitives below; the high-level
+    :meth:`put` / :meth:`get` (including tree fan-out) and JSON ref handling are
+    shared. ``put`` is idempotent — hash first, skip the write if :meth:`has` —
+    so re-runs and cross-step duplicates cost nothing.
+    """
+
+    # -- backend primitives ---------------------------------------------------
+
+    @abstractmethod
+    def has(self, sha256: str) -> bool:
+        """Whether a blob with this content hash is already stored."""
+
+    @abstractmethod
+    def _write_blob(self, sha256: str, src: Path) -> None:
+        """Idempotently store the file at *src* under *sha256* (treat blobs as immutable)."""
+
+    @abstractmethod
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        """Materialize the blob *sha256* to the file *dest* (parent dirs exist)."""
+
+    @abstractmethod
+    def _write_ref(self, name: str, payload: str) -> None:
+        """Set the mutable ref *name* to *payload* (last writer wins)."""
+
+    @abstractmethod
+    def _read_ref(self, name: str) -> str | None:
+        """Read the ref *name*, or ``None`` if unset."""
+
+    @abstractmethod
+    def publish(self, art: Artifact, path: str) -> str:
+        """Expose *art* at a named, extensioned *path* and return its URL.
+
+        A by-hash copy to a path whose extension drives the served ``Content-Type``
+        (a bare ``cas/<sha>`` has no extension, so a browser won't render it). Kept
+        separate from :meth:`put` and deliberately the only outward-facing verb, so
+        persisting a result never publishes it as a side effect.
+        """
+
+    # -- high-level surface (shared) ------------------------------------------
+
+    def put(self, data: bytes | Path, *, name: str) -> Artifact:
+        """Store *data* (bytes, a file, or a directory) and return its handle.
+
+        A directory becomes a ``tree`` artifact: each file is stored as its own
+        blob and the returned handle carries the manifest. ``name`` is the logical
+        name (carry the extension — it sets the served media type).
+        """
+        if isinstance(data, (bytes, bytearray)):
+            return self._put_bytes(bytes(data), name=name)
+        src = Path(data)
+        if src.is_dir():
+            return self._put_tree(src, name=name)
+        return self._put_file(src, name=name)
+
+    def _put_bytes(self, data: bytes, *, name: str) -> Artifact:
+        sha = _hash_bytes(data)
+        if not self.has(sha):
+            with _spill(data) as tmp:
+                self._write_blob(sha, tmp)
+        return Artifact(sha256=sha, size=len(data), name=name)
+
+    def _put_file(self, src: Path, *, name: str) -> Artifact:
+        sha, size = _hash_file(src)
+        if not self.has(sha):
+            self._write_blob(sha, src)
+        return Artifact(sha256=sha, size=size, name=name)
+
+    def _put_tree(self, src: Path, *, name: str) -> Artifact:
+        children = tuple(
+            self._put_file(p, name=str(p.relative_to(src).as_posix()))
+            for p in sorted(src.rglob('*'))
+            if p.is_file()
+        )
+        sha = _tree_sha(children)
+        size = sum(c.size for c in children)
+        return Artifact(sha256=sha, size=size, name=name, kind='tree', children=children)
+
+    def get(self, art: Artifact, dest: Path) -> Path:
+        """Materialize *art* at *dest* and return it.
+
+        For a ``file`` artifact *dest* is the destination file; for a ``tree`` it's
+        the destination directory, and the children resolve concurrently (the
+        per-op latency of a remote backend overlaps rather than serializes).
+        """
+        dest = Path(dest)
+        if art.kind == 'tree':
+            dest.mkdir(parents=True, exist_ok=True)
+            with ThreadPoolExecutor(max_workers=min(8, len(art.children) or 1)) as ex:
+                list(ex.map(lambda c: self.get(c, dest / c.name), art.children))
+            return dest
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        self._read_blob(art.sha256, dest)
+        return dest
+
+    def set_ref(self, name: str, art: Artifact) -> None:
+        """Point the mutable name *name* at *art* — the cross-experiment by-name handle."""
+        self._write_ref(name, json.dumps(art.to_dict(), sort_keys=True))
+
+    def get_ref(self, name: str) -> Artifact | None:
+        """Resolve the name *name* to its artifact handle, or ``None`` if unset."""
+        payload = self._read_ref(name)
+        return Artifact.from_dict(json.loads(payload)) if payload is not None else None
+
+
+@contextmanager
+def _spill(data: bytes) -> Iterator[Path]:
+    """Write *data* to a short-lived temp file (so a bytes ``put`` reuses the file path)."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(data)
+        tmp = Path(f.name)
+    try:
+        yield tmp
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def store_root_for(data_dir: Path | str) -> Path:
+    """The project-scoped store root that sits beside an experiment's *data_dir*.
+
+    A volume path is ``<data_root>/<experiment>``, so its parent is the project
+    root and ``<parent>/store`` is shared by every experiment — content-addressed,
+    so identical bytes coincide and a named ref handed off by one experiment
+    resolves in another. Derived from the path (not the cwd), so a detached worker
+    under its own cwd lands on the same store.
+    """
+    return Path(data_dir).parent / 'store'
+
+
+class LocalStore(Store):
+    """A ``cas/<sha256>`` blob tree on local disk, with file-backed refs and views.
+
+    The boring default: no network, immutability enforced by write-once-by-hash.
+    ``publish`` copies a blob to ``published/<path>`` and returns a ``file://`` URL
+    — the same shape a bucket-backed store returns as an ``https://`` resolve URL,
+    so a report reads one ``url`` either way.
+    """
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+        self.cas = self.root / 'cas'
+        self.refs = self.root / 'refs'
+        self.published = self.root / 'published'
+
+    def _blob_path(self, sha256: str) -> Path:
+        return self.cas / sha256
+
+    def has(self, sha256: str) -> bool:
+        return self._blob_path(sha256).exists()
+
+    def _write_blob(self, sha256: str, src: Path) -> None:
+        self.cas.mkdir(parents=True, exist_ok=True)
+        dest = self._blob_path(sha256)
+        if dest.exists():  # immutable: another writer won the race; bytes are identical by hash
+            return
+        tmp = dest.with_name(f'{sha256}.tmp.{src.stat().st_ino}')
+        shutil.copyfile(src, tmp)  # copy (never hardlink): a caller mutating dest must not corrupt the CAS
+        tmp.replace(dest)  # atomic publish into the CAS
+
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        shutil.copyfile(self._blob_path(sha256), dest)
+
+    def _ref_path(self, name: str) -> Path:
+        return self.refs / f'{name}.json'
+
+    def _write_ref(self, name: str, payload: str) -> None:
+        p = self._ref_path(name)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix('.json.tmp')
+        tmp.write_text(payload)
+        tmp.replace(p)
+
+    def _read_ref(self, name: str) -> str | None:
+        p = self._ref_path(name)
+        return p.read_text() if p.exists() else None
+
+    def publish(self, art: Artifact, path: str) -> str:
+        if art.kind == 'tree':
+            raise ValueError('publish a single file (resolve a tree first, or publish its children)')
+        dest = self.published / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        self._read_blob(art.sha256, dest)
+        return dest.resolve().as_uri()
+
+
+# ---------------------------------------------------------------------------
+# Ambient store (the get_data_dir pattern)
+# ---------------------------------------------------------------------------
+
+_store: contextvars.ContextVar[Store | None] = contextvars.ContextVar('mini_store', default=None)
+
+
+@contextmanager
+def store_context(store: Store) -> Iterator[None]:
+    """Bind *store* as the ambient store for :func:`put` / :func:`get` in this context."""
+    token = _store.set(store)
+    try:
+        yield
+    finally:
+        _store.reset(token)
+
+
+def get_store() -> Store:
+    """The ambient :class:`Store`, set by the apparatus around a step (or a report).
+
+    Raises if called outside a store context — the same contract as
+    :func:`~mini.volume.get_data_dir`.
+    """
+    s = _store.get()
+    if s is None:
+        raise RuntimeError(
+            'No store configured. put()/get() must run inside a step launched by an '
+            'Apparatus, or under an explicit store_context(...).'
+        )
+    return s
+
+
+def put(data: bytes | Path, *, name: str) -> Artifact:
+    """Store *data* in the ambient store and return its handle. See :meth:`Store.put`."""
+    return get_store().put(data, name=name)
+
+
+def get(art: Artifact, dest: Path) -> Path:
+    """Materialize *art* from the ambient store at *dest*. See :meth:`Store.get`."""
+    return get_store().get(art, dest)
+
+
+def publish(art: Artifact, path: str) -> str:
+    """Publish *art* at a named *path* via the ambient store. See :meth:`Store.publish`."""
+    return get_store().publish(art, path)
+
+
+def set_ref(name: str, art: Artifact) -> None:
+    """Point a name at *art* in the ambient store — the cross-experiment handle."""
+    get_store().set_ref(name, art)
+
+
+def get_ref(name: str) -> Artifact | None:
+    """Resolve a name to its artifact in the ambient store, or ``None``."""
+    return get_store().get_ref(name)

--- a/tests/mini/test_experiments_e2e.py
+++ b/tests/mini/test_experiments_e2e.py
@@ -78,6 +78,31 @@ def test_role_demo_runs_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert set(out) == {'probe', 'gpu'}  # both keys produced via distinct role-labelled steps
 
 
+def test_cross_experiment_artifact_reuse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """``acts`` publishes an activation cache; ``probe`` (a *separate* experiment)
+    resolves the same bytes from the project-scoped store — no recompute, no shared
+    volume. The acceptance test for #13/#22's artifact-sharing half."""
+    monkeypatch.chdir(tmp_path)  # both experiments anchor .mini (and .mini/store) here
+
+    acts = _drive(load_experiment(REPO / 'docs/acts/experiment.py'), LocalApparatus('acts'))
+    probe = _drive(load_experiment(REPO / 'docs/probe/experiment.py'), LocalApparatus('probe'))
+
+    # B read A's exact bytes: its recorded source sha is A's artifact sha.
+    assert probe['source_sha'] == acts['artifact'].sha256
+    assert probe['n_layers'] == acts['shards']
+
+    # The two experiments kept separate volumes but one shared store: B never ran
+    # A's extraction (its only task is the probe), and the blobs live under .mini/store.
+    probe_fns = {r.get('fn') for r in LocalApparatus('probe').memo_store().records()}
+    assert probe_fns == {'probe_activations'}  # no extract_activations recompute
+    assert (tmp_path / '.mini' / 'store' / 'cas').is_dir()
+
+    # The handle resolves from a fresh client (a report would do exactly this).
+    store = LocalApparatus('probe').store()
+    cache = store.get(acts['artifact'], tmp_path / 'check')
+    assert len(list(cache.glob('*.npy'))) == acts['shards']
+
+
 def test_interactive_apparatus_sweep_pattern():
     """The interactive pattern: drive an ``Apparatus`` directly (notebook-style) —
     fan a sweep out with ``.map`` and reduce to the best config. No memo store/CLI."""

--- a/tests/mini/test_hf_store.py
+++ b/tests/mini/test_hf_store.py
@@ -55,7 +55,7 @@ def test_put_get_round_trips_over_the_bucket(hf):
     from mini.hf_store import HFStore
     from mini.store import LocalStore
 
-    fresh = HFStore(BUCKET, cache=LocalStore(Path(store._cache.root).parent / 'cache2'))
+    fresh = HFStore(store.bucket, cache=LocalStore(Path(store._cache.root).parent / 'cache2'))
     out = fresh.get(art, Path(store._cache.root).parent / 'out.txt')
     assert out.read_bytes() == data
 

--- a/tests/mini/test_hf_store.py
+++ b/tests/mini/test_hf_store.py
@@ -1,0 +1,89 @@
+"""Integration test for the Hugging Face bucket store — network-gated.
+
+Talks to a real bucket, so it's skipped unless ``MINI_STORE_BUCKET`` and
+``HF_TOKEN`` are set. It writes only under a unique ``cas/`` blob and a
+per-run ``refs/_test/<uuid>`` / ``published/_test/<uuid>`` prefix, and deletes
+everything it created in teardown, so it never collides with real artifacts.
+
+Run it with::
+
+    MINI_STORE_BUCKET=<ns>/<bucket> HF_TOKEN=... uv run pytest tests/mini/test_hf_store.py
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+
+import pytest
+
+BUCKET = os.environ.get('MINI_STORE_BUCKET')
+
+pytestmark = pytest.mark.skipif(
+    not (BUCKET and os.environ.get('HF_TOKEN')),
+    reason='set MINI_STORE_BUCKET + HF_TOKEN to run the HF bucket integration test',
+)
+
+
+@pytest.fixture
+def hf(tmp_path: Path):
+    """An HFStore against the real bucket, with a unique prefix and full cleanup."""
+    from huggingface_hub import HfApi
+
+    from mini.hf_store import HFStore
+    from mini.store import LocalStore
+
+    assert BUCKET is not None  # narrowed by pytestmark skip
+    tag = secrets.token_hex(4)
+    store = HFStore(BUCKET, cache=LocalStore(tmp_path / 'cache'))
+    created: list[str] = []
+    yield store, tag, created
+    # Teardown: remove every path this test created.
+    if created:
+        HfApi(token=os.environ['HF_TOKEN']).batch_bucket_files(BUCKET, delete=sorted(set(created)))
+
+
+def test_put_get_round_trips_over_the_bucket(hf):
+    store, tag, created = hf
+    data = f'mini hf round-trip {tag}'.encode()
+    art = store.put(data, name='probe.txt')
+    created.append(f'cas/{art.sha256}')
+
+    assert store.has(art.sha256)
+    # Resolve through a *fresh* cache to force a real download, not a cache hit.
+    from mini.hf_store import HFStore
+    from mini.store import LocalStore
+
+    fresh = HFStore(BUCKET, cache=LocalStore(Path(store._cache.root).parent / 'cache2'))
+    out = fresh.get(art, Path(store._cache.root).parent / 'out.txt')
+    assert out.read_bytes() == data
+
+
+def test_ref_round_trips_over_the_bucket(hf):
+    store, tag, created = hf
+    art = store.put(f'ref payload {tag}'.encode(), name='r.bin')
+    created.append(f'cas/{art.sha256}')
+    name = f'_test/{tag}/handle'
+    store.set_ref(name, art)
+    created.append(f'refs/{name}.json')
+
+    assert store.get_ref(name) == art
+    assert store.get_ref(f'_test/{tag}/missing') is None
+
+
+def test_publish_serves_with_content_type_from_extension(hf):
+    store, tag, created = hf
+    png = b'\x89PNG\r\n\x1a\n' + tag.encode()  # not a real PNG, but a .png name
+    art = store.put(png, name='fig.png')
+    created.append(f'cas/{art.sha256}')
+    path = f'_test/{tag}/fig.png'
+    url = store.publish(art, path)
+    created.append(f'published/{path}')
+
+    assert url == f'https://huggingface.co/buckets/{BUCKET}/resolve/published/{path}'
+    import requests
+
+    head = requests.get(url, timeout=30)
+    assert head.status_code == 200
+    assert head.headers['content-type'].startswith('image/png')  # inferred from the extension

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -1,0 +1,175 @@
+"""Tests for the content-addressed artifact store.
+
+Two layers: the :class:`~mini.store.LocalStore` backend (hashing, idempotency,
+trees, refs, publish) and the contextvar front door (``put``/``get`` resolving
+the ambient store, the same shape as ``get_data_dir``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mini.store import (
+    Artifact,
+    LocalStore,
+    get,
+    get_ref,
+    get_store,
+    publish,
+    put,
+    set_ref,
+    store_context,
+    store_root_for,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> LocalStore:
+    return LocalStore(tmp_path / 'store')
+
+
+# ---------------------------------------------------------------------------
+# Artifact handle
+# ---------------------------------------------------------------------------
+
+
+def test_content_type_inferred_from_name():
+    assert Artifact('sha', 1, 'fig.png').content_type == 'image/png'
+    assert Artifact('sha', 1, 'data.json').content_type == 'application/json'
+    assert Artifact('sha', 1, 'blob').content_type == 'application/octet-stream'  # no extension
+
+
+def test_content_type_explicit_overrides_guess():
+    assert Artifact('sha', 1, 'blob', media_type='image/svg+xml').content_type == 'image/svg+xml'
+
+
+def test_artifact_round_trips_through_dict():
+    tree = Artifact(
+        'root', 6, 'acts', kind='tree', children=(Artifact('a', 4, 'a.bin'), Artifact('b', 2, 'sub/b.bin'))
+    )
+    assert Artifact.from_dict(tree.to_dict()) == tree
+
+
+# ---------------------------------------------------------------------------
+# LocalStore: blobs
+# ---------------------------------------------------------------------------
+
+
+def test_put_bytes_round_trips(store: LocalStore, tmp_path: Path):
+    art = store.put(b'hello world', name='greeting.txt')
+    assert art.kind == 'file'
+    assert store.has(art.sha256)
+    out = store.get(art, tmp_path / 'out.txt')
+    assert out.read_bytes() == b'hello world'
+
+
+def test_put_is_content_addressed_and_idempotent(store: LocalStore):
+    """Identical bytes coincide regardless of name; a re-put writes no second blob."""
+    a = store.put(b'same', name='one.bin')
+    b = store.put(b'same', name='two.bin')  # different name, same bytes
+    assert a.sha256 == b.sha256
+    blobs = list((store.root / 'cas').iterdir())
+    assert len(blobs) == 1  # stored once
+
+
+def test_put_file_hashes_streaming(store: LocalStore, tmp_path: Path):
+    src = tmp_path / 'data.bin'
+    src.write_bytes(b'\x00\x01\x02' * 1000)
+    art = store.put(src, name='data.bin')
+    assert art.size == 3000
+    assert store.get(art, tmp_path / 'rt.bin').read_bytes() == src.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# LocalStore: trees
+# ---------------------------------------------------------------------------
+
+
+def test_put_get_tree_round_trips(store: LocalStore, tmp_path: Path):
+    src = tmp_path / 'acts'
+    (src / 'sub').mkdir(parents=True)
+    (src / 'layer0.bin').write_bytes(b'AAAA')
+    (src / 'sub' / 'layer1.bin').write_bytes(b'BB')
+
+    tree = store.put(src, name='acts')
+    assert tree.kind == 'tree'
+    assert tree.size == 6
+    assert {c.name for c in tree.children} == {'layer0.bin', 'sub/layer1.bin'}
+
+    dest = store.get(tree, tmp_path / 'resolved')
+    assert (dest / 'layer0.bin').read_bytes() == b'AAAA'
+    assert (dest / 'sub' / 'layer1.bin').read_bytes() == b'BB'
+
+
+def test_identical_trees_share_blobs(store: LocalStore, tmp_path: Path):
+    """A file shared between two trees is stored once (per-file dedup)."""
+    for d in ('one', 'two'):
+        (tmp_path / d).mkdir()
+        (tmp_path / d / 'shared.bin').write_bytes(b'SHARED')
+    (tmp_path / 'two' / 'extra.bin').write_bytes(b'EXTRA')
+
+    t1 = store.put(tmp_path / 'one', name='one')
+    t2 = store.put(tmp_path / 'two', name='two')
+    shared = {c.sha256 for c in t1.children} & {c.sha256 for c in t2.children}
+    assert len(shared) == 1  # the shared file's blob coincides
+    assert t1.sha256 != t2.sha256  # but the manifests differ
+
+
+# ---------------------------------------------------------------------------
+# LocalStore: refs + publish
+# ---------------------------------------------------------------------------
+
+
+def test_refs_round_trip_including_nested_names(store: LocalStore):
+    art = store.put(b'corpus', name='corpus.bin')
+    store.set_ref('datasets/tiny/v1', art)
+    assert store.get_ref('datasets/tiny/v1') == art
+
+
+def test_get_ref_missing_returns_none(store: LocalStore):
+    assert store.get_ref('nope') is None
+
+
+def test_publish_writes_extensioned_view_and_returns_url(store: LocalStore):
+    art = store.put(b'\x89PNG fake', name='source.png')
+    url = store.publish(art, 'reports/exp/loss.png')
+    assert url.startswith('file://')
+    published = store.published / 'reports' / 'exp' / 'loss.png'
+    assert published.read_bytes() == b'\x89PNG fake'  # served by extension, not bare sha
+
+
+def test_publish_rejects_trees(store: LocalStore, tmp_path: Path):
+    (tmp_path / 'd').mkdir()
+    (tmp_path / 'd' / 'f.bin').write_bytes(b'x')
+    tree = store.put(tmp_path / 'd', name='d')
+    with pytest.raises(ValueError, match='single file'):
+        store.publish(tree, 'reports/x')
+
+
+# ---------------------------------------------------------------------------
+# Project scoping + ambient store
+# ---------------------------------------------------------------------------
+
+
+def test_store_root_is_project_scoped_beside_the_volume():
+    # A volume at <root>/<experiment> shares <root>/store with every experiment.
+    assert store_root_for(Path('/proj/.mini/acts')) == Path('/proj/.mini/store')
+
+
+def test_get_store_raises_outside_context():
+    with pytest.raises(RuntimeError, match='No store configured'):
+        get_store()
+
+
+def test_ambient_put_get_and_refs(store: LocalStore, tmp_path: Path):
+    with store_context(store):
+        art = put(b'payload', name='p.bin')
+        set_ref('k', art)
+        assert get_ref('k') == art
+        assert get(art, tmp_path / 'p.bin').read_bytes() == b'payload'
+        url = publish(art, 'reports/p.bin')
+        assert url.startswith('file://')
+    with pytest.raises(RuntimeError):  # ambient store resets on exit
+        get_store()

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -46,9 +46,7 @@ def test_content_type_explicit_overrides_guess():
 
 
 def test_artifact_round_trips_through_dict():
-    tree = Artifact(
-        'root', 6, 'acts', kind='tree', children=(Artifact('a', 4, 'a.bin'), Artifact('b', 2, 'sub/b.bin'))
-    )
+    tree = Artifact('root', 6, 'acts', kind='tree', children=(Artifact('a', 4, 'a.bin'), Artifact('b', 2, 'sub/b.bin')))
     assert Artifact.from_dict(tree.to_dict()) == tree
 
 

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -14,12 +14,14 @@ import pytest
 from mini.store import (
     Artifact,
     LocalStore,
+    default_store,
     get,
     get_ref,
     get_store,
     publish,
     put,
     set_ref,
+    store_bucket,
     store_context,
     store_root_for,
 )
@@ -68,8 +70,14 @@ def test_put_is_content_addressed_and_idempotent(store: LocalStore):
     a = store.put(b'same', name='one.bin')
     b = store.put(b'same', name='two.bin')  # different name, same bytes
     assert a.sha256 == b.sha256
-    blobs = list((store.root / 'cas').iterdir())
-    assert len(blobs) == 1  # stored once
+    blobs = [p for p in (store.root / 'cas').rglob('*') if p.is_file()]
+    assert len(blobs) == 1  # stored once (under its two-char shard dir)
+
+
+def test_blobs_are_sharded_by_prefix(store: LocalStore):
+    """A blob lands under a two-char shard dir (``cas/ab/abcd…``), not a flat tree."""
+    art = store.put(b'hello world', name='greeting.txt')
+    assert (store.root / 'cas' / art.sha256[:2] / art.sha256).is_file()
 
 
 def test_put_file_hashes_streaming(store: LocalStore, tmp_path: Path):
@@ -154,6 +162,42 @@ def test_publish_rejects_trees(store: LocalStore, tmp_path: Path):
 def test_store_root_is_project_scoped_beside_the_volume():
     # A volume at <root>/<experiment> shares <root>/store with every experiment.
     assert store_root_for(Path('/proj/.mini/acts')) == Path('/proj/.mini/store')
+
+
+def test_store_bucket_reads_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\nstore-bucket = "ns/bkt"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+    assert store_bucket() == 'ns/bkt'
+
+
+def test_store_bucket_env_overrides_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\nstore-bucket = "ns/bkt"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'other/override')
+    assert store_bucket() == 'other/override'
+
+
+def test_store_bucket_unset_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[project]\nname = "x"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+    assert store_bucket() is None
+
+
+def test_default_store_falls_back_to_local_without_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A configured bucket but no HF token (trying the repo, pre-`./go auth`) → local, not a crash."""
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setattr('mini.store._hf_token', lambda: None)
+    assert isinstance(default_store(tmp_path / 'store'), LocalStore)
+
+
+def test_default_store_uses_bucket_with_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from mini.hf_store import HFStore
+
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setattr('mini.store._hf_token', lambda: 'tok')
+    assert isinstance(default_store(tmp_path / 'store'), HFStore)
 
 
 def test_get_store_raises_outside_context():

--- a/todo.md
+++ b/todo.md
@@ -10,20 +10,41 @@ cross-experiment artifact sharing works on Modal **without** a shared Volume.
 Deferred, in rough priority order:
 
 - **Separate publish bucket / private durable store.** We use one public bucket
-  for both durable CAS and published views (HF free tier = one bucket). `publish`
-  is a separate verb, so pointing it at a second (public) bucket while the CAS
-  goes private is a small change when wanted.
+  for both durable CAS and published views. HF buckets have **no per-prefix ACL** —
+  public/private is bucket-level only — so a private CAS + public `published/`
+  genuinely needs *two* buckets, not a prefix split. `publish` is already a
+  separate verb, so pointing it at a second bucket is a small change. (HF docs show
+  no documented cap on bucket *count* per account; free storage is account-level:
+  ~100 GB private, public best-effort.)
 
 - **Versioned publish tier.** A bucket gives immutable *content* (via `cas/<sha>`
-  views) but not immutable *names with history*. If we ever need to cite a frozen
-  figure, the cheap option is an append-only ref log (`refs/<name>/<run-id>`) over
-  the same bucket before reaching for a dataset repo. (Open question from
+  views) but not immutable *names with history*, and buckets are overwrite-in-place
+  with **no server-side append-only / object-lock**. So an `refs/<name>/<run-id>`
+  log is only *convention*, not enforced — a frozen-citation guarantee would need a
+  dataset repo (real git history) rather than a bucket. (Open question from
   `research/artifact-store.md`: bucket vs. dataset repo.)
 
 - **Streaming → promote-to-hash.** For chunk-by-chunk writers (Zarr, activation
   dumps), stream to a working path hashing incrementally, then server-side
   copy-by-xet-hash each chunk to `cas/<sha>` and assemble the tree. The seam is
   there (`HFStore` already copies by xet hash for `publish`); not built yet.
+
+- **Chunked datatrees (Zarr etc.) — out of scope for the CAS; use `hf://` directly.**
+  The per-file-blob + manifest design is fine for a handful of `.npy` shards but is
+  the wrong shape for a tree of thousands of tiny chunks: N `put` round trips on
+  write, and a `get` reassembles the *whole* tree before a consumer touches one
+  slice (kills random-read latency). The conclusion after review is **don't grow
+  the store to chase this** — not a by-name mirror (a mutable, non-atomic key tree
+  reintroduces the half-written-read and dual-namespace-GC hazards the CAS exists
+  to avoid), and not Zarr-specific packing/sharding baked into `put` (too tied to
+  one format; the store stays bytes/files/trees-agnostic). For the rare case that
+  actually needs random-access reads over the network, the right answer is to skip
+  the CAS for *that* artifact and let the array library do remote IO straight
+  against the bucket — Zarr v3 + `s3fs`/`hf://` fsspec over the bucket's HTTP
+  endpoint, with the producer choosing sharding if it wants fewer/larger objects.
+  Document that escape hatch in storage.md if/when someone hits it; keep the CAS
+  for immutable artifact handoff. (Worth a one-off check that the bucket endpoint
+  honours HTTP `Range` before recommending the fsspec path.)
 
 - **Modal gotcha — stale serialized worker.** A long-lived detached app can serve
   a previously-serialized `_modal_task_entry` (so store-wiring edits don't take

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,49 @@
+# Todo
+
+## Artifact store / sharing (#13, #22) — follow-ups
+
+The content-addressed artifact store (`mini.store`) landed with `LocalStore`,
+project-scoped sharing, named refs, and `publish` (see
+`.agents/skills/mi-ni/references/storage.md`). Deferred, in rough priority order:
+
+- **`HFStore` — web-reachable publish (#13 publish tier).** `publish` currently
+  returns a `file://` URL from `LocalStore`. A Hugging Face bucket backend would
+  return an `https://` resolve URL for the same handle (extension drives
+  `Content-Type`), moving large report assets off Git LFS. Blocked on: adding
+  `huggingface_hub` (not installed) + the bucket egress allow-list
+  (`*.xethub.hf.co`, `*.cdn.hf.co`); the bucket-vs-dataset-repo choice is still
+  open (see `research/artifact-store.md`). Keep `HFStore` backend-swappable so the
+  publish tier and a future durable working store can collapse onto one bucket.
+
+- **Project-scoped Modal Volume (#22).** The artifact CAS rides the experiment's
+  Modal Volume, so cross-experiment sharing on Modal only works within one
+  experiment's Volume today (locally it's already project-wide). Repointing the
+  Volume from experiment-name to project-id is the #22 working-store change — but
+  it drags the control-plane cascade with it: `cancel`/`retry`/budget teardown and
+  the `__run__` metadata must become **per-experiment tag-scoped** (a shared store
+  spans all experiments, so an un-scoped `cancel` would settle every experiment's
+  tasks). Rewrite `test_budget.py::test_budget_is_scoped_per_experiment` to assert
+  tag-scoping rather than per-store isolation. This is the large, risky half;
+  landed separately on purpose.
+
+- **Implicit memo-level dedup (#22).** Today cross-experiment reuse is *explicit*
+  (a named ref handed off via the shared store). The implicit version — experiment
+  B memo-*hits* A's identical prep with no ref and no recompute — needs the memo
+  resolution to consult a project-scoped, fingerprint-keyed result store, with the
+  per-experiment `MemoStore` demoted to a run's control plane. Depends on the
+  tag-scoping above.
+
+- **Garbage collection (#15).** A CAS only grows. Need refcounting from live memo
+  results + a sweep. Backend-shaped: a bucket has server-side `rm`; a Modal `Dict`
+  has only `clear()`, no per-key delete — confirm the reclamation story under the
+  project-scoped namespace.
+
+- **Smaller:** whether `Store` should be async to match `Volume`; the on-disk
+  manifest format for trees if it ever needs to be read without Python; and a
+  `mini publish` / artifact-aware CLI surface if reports want one.
+
+## Unrelated nit spotted
+
+- `utils.time.duration` accepts `min`/`h`/`d` but not `m`; the `mini` CLI help and
+  a couple of docstrings advertise `--budget 30m`, which raises. Either add an `m`
+  alias or fix the docs to `30min`.

--- a/todo.md
+++ b/todo.md
@@ -2,29 +2,51 @@
 
 ## Artifact store / sharing (#13, #22) — follow-ups
 
-The content-addressed artifact store (`mini.store`) landed with `LocalStore`,
-project-scoped sharing, named refs, and `publish` (see
-`.agents/skills/mi-ni/references/storage.md`). Deferred, in rough priority order:
+The content-addressed artifact store (`mini.store`) landed with `LocalStore` +
+`HFStore`, project-scoped sharing, named refs, and `publish` (see
+`.agents/skills/mi-ni/references/storage.md`). `HFStore` is selected by
+`MINI_STORE_BUCKET`; the Modal worker gets it via a forwarded Secret, so
+cross-experiment artifact sharing works on Modal **without** a shared Volume.
+Deferred, in rough priority order:
 
-- **`HFStore` — web-reachable publish (#13 publish tier).** `publish` currently
-  returns a `file://` URL from `LocalStore`. A Hugging Face bucket backend would
-  return an `https://` resolve URL for the same handle (extension drives
-  `Content-Type`), moving large report assets off Git LFS. Blocked on: adding
-  `huggingface_hub` (not installed) + the bucket egress allow-list
-  (`*.xethub.hf.co`, `*.cdn.hf.co`); the bucket-vs-dataset-repo choice is still
-  open (see `research/artifact-store.md`). Keep `HFStore` backend-swappable so the
-  publish tier and a future durable working store can collapse onto one bucket.
+- **Separate publish bucket / private durable store.** We use one public bucket
+  for both durable CAS and published views (HF free tier = one bucket). `publish`
+  is a separate verb, so pointing it at a second (public) bucket while the CAS
+  goes private is a small change when wanted.
 
-- **Project-scoped Modal Volume (#22).** The artifact CAS rides the experiment's
-  Modal Volume, so cross-experiment sharing on Modal only works within one
-  experiment's Volume today (locally it's already project-wide). Repointing the
-  Volume from experiment-name to project-id is the #22 working-store change — but
-  it drags the control-plane cascade with it: `cancel`/`retry`/budget teardown and
-  the `__run__` metadata must become **per-experiment tag-scoped** (a shared store
-  spans all experiments, so an un-scoped `cancel` would settle every experiment's
-  tasks). Rewrite `test_budget.py::test_budget_is_scoped_per_experiment` to assert
-  tag-scoping rather than per-store isolation. This is the large, risky half;
-  landed separately on purpose.
+- **Versioned publish tier.** A bucket gives immutable *content* (via `cas/<sha>`
+  views) but not immutable *names with history*. If we ever need to cite a frozen
+  figure, the cheap option is an append-only ref log (`refs/<name>/<run-id>`) over
+  the same bucket before reaching for a dataset repo. (Open question from
+  `research/artifact-store.md`: bucket vs. dataset repo.)
+
+- **Streaming → promote-to-hash.** For chunk-by-chunk writers (Zarr, activation
+  dumps), stream to a working path hashing incrementally, then server-side
+  copy-by-xet-hash each chunk to `cas/<sha>` and assemble the tree. The seam is
+  there (`HFStore` already copies by xet hash for `publish`); not built yet.
+
+- **Modal gotcha — stale serialized worker.** A long-lived detached app can serve
+  a previously-serialized `_modal_task_entry` (so store-wiring edits don't take
+  until its containers drain). Surfaced while testing: a fresh app name or
+  stopping the app fixes it. General to the memo worker, not the store; worth a
+  note in running.md and maybe a deploy-version bump on worker-code change.
+
+- **Interactive `amap` store wiring.** The blocking notebook path
+  (`app.map`/`arun`) enters `data_dir_context` but not `store_context`, so
+  `mini.store.put`/`get` only work on the memoized path. Wire it through
+  `_wrap_for_local`/`_wrap_for_modal` if notebooks want artifacts directly.
+
+- **Project-scoped Modal Volume (#22).** With HF backing the store, artifacts no
+  longer *need* a shared Volume. The #22 volume change is now only for sharing
+  *non-artifact* volume bytes (raw working files via `get_data_dir()`, checkpoints)
+  and for memo-level compute dedup — and it still drags the control-plane cascade
+  with it: `cancel`/`retry`/budget teardown and the `__run__` metadata must become
+  **per-experiment tag-scoped** (a shared store spans all experiments, so an
+  un-scoped `cancel` would settle every experiment's tasks). Rewrite
+  `test_budget.py::test_budget_is_scoped_per_experiment` to assert tag-scoping.
+  Recommendation (see PR discussion): consider keeping Volumes isolated and
+  treating the artifact store as the sharing surface, so this cascade stays
+  optional.
 
 - **Implicit memo-level dedup (#22).** Today cross-experiment reuse is *explicit*
   (a named ref handed off via the shared store). The implicit version — experiment

--- a/uv.lock
+++ b/uv.lock
@@ -617,6 +617,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a5/558da89f66464d8d0229ff497e8b8666977de2d8cf48c28a2862ecf1250f/huggingface_hub-1.19.0-py3-none-any.whl", hash = "sha256:1dc72e1f6b4d6df6b30eb72e57d00514ef453d660f04af2b87f0e67267f31ee0", size = 693398, upload-time = "2026-06-11T12:33:16.695Z" },
 ]
 
+[package.optional-dependencies]
+hf-xet = [
+    { name = "hf-xet" },
+]
+
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
@@ -952,6 +957,7 @@ dependencies = [
     { name = "datasets" },
     { name = "equinox" },
     { name = "ftfy" },
+    { name = "huggingface-hub", extra = ["hf-xet"] },
     { name = "imageio-ffmpeg" },
     { name = "jax" },
     { name = "jaxtyping" },
@@ -993,6 +999,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "equinox", specifier = ">=0.13" },
     { name = "ftfy", specifier = ">=6.3.1" },
+    { name = "huggingface-hub", extras = ["hf-xet"], specifier = ">=1.19" },
     { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "jax", specifier = ">=0.6" },
     { name = "jaxtyping", specifier = ">=0.2.38" },


### PR DESCRIPTION
Add durable storage for artifacts in Hugging Face buckets.

## What this adds

`mini.store`: a frozen, location-free **`Artifact`** handle and a project-scoped, content-addressed **`Store`** (`put`/`get`/`publish` + a small mutable ref layer). Steps reach it through a contextvar the worker enters, so `from mini.store import put, get` works inside any step — the same pattern as `get_data_dir`.

A step now returns a handle instead of a volume `Path`, so results pickle durably and a downstream step's memo key fingerprints by **content**, not location. The store is scoped to the **project** (not the experiment), so blobs and named refs are shared: one experiment publishes an asset by name, another resolves the exact bytes without recomputing.

Backends:
- `LocalStore` (default): a `cas/<sha>` tree on disk under `.mini/store`. No network.
- `HFStore` (`MINI_STORE_BUCKET` set): the same layout over a Xet-backed Hugging Face bucket — durable, shared across machines and backends, and web-reachable. A worker `put`s a blob, and a report or another experiment `get`s it back. `publish()` returns a real `https://…/resolve/…` URL via a server-side copy *by xet hash* (no bytes moved), served with a `Content-Type` from the extension.

`default_store()` picks the backend from the env; nothing in experiment or report code changes.

## Design decisions (resolving the spec toward "publish reports/visualisations with large interp assets")
- Project-scoped store, experiment-scoped volume. The new store is shared from day one (no migration risk); the existing per-experiment volume/memo and the control plane are left untouched.
- HF backing fixes the volume-isolation limit for artifacts. Because the bucket is reachable everywhere, Modal cross-experiment sharing works without a project-scoped Volume. The Volume becomes an optional warm cache.
- `publish` is a separate action from `put`, so persisting a result never publishes it; pointing publish at a separate (private-CAS / public-publish) bucket later is a small change.
- `name` in `put` is not a key (content is). Ref names and publish paths are the shared mutable namespace, prefixed by meaning (`activations/<dataset>`, `reports/<exp>/…`).

## Validated end to end
- Local cross-experiment reuse: `docs/probe` resolves `docs/acts`' bytes by name (matching sha).
- A **Modal worker writing artifacts to the bucket** (Xet egress + Secret forwarding confirmed), then read back from a local client.
- `publish` → a URL serving `200`, `image/png` (content-type from the extension).

## Surface
- `store.py`: `Artifact`, `Store`, `LocalStore`, contextvar front door, tree artifacts (per-file dedup, concurrent resolve), `default_store`.
- `hf_store.py`: `HFStore` over `HfApi` bucket ops (warm cache, batched tree put, publish by xet hash).
- Wiring: `Apparatus.store()`, both workers; Modal forwards `MINI_STORE_BUCKET` + token via a Secret; `ModalVolumeStore` for the volume-backed read path when no bucket.
- `./go auth` now logs into Hugging Face (cached token; no `HF_TOKEN` export needed).
- `docs/acts` + `docs/probe`: a producer/consumer pair, with a report that publishes a figure.
- Docs: `mini` skill `references/storage.md`; deferrals in `todo.md`.

## Deferred (see `todo.md`)
Separate publish bucket / private CAS; versioned publish tier (repo rather than bucket); streaming→promote-to-hash; interactive-`amap` store wiring; and #22's volume + control-plane tag-scoping (now only needed for non-artifact volume bytes and memo-level dedup).

One operational note surfaced in testing: a long-lived detached Modal app can serve a **stale serialized worker** after worker-side code edits (a fresh app name or stopping the app fixes it) — general to the memo worker, recorded in `todo.md`.

Refs #13, #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)