### PR TITLE
Store bucket config in pyproject.toml with env override

### DIFF
--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -71,25 +71,32 @@ See `docs/acts` (producer) and `docs/probe` (consumer) for a runnable pair.
 
 ## Choosing the backend (local vs. Hugging Face bucket)
 
-One env var picks the durable backend; nothing in experiment or report code
+The backend is configuration, not code — nothing in an experiment or report
 changes:
 
-- **Unset** → `LocalStore`, a `cas/<sha>` tree on disk under `.mini/store`. The
-  boring default; no network. Project-wide sharing works *locally*.
-- **`MINI_STORE_BUCKET=<namespace>/<bucket>`** (plus `HF_TOKEN`) → `HFStore`, the
-  same layout over a Xet-backed Hugging Face bucket. Now the durable store is
-  shared across *machines and backends*: a Modal worker `put`s a blob, and a
-  local report or another experiment `get`s it back — no shared Volume. The local
-  dir demotes to a warm cache (`.mini/store-cache/hf`).
+- **No bucket configured** → `LocalStore`, a `cas/<ab>/<sha>` tree under
+  `.mini/store`. The default; no network. Project-wide sharing works *locally*.
+- **A bucket configured** → `HFStore`, the same layout over a Xet-backed Hugging
+  Face bucket, shared across *machines and backends*: a Modal worker `put`s a
+  blob; a local report or another experiment `get`s it back, no shared Volume.
+  The local dir demotes to a warm cache (`.mini/store-cache/hf`).
 
-`mini run --app modal` forwards the bucket + token into the worker (via a Modal
-Secret), so the remote step writes to the same bucket. Bucket I/O needs
-`*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the network egress allow-list.
+Set the bucket once in `pyproject.toml` so it travels with the repo (set in one
+place, not three):
 
-Auth: `./go auth` logs you into Hugging Face alongside Modal/WandB (a fine-grained
-token with read+write to the bucket). The token is cached by `hf`; the store and
-the Modal Secret both pick it up from there, so you don't need `HF_TOKEN` exported
-— only `MINI_STORE_BUCKET` set to select the bucket.
+```toml
+[tool.mini]
+store-bucket = "your-namespace/your-bucket"
+```
+
+`MINI_STORE_BUCKET` overrides it for a one-off shell or CI. `mini run --app modal`
+forwards the resolved bucket + token into the worker via a Modal Secret. Bucket
+I/O needs `*.xethub.hf.co` (and `*.cdn.hf.co` for serving) on the egress
+allow-list.
+
+Auth: `./go auth` logs into Hugging Face (a fine-grained token with read+write to
+the bucket). `hf` caches it; the store and the Modal Secret read it from there, so
+`HF_TOKEN` need not be exported — the bucket name isn't a secret, only the token.
 
 ## Publishing to the web
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ pages = [
     "markdown>=3",
 ]
 
+[tool.mini]
+# The project's Hugging Face bucket for the content-addressed artifact store
+# (see .agents/skills/mi-ni/references/storage.md). Committed here so it's set
+# once and shared by every checkout, Modal worker, and CI run — the bucket name
+# is not a secret (the token lives in the env / `hf` cache). Override per-shell
+# with MINI_STORE_BUCKET. Unset → the store stays local (no network).
+# store-bucket = "your-namespace/your-bucket"
+
 [tool.uv]
 # Dependency cooldown to mitigate risk of supply chain attacks.
 # https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -33,7 +33,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from mini.store import Artifact, LocalStore, Store, _hash_file, _tree_sha
+from mini.store import Artifact, LocalStore, Store, _cas_key, _hash_file, _tree_sha
 
 __all__ = ['HFStore']
 
@@ -68,7 +68,7 @@ class HFStore(Store):
             return False
 
     def has(self, sha256: str) -> bool:
-        return self._cache.has(sha256) or self._remote_has(f'cas/{sha256}')
+        return self._cache.has(sha256) or self._remote_has(_cas_key(sha256))
 
     def _cache_blob(self, sha256: str, src: Path) -> None:
         if not self._cache.has(sha256):
@@ -79,14 +79,14 @@ class HFStore(Store):
     def _write_blob(self, sha256: str, src: Path) -> None:
         # Reached only on a cache+remote miss (the base ``put`` checks ``has``
         # first); Xet still dedups the chunks if the bytes happen to exist.
-        self.api.batch_bucket_files(self.bucket, add=[(str(src), f'cas/{sha256}')])
+        self.api.batch_bucket_files(self.bucket, add=[(str(src), _cas_key(sha256))])
         self._cache_blob(sha256, src)
 
     def _read_blob(self, sha256: str, dest: Path) -> None:
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
-            self._cache.cas.mkdir(parents=True, exist_ok=True)
-            self.api.download_bucket_files(self.bucket, files=[(f'cas/{sha256}', str(blob))])
+            blob.parent.mkdir(parents=True, exist_ok=True)
+            self.api.download_bucket_files(self.bucket, files=[(_cas_key(sha256), str(blob))])
         shutil.copyfile(blob, dest)
 
     def _put_tree(self, src: Path, *, name: str) -> Artifact:
@@ -101,7 +101,7 @@ class HFStore(Store):
             sha, size = _hash_file(p)
             children.append(Artifact(sha256=sha, size=size, name=p.relative_to(src).as_posix()))
             if not self._cache.has(sha):
-                add.append((str(p), f'cas/{sha}'))
+                add.append((str(p), _cas_key(sha)))
             self._cache_blob(sha, p)
         if add:
             self.api.batch_bucket_files(self.bucket, add=add)  # one round trip for the set
@@ -126,7 +126,7 @@ class HFStore(Store):
     def publish(self, art: Artifact, path: str) -> str:
         if art.kind == 'tree':
             raise ValueError('publish a single file (resolve a tree first, or publish its children)')
-        info = list(self.api.get_bucket_paths_info(self.bucket, [f'cas/{art.sha256}']))
+        info = list(self.api.get_bucket_paths_info(self.bucket, [_cas_key(art.sha256)]))
         if not info:
             raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
         # Server-side copy *by xet hash*: a metadata op, no bytes moved. The

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -62,9 +62,14 @@ class HFStore(Store):
     # -- existence / cache ----------------------------------------------------
 
     def _remote_has(self, path: str) -> bool:
+        # A missing path is "absent" (return False); an auth/permission/network
+        # failure must *not* masquerade as absent — that would silently trigger a
+        # re-upload (and hide a misconfigured token), so let those propagate.
+        from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+
         try:
             return any(True for _ in self.api.get_bucket_paths_info(self.bucket, [path]))
-        except Exception:  # missing path / transient read — treat as absent
+        except EntryNotFoundError, RepositoryNotFoundError:
             return False
 
     def has(self, sha256: str) -> bool:
@@ -117,9 +122,10 @@ class HFStore(Store):
         path = f'refs/{name}.json'
         if not self._remote_has(path):
             return None
-        tmp = Path(tempfile.mkdtemp()) / 'ref.json'
-        self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
-        return tmp.read_text()
+        with tempfile.TemporaryDirectory() as d:  # cleaned up, unlike a bare mkdtemp
+            tmp = Path(d) / 'ref.json'
+            self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
+            return tmp.read_text()
 
     # -- publish --------------------------------------------------------------
 

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import secrets
 import time
 from contextlib import asynccontextmanager, nullcontext
@@ -35,7 +34,7 @@ from mini.progress import ProgressMessage, progress_context
 from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
 from mini.runs import data_root
-from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, _cas_key, default_store, store_bucket
+from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, _cas_key, _hf_token, default_store, store_bucket
 from mini.volume import data_dir_context
 
 log = logging.getLogger(__name__)
@@ -223,9 +222,7 @@ def _hf_store_secret() -> modal.Secret | None:
     bucket = store_bucket()
     if not bucket:
         return None
-    from huggingface_hub import get_token
-
-    token = os.environ.get('HF_TOKEN') or get_token()  # env, or the cached `hf auth login`
+    token = _hf_token()  # env, or the cached `hf auth login`
     if not token:
         return None
     return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
@@ -349,12 +346,14 @@ class ModalApparatus(Apparatus[ModalVolume]):
     def store(self) -> Store:
         """The artifact store for reads on the client (reports, ``ctx`` resolves).
 
-        With ``MINI_STORE_BUCKET`` set, that's the shared HF bucket the worker
-        wrote to — so artifacts read back the same everywhere, no Volume needed.
-        Otherwise it's a read-through over this experiment's Modal Volume,
-        warm-caching into a local checkout (``.mini/store-cache/<app>``).
+        With a bucket configured *and* a token available, that's the shared HF
+        bucket the worker wrote to — so artifacts read back the same everywhere, no
+        Volume needed. Otherwise it's a read-through over this experiment's Modal
+        Volume, warm-caching into a local checkout (``.mini/store-cache/<app>``).
+        The token gate mirrors ``_hf_store_secret``: with no token the worker writes
+        to the Volume, so the client must read from there too (not an empty bucket).
         """
-        if store_bucket():
+        if store_bucket() and _hf_token():
             return default_store(data_root() / 'store')
         assert self.app.name  # guaranteed by __init__ (a named App is required)
         cache = LocalStore(data_root() / 'store-cache' / self.app.name)

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -35,7 +35,7 @@ from mini.progress import ProgressMessage, progress_context
 from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
 from mini.runs import data_root
-from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, default_store
+from mini.store import STORE_BUCKET_ENV, Artifact, LocalStore, Store, _cas_key, default_store, store_bucket
 from mini.volume import data_dir_context
 
 log = logging.getLogger(__name__)
@@ -156,7 +156,7 @@ class ModalMemoStore(MemoStore):
 class ModalVolumeStore(Store):
     """Client-side artifact :class:`~mini.store.Store` that reads blobs off the Volume.
 
-    The remote worker writes the CAS *under* the mounted Volume (``store/cas/<sha>``)
+    The remote worker writes the CAS *under* the mounted Volume (``store/cas/ab/<sha>``)
     and commits it; this reads those blobs back from the client (a report, or
     ``ctx.run`` resolving a handle into the next step) with no running function,
     caching each blob into a local :class:`~mini.store.LocalStore` so a re-read is
@@ -176,7 +176,7 @@ class ModalVolumeStore(Store):
         if self._cache.has(sha256):
             return True
         try:
-            self._read_volume_bytes(f'store/cas/{sha256}')
+            self._read_volume_bytes(f'store/{_cas_key(sha256)}')
             return True
         except FileNotFoundError, modal.exception.NotFoundError:
             return False
@@ -186,8 +186,8 @@ class ModalVolumeStore(Store):
 
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
-            data = self._read_volume_bytes(f'store/cas/{sha256}')
-            self._cache.cas.mkdir(parents=True, exist_ok=True)
+            data = self._read_volume_bytes(f'store/{_cas_key(sha256)}')
+            blob.parent.mkdir(parents=True, exist_ok=True)
             tmp = blob.with_name(f'{sha256}.tmp')
             tmp.write_bytes(data)
             tmp.replace(blob)
@@ -215,11 +215,12 @@ class ModalVolumeStore(Store):
 def _hf_store_secret() -> modal.Secret | None:
     """A Modal Secret carrying the HF bucket config into the worker, if configured.
 
-    When ``MINI_STORE_BUCKET`` (and ``HF_TOKEN``) are set locally, forward them into
-    the remote container's env so the worker's ``default_store`` resolves to the
-    shared bucket. Absent, the worker falls back to the Volume-backed store.
+    When a bucket is configured (``[tool.mini] store-bucket`` or the env override)
+    and a token is available, forward both into the remote container's env so the
+    worker's ``default_store`` resolves to the shared bucket. Absent either, the
+    worker falls back to the Volume-backed store.
     """
-    bucket = os.environ.get(STORE_BUCKET_ENV)
+    bucket = store_bucket()
     if not bucket:
         return None
     from huggingface_hub import get_token
@@ -353,7 +354,7 @@ class ModalApparatus(Apparatus[ModalVolume]):
         Otherwise it's a read-through over this experiment's Modal Volume,
         warm-caching into a local checkout (``.mini/store-cache/<app>``).
         """
-        if os.environ.get(STORE_BUCKET_ENV):
+        if store_bucket():
             return default_store(data_root() / 'store')
         assert self.app.name  # guaranteed by __init__ (a named App is required)
         cache = LocalStore(data_root() / 'store-cache' / self.app.name)

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import contextvars
 import hashlib
 import json
+import logging
 import mimetypes
 import os
 import shutil
@@ -77,6 +78,8 @@ __all__ = [
 STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
 
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -332,21 +335,44 @@ def store_bucket() -> str | None:
     return os.environ.get(STORE_BUCKET_ENV) or _project_config().get('store-bucket')
 
 
+def _hf_token() -> str | None:
+    """The Hugging Face token from the env or the ``hf auth login`` cache, or ``None``."""
+    if tok := os.environ.get('HF_TOKEN'):
+        return tok
+    try:
+        from huggingface_hub import get_token
+
+        return get_token()
+    except Exception:
+        return None
+
+
 def default_store(root: Path | str) -> Store:
     """The project store for a given local *root* — bucket-backed if configured.
 
-    When a bucket is configured (:func:`store_bucket`) the durable store is the
-    shared Hugging Face bucket (with *root* demoted to a local warm cache);
-    otherwise it's a :class:`LocalStore` rooted at *root*. One switch flips every
-    put/get/publish — in a step, a report, or a worker — from on-disk to
-    shared-and-web-reachable.
+    When a bucket is configured (:func:`store_bucket`) *and* a Hugging Face token is
+    available, the durable store is the shared bucket (with *root* demoted to a
+    local warm cache); otherwise it's a :class:`LocalStore` rooted at *root*. One
+    switch flips every put/get/publish — in a step, a report, or a worker — from
+    on-disk to shared-and-web-reachable.
+
+    A configured bucket with *no* token (someone trying the repo in Codespaces, or
+    a fresh checkout before ``./go auth``) falls back to the local store with a
+    warning rather than failing mid-run — the bucket name travels with the repo,
+    but using it needs auth the trier doesn't have yet.
     """
     root = Path(root)
     bucket = store_bucket()
-    if bucket:
+    if bucket and (token := _hf_token()):
         from mini.hf_store import HFStore
 
-        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'))
+        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'), token=token)
+    if bucket:
+        log.warning(
+            'store-bucket %r is configured but no Hugging Face token was found — using the local '
+            'store instead. Run `./go auth` (or set HF_TOKEN) to read/write the shared bucket.',
+            bucket,
+        )
     return LocalStore(root)
 
 

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -47,6 +47,7 @@ import json
 import mimetypes
 import os
 import shutil
+import tomllib
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -67,11 +68,12 @@ __all__ = [
     'get_ref',
     'store_root_for',
     'default_store',
+    'store_bucket',
     'STORE_BUCKET_ENV',
 ]
 
-# Env var naming the project's Hugging Face bucket. Set it (alongside HF_TOKEN)
-# to make the durable/publish tier the shared bucket; unset, the store is local.
+# Env var naming the project's Hugging Face bucket — an *override* for the
+# `[tool.mini] store-bucket` committed in pyproject.toml (see `store_bucket`).
 STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
 
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
@@ -131,6 +133,17 @@ class Artifact:
             kind=d.get('kind', 'file'),
             children=tuple(cls.from_dict(c) for c in d.get('children', ())),
         )
+
+
+def _cas_key(sha256: str) -> str:
+    """A blob's path within the store, sharded by a two-char prefix (``cas/ab/abcd…``).
+
+    Git and Git-LFS both fan blobs out under a short prefix dir so the CAS never
+    becomes one flat directory of thousands of entries — slow to list on disk and
+    unwieldy in a bucket's web UI. One level of two hex chars (256 buckets) is
+    plenty at our scale; the full sha still names the file, so it stays the id.
+    """
+    return f'cas/{sha256[:2]}/{sha256}'
 
 
 def _hash_bytes(data: bytes) -> str:
@@ -289,16 +302,47 @@ def store_root_for(data_dir: Path | str) -> Path:
     return Path(data_dir).parent / 'store'
 
 
+def _project_config() -> dict:
+    """``[tool.mini]`` from the nearest ``pyproject.toml`` walking up from cwd, or ``{}``.
+
+    Read lazily off the live cwd (like :func:`~mini.runs.data_root`) so a ``chdir``
+    — or a test in a tmp dir — resolves the right project, and nothing parses TOML
+    at import time.
+    """
+    cwd = Path.cwd().resolve()
+    for d in (cwd, *cwd.parents):
+        pp = d / 'pyproject.toml'
+        if pp.exists():
+            try:
+                return tomllib.loads(pp.read_text()).get('tool', {}).get('mini', {})
+            except OSError, tomllib.TOMLDecodeError:
+                return {}
+    return {}
+
+
+def store_bucket() -> str | None:
+    """The configured Hugging Face bucket (``namespace/name``), or ``None`` for local.
+
+    Resolution order: the ``MINI_STORE_BUCKET`` env var first (so CI or a one-off
+    shell can override), else ``[tool.mini] store-bucket`` in ``pyproject.toml`` —
+    so the project's default *travels with the repo*, set once and shared by every
+    checkout, Modal worker, and CI run rather than re-set in three places. The
+    bucket name isn't a secret; the token still lives in the env / ``hf`` cache.
+    """
+    return os.environ.get(STORE_BUCKET_ENV) or _project_config().get('store-bucket')
+
+
 def default_store(root: Path | str) -> Store:
     """The project store for a given local *root* — bucket-backed if configured.
 
-    When ``MINI_STORE_BUCKET`` is set the durable store is the shared Hugging Face
-    bucket (with *root* demoted to a local warm cache); otherwise it's a
-    :class:`LocalStore` rooted at *root*. One switch flips every put/get/publish —
-    in a step, a report, or a worker — from on-disk to shared-and-web-reachable.
+    When a bucket is configured (:func:`store_bucket`) the durable store is the
+    shared Hugging Face bucket (with *root* demoted to a local warm cache);
+    otherwise it's a :class:`LocalStore` rooted at *root*. One switch flips every
+    put/get/publish — in a step, a report, or a worker — from on-disk to
+    shared-and-web-reachable.
     """
     root = Path(root)
-    bucket = os.environ.get(STORE_BUCKET_ENV)
+    bucket = store_bucket()
     if bucket:
         from mini.hf_store import HFStore
 
@@ -307,7 +351,7 @@ def default_store(root: Path | str) -> Store:
 
 
 class LocalStore(Store):
-    """A ``cas/<sha256>`` blob tree on local disk, with file-backed refs and views.
+    """A ``cas/<ab>/<sha256>`` blob tree on local disk, with file-backed refs and views.
 
     The boring default: no network, immutability enforced by write-once-by-hash.
     ``publish`` copies a blob to ``published/<path>`` and returns a ``file://`` URL
@@ -317,19 +361,18 @@ class LocalStore(Store):
 
     def __init__(self, root: Path | str):
         self.root = Path(root)
-        self.cas = self.root / 'cas'
         self.refs = self.root / 'refs'
         self.published = self.root / 'published'
 
     def _blob_path(self, sha256: str) -> Path:
-        return self.cas / sha256
+        return self.root / _cas_key(sha256)
 
     def has(self, sha256: str) -> bool:
         return self._blob_path(sha256).exists()
 
     def _write_blob(self, sha256: str, src: Path) -> None:
-        self.cas.mkdir(parents=True, exist_ok=True)
         dest = self._blob_path(sha256)
+        dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():  # immutable: another writer won the race; bytes are identical by hash
             return
         tmp = dest.with_name(f'{sha256}.tmp.{src.stat().st_ino}')

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -20,6 +20,7 @@ from mini.store import (
     publish,
     put,
     set_ref,
+    store_bucket,
     store_context,
     store_root_for,
 )
@@ -68,8 +69,14 @@ def test_put_is_content_addressed_and_idempotent(store: LocalStore):
     a = store.put(b'same', name='one.bin')
     b = store.put(b'same', name='two.bin')  # different name, same bytes
     assert a.sha256 == b.sha256
-    blobs = list((store.root / 'cas').iterdir())
-    assert len(blobs) == 1  # stored once
+    blobs = [p for p in (store.root / 'cas').rglob('*') if p.is_file()]
+    assert len(blobs) == 1  # stored once (under its two-char shard dir)
+
+
+def test_blobs_are_sharded_by_prefix(store: LocalStore):
+    """A blob lands under a two-char shard dir (``cas/ab/abcd…``), not a flat tree."""
+    art = store.put(b'hello world', name='greeting.txt')
+    assert (store.root / 'cas' / art.sha256[:2] / art.sha256).is_file()
 
 
 def test_put_file_hashes_streaming(store: LocalStore, tmp_path: Path):
@@ -154,6 +161,27 @@ def test_publish_rejects_trees(store: LocalStore, tmp_path: Path):
 def test_store_root_is_project_scoped_beside_the_volume():
     # A volume at <root>/<experiment> shares <root>/store with every experiment.
     assert store_root_for(Path('/proj/.mini/acts')) == Path('/proj/.mini/store')
+
+
+def test_store_bucket_reads_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\nstore-bucket = "ns/bkt"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+    assert store_bucket() == 'ns/bkt'
+
+
+def test_store_bucket_env_overrides_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\nstore-bucket = "ns/bkt"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'other/override')
+    assert store_bucket() == 'other/override'
+
+
+def test_store_bucket_unset_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[project]\nname = "x"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+    assert store_bucket() is None
 
 
 def test_get_store_raises_outside_context():

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -14,6 +14,7 @@ import pytest
 from mini.store import (
     Artifact,
     LocalStore,
+    default_store,
     get,
     get_ref,
     get_store,
@@ -182,6 +183,21 @@ def test_store_bucket_unset_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
     assert store_bucket() is None
+
+
+def test_default_store_falls_back_to_local_without_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A configured bucket but no HF token (trying the repo, pre-`./go auth`) → local, not a crash."""
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setattr('mini.store._hf_token', lambda: None)
+    assert isinstance(default_store(tmp_path / 'store'), LocalStore)
+
+
+def test_default_store_uses_bucket_with_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from mini.hf_store import HFStore
+
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setattr('mini.store._hf_token', lambda: 'tok')
+    assert isinstance(default_store(tmp_path / 'store'), HFStore)
 
 
 def test_get_store_raises_outside_context():

--- a/todo.md
+++ b/todo.md
@@ -25,6 +25,22 @@ Deferred, in rough priority order:
   copy-by-xet-hash each chunk to `cas/<sha>` and assemble the tree. The seam is
   there (`HFStore` already copies by xet hash for `publish`); not built yet.
 
+- **Chunked datatrees (Zarr) — the tree manifest is the wrong shape at scale.**
+  The per-file-blob + manifest design is fine for a handful of `.npy` shards but
+  degrades on a Zarr datatree of thousands of tiny chunks: N `put` round trips on
+  write, and a `get` reassembles the *whole* tree before a consumer touches one
+  slice (kills random-read latency). Don't reach for a mutable `objects-by-name/`
+  mirror to enable opening Zarr over `resolve/` URLs — a mutable, non-atomic key
+  tree reintroduces the half-written-read and dual-namespace-GC hazards the CAS
+  exists to avoid (only acceptable as *immutable, version-suffixed* trees).
+  Preferred direction: Zarr v3 **sharding** (collapses N chunks to a few shard
+  files, random reads become HTTP range requests) + store the sharded tree as a
+  *single packed* `cas/<sha>` object opened over `resolve/` with range reads —
+  atomic publish, trivial GC, low-latency slicing, no second namespace. Unverified
+  assumption to check first: does HF's Xet `resolve/` honor HTTP `Range` with low
+  per-request latency? A one-off ranged `curl` against a real bucket object
+  decides whether any of this is viable.
+
 - **Modal gotcha — stale serialized worker.** A long-lived detached app can serve
   a previously-serialized `_modal_task_entry` (so store-wiring edits don't take
   until its containers drain). Surfaced while testing: a fresh app name or

--- a/todo.md
+++ b/todo.md
@@ -10,14 +10,18 @@ cross-experiment artifact sharing works on Modal **without** a shared Volume.
 Deferred, in rough priority order:
 
 - **Separate publish bucket / private durable store.** We use one public bucket
-  for both durable CAS and published views (HF free tier = one bucket). `publish`
-  is a separate verb, so pointing it at a second (public) bucket while the CAS
-  goes private is a small change when wanted.
+  for both durable CAS and published views. HF buckets have **no per-prefix ACL** —
+  public/private is bucket-level only — so a private CAS + public `published/`
+  genuinely needs *two* buckets, not a prefix split. `publish` is already a
+  separate verb, so pointing it at a second bucket is a small change. (HF docs show
+  no documented cap on bucket *count* per account; free storage is account-level:
+  ~100 GB private, public best-effort.)
 
 - **Versioned publish tier.** A bucket gives immutable *content* (via `cas/<sha>`
-  views) but not immutable *names with history*. If we ever need to cite a frozen
-  figure, the cheap option is an append-only ref log (`refs/<name>/<run-id>`) over
-  the same bucket before reaching for a dataset repo. (Open question from
+  views) but not immutable *names with history*, and buckets are overwrite-in-place
+  with **no server-side append-only / object-lock**. So an `refs/<name>/<run-id>`
+  log is only *convention*, not enforced — a frozen-citation guarantee would need a
+  dataset repo (real git history) rather than a bucket. (Open question from
   `research/artifact-store.md`: bucket vs. dataset repo.)
 
 - **Streaming → promote-to-hash.** For chunk-by-chunk writers (Zarr, activation
@@ -25,21 +29,22 @@ Deferred, in rough priority order:
   copy-by-xet-hash each chunk to `cas/<sha>` and assemble the tree. The seam is
   there (`HFStore` already copies by xet hash for `publish`); not built yet.
 
-- **Chunked datatrees (Zarr) — the tree manifest is the wrong shape at scale.**
-  The per-file-blob + manifest design is fine for a handful of `.npy` shards but
-  degrades on a Zarr datatree of thousands of tiny chunks: N `put` round trips on
+- **Chunked datatrees (Zarr etc.) — out of scope for the CAS; use `hf://` directly.**
+  The per-file-blob + manifest design is fine for a handful of `.npy` shards but is
+  the wrong shape for a tree of thousands of tiny chunks: N `put` round trips on
   write, and a `get` reassembles the *whole* tree before a consumer touches one
-  slice (kills random-read latency). Don't reach for a mutable `objects-by-name/`
-  mirror to enable opening Zarr over `resolve/` URLs — a mutable, non-atomic key
-  tree reintroduces the half-written-read and dual-namespace-GC hazards the CAS
-  exists to avoid (only acceptable as *immutable, version-suffixed* trees).
-  Preferred direction: Zarr v3 **sharding** (collapses N chunks to a few shard
-  files, random reads become HTTP range requests) + store the sharded tree as a
-  *single packed* `cas/<sha>` object opened over `resolve/` with range reads —
-  atomic publish, trivial GC, low-latency slicing, no second namespace. Unverified
-  assumption to check first: does HF's Xet `resolve/` honor HTTP `Range` with low
-  per-request latency? A one-off ranged `curl` against a real bucket object
-  decides whether any of this is viable.
+  slice (kills random-read latency). The conclusion after review is **don't grow
+  the store to chase this** — not a by-name mirror (a mutable, non-atomic key tree
+  reintroduces the half-written-read and dual-namespace-GC hazards the CAS exists
+  to avoid), and not Zarr-specific packing/sharding baked into `put` (too tied to
+  one format; the store stays bytes/files/trees-agnostic). For the rare case that
+  actually needs random-access reads over the network, the right answer is to skip
+  the CAS for *that* artifact and let the array library do remote IO straight
+  against the bucket — Zarr v3 + `s3fs`/`hf://` fsspec over the bucket's HTTP
+  endpoint, with the producer choosing sharding if it wants fewer/larger objects.
+  Document that escape hatch in storage.md if/when someone hits it; keep the CAS
+  for immutable artifact handoff. (Worth a one-off check that the bucket endpoint
+  honours HTTP `Range` before recommending the fsspec path.)
 
 - **Modal gotcha — stale serialized worker.** A long-lived detached app can serve
   a previously-serialized `_modal_task_entry` (so store-wiring edits don't take


### PR DESCRIPTION
Move the Hugging Face bucket configuration from environment-only (`MINI_STORE_BUCKET`) to a committed setting in `pyproject.toml` (`[tool.mini] store-bucket`), with the env var as an override. This lets the bucket name travel with the repo — set once, shared by every checkout, Modal worker, and CI run — rather than being re-configured in multiple places.

Key changes:

- **New `store_bucket()` function** reads the bucket from `[tool.mini] store-bucket` in `pyproject.toml`, falling back to the `MINI_STORE_BUCKET` env var for one-off overrides
- **New `_hf_token()` function** centralizes token resolution (env or `hf` cache), used by both `default_store` and Modal setup
- **Graceful fallback** when a bucket is configured but no token is available: logs a warning and uses the local store instead of crashing mid-run
- **Blob sharding** refactored into `_cas_key()` helper: blobs now live under `cas/<ab>/<sha256>` (two-char prefix) instead of flat `cas/<sha256>`, matching Git/Git-LFS conventions to avoid unwieldy flat directories
- **Updated documentation** in `storage.md` and docstrings to reflect the new configuration model

The bucket name isn't a secret; the token still lives in the env or `hf` cache. This change makes the store configuration more discoverable and reduces friction for new contributors and CI setups.

Added unit tests for:
- `store_bucket()` reading from `pyproject.toml`
- `MINI_STORE_BUCKET` env override
- Blob sharding under two-char prefix dirs
- Graceful fallback to local store when bucket is configured but no token exists
- HFStore selection when both bucket and token are available

https://claude.ai/code/session_01U3aEXVbXuwRtRZprhVJuEt