### PR TITLE
Move reports/reporting/publications off Git LFS onto HFStore

### DIFF
--- a/.agents/skills/mi-ni/SKILL.md
+++ b/.agents/skills/mi-ni/SKILL.md
@@ -24,7 +24,7 @@ src/mini/
 
 - **Author** a memoized experiment — the `main(ctx)` DAG, repo layout, and cache-friendly design: [authoring.md](./references/authoring.md). Key internals in [memoization.md](./references/memoization.md).
 - **Run & monitor** one from the CLI — the wake-loop, recovery, hotfix safety, and how to delegate/schedule a long run: [running.md](./references/running.md).
-- **Store & share large outputs** — return `Artifact` handles instead of volume paths, share artifacts across experiments by name, and publish figures to a URL: [storage.md](./references/storage.md).
+- **Store & share large outputs** — return `Artifact` handles instead of volume paths, share artifacts across experiments by name, and publish artifacts to a URL: [storage.md](./references/storage.md). Externalizing a report's figures/assets for the web: [vis.md](./references/vis.md).
 
 To keep cost down, delegate launching and babysitting to the `experiment-monitor` subagent (it escalates to `experiment-doctor`); see running.md.
 
@@ -38,4 +38,4 @@ To keep cost down, delegate launching and babysitting to the `experiment-monitor
 
 ## Visualization helpers
 
-`mini.vis` provides utilities for figure theming, such as base styles and light/dark support. See [vis.md](./references/vis.md).
+`mini.vis` provides utilities for figure theming (base styles, light/dark support) and for externalizing a report's figures and data assets so the exported HTML stays light and publishes off Git LFS. See [vis.md](./references/vis.md).

--- a/.agents/skills/mi-ni/references/authoring.md
+++ b/.agents/skills/mi-ni/references/authoring.md
@@ -69,7 +69,8 @@ def extract(cfg) -> dict:
 
 The store is **project-scoped**, so one experiment can hand an artifact to
 another by name (`set_ref`/`get_ref`) with no recompute. Full semantics — trees,
-publishing figures to a URL, the Modal caveat — in [storage.md](./storage.md).
+publishing artifacts to a URL, the Modal caveat — in [storage.md](./storage.md).
+Externalizing a *report's* figures and data for publishing is in [vis.md](./vis.md).
 
 ## Routing steps to compute
 

--- a/.agents/skills/mi-ni/references/authoring.md
+++ b/.agents/skills/mi-ni/references/authoring.md
@@ -70,7 +70,9 @@ def extract(cfg) -> dict:
 The store is **project-scoped**, so one experiment can hand an artifact to
 another by name (`set_ref`/`get_ref`) with no recompute. Full semantics — trees,
 publishing artifacts to a URL, the Modal caveat — in [storage.md](./storage.md).
-Externalizing a *report's* figures and data for publishing is in [vis.md](./vis.md).
+Externalizing a *report's* figures and data for publishing is in
+[storage.md](./storage.md#report-bundles); the `themed` hook for it is in
+[vis.md](./vis.md).
 
 ## Routing steps to compute
 

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -100,24 +100,29 @@ the bucket). `hf` caches it; the store and the Modal Secret read it from there, 
 
 ## Publishing to the web
 
-`publish(art, path)` exposes a blob at a named, extensioned path and returns a
-URL — for reports and figures that need to render in a browser (the extension
-drives the served `Content-Type`). It's deliberately separate from `put` and the
-only outward-facing verb, so persisting a result never publishes it as a side
-effect. Do it in the **report**, where assets go out:
+`publish(art, path)` is the store's outward-facing verb: it exposes a blob at a
+named, extensioned path and returns a URL (the extension drives the served
+`Content-Type`). It's deliberately separate from `put`, so persisting a result
+never publishes it as a side effect.
 
 ```python
-url = store.publish(fig_png, f'reports/{exp}/loss.png')
+url = store.publish(art, f'reports/{exp}/loss.png')
 ```
 
 `LocalStore` returns a `file://` URL (the published view lives under the project
 store). With `MINI_STORE_BUCKET` set, `HFStore` returns a real `https://` resolve
-URL for the same handle — the publish is a server-side copy *by xet hash* (no
-bytes moved) to an extensioned path, and the bucket serves it with a
-`Content-Type` from that extension. The bucket is **public**, so `publish` is the
-deliberate outward step; the durable CAS only goes public because we share one
-bucket for now (a separate private store + public publish bucket is a later
-split — see `todo.md`).
+URL for the same handle — a server-side copy *by xet hash* (no bytes moved) to an
+extensioned path, served with a `Content-Type` from that extension. The bucket is
+**public**, so `publish` is the deliberate outward step; the durable CAS only goes
+public because we share one bucket for now (a private store + public publish bucket
+is a later split — see `todo.md`).
+
+**Reports don't call `publish` directly.** A report externalizes its figures and
+data through `mini.vis` (`use_publisher(report_bundle(__file__))` — see
+[vis.md](./vis.md)), which writes content-addressed files referenced by *relative*
+URLs. `scripts/build_site.py` then `publish`es those to the bucket and inserts one
+`<base href>` so the relative URLs resolve there — one HTML that works both opened
+locally and served from Pages.
 
 ## Checkpoints are different
 

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -117,12 +117,46 @@ extensioned path, served with a `Content-Type` from that extension. The bucket i
 public because we share one bucket for now (a private store + public publish bucket
 is a later split — see `todo.md`).
 
-**Reports don't call `publish` directly.** A report externalizes its figures and
-data through `mini.vis` (`use_publisher(report_bundle(__file__))` — see
-[vis.md](./vis.md)), which writes content-addressed files referenced by *relative*
-URLs. `scripts/build_site.py` then `publish`es those to the bucket and inserts one
-`<base href>` so the relative URLs resolve there — one HTML that works both opened
-locally and served from Pages.
+**Reports don't call `publish` directly** — they go through a report bundle.
+
+## Report bundles
+
+A report is a **bundle**: one Marimo HTML document plus its heavy assets (figures,
+data blobs). `mini.reports` owns both halves — producing the assets and repointing
+them at the bucket on publish.
+
+**Produce.** Set a `Publisher` once in the report's setup cell; every `themed` figure
+then externalizes through it (figure cells are unchanged), and `asset_url` is the
+general verb for any blob a report's JS reads (a large JSON for a data browser, an
+SPA's data files):
+
+```py
+from mini.reports import use_publisher, report_bundle
+
+pub = use_publisher(report_bundle(__file__))   # assets → this report's __marimo__/_assets/
+url = pub.asset_url(points_json, name='points.json')   # -> '_assets/<sha>/points.json'
+```
+
+Each asset is written to `_assets/<sha>/<name>`: the SHA directory is the content
+address (identical bytes are written once and shared across reports), and the readable
+`name` is the leaf — so a browser "Save as" suggests that name (it takes the URL's last
+segment; the bucket sets no `Content-Disposition`). With no publisher, figures inline
+as self-contained `data:` URIs, so a no-frills export still works.
+
+**Publish.** The relative URL is the point: the *same* HTML works two ways. Opened
+locally, `_assets/…` resolves to the co-located files (offline; the figures are real
+PNGs). Published, `scripts/build_site.py` uploads `_assets/` to the bucket and inserts
+one `<base href>` in the `<head>` so the same relative URLs resolve there — no per-URL
+rewriting.
+
+Because `<base>` repoints *every* relative URL, the rule is **the only relative URLs in
+a report are its assets**. Author-written nav/source links would break against the
+bucket, so `build_site` resolves them: a link to another report or `.md` becomes its
+rendered page, a link to a source file becomes its GitHub source, and anything it can't
+place is left alone with a warning. Write natural relative links
+(`[experiment](./experiment.py)`); the absolute targets are derived from the git remote
+(override with `MINI_SITE_URL` / `MINI_SOURCE_URL`). Design notes:
+`research/reports-hfstore-migration.md`.
 
 ## Checkpoints are different
 

--- a/.agents/skills/mi-ni/references/vis.md
+++ b/.agents/skills/mi-ni/references/vis.md
@@ -24,41 +24,27 @@ def plot_factory() -> plt.Figure:
 mo.Html(plot_factory())
 ```
 
-## Externalizing figures and assets (reports)
+## Externalizing figures (reports)
 
 By default a `themed` figure inlines as a `data:` URI — fine to view, heavy for a
-report (two PNGs per figure, light + dark). A `Publisher` instead writes each asset
-out as a content-addressed file and references it by a **relative** URL, keeping the
-report HTML light. Set one up once in the report's setup cell; figure cells don't
+report (two PNGs per figure, light + dark). To keep the report HTML light, set a
+**publisher** once in the setup cell and `themed` writes each figure out to a
+content-addressed file referenced by a relative URL instead. Figure cells don't
 change:
 
 ```py
-from mini.vis import themed, use_publisher, report_bundle
+from mini.vis import themed
+from mini.reports import use_publisher, report_bundle
 
 use_publisher(report_bundle(__file__))   # assets → this report's __marimo__/_assets/
 
-@themed(alt_text='…')
+@themed(alt_text='…', name='loss-curve')  # name → loss-curve-{light,dark}.png
 def _plot(): ...
 mo.Html(_plot())
 ```
 
-`report_bundle(__file__)` points assets at `…/__marimo__/_assets/` beside the
-exported HTML, so the relative `_assets/<sha>.png` URL resolves there. With no
-publisher, figures inline as before (a self-contained export still works). For
-arbitrary blobs a report's JS reads (a large JSON a data browser fetches, an SPA's
-data files), use the publisher directly — `asset_url` writes the bytes and returns
-the same kind of relative URL:
-
-```py
-pub = use_publisher(report_bundle(__file__))
-url = pub.asset_url(points_json, name='points.json')   # -> '_assets/<sha>.json'
-```
-
-**How it reaches the web.** The relative URL is the point: the *same* HTML works two
-ways. Opened locally, `_assets/…` resolves to the co-located files (offline; the
-figures are real PNGs you can open). Published, `scripts/build_site.py` uploads
-`_assets/` to the HF bucket and inserts one `<base href>` in the `<head>` so the same
-relative URLs resolve there — no per-URL rewriting. Because `<base>` repoints *every*
-relative URL, the rule is **the only relative URLs in a report are its assets**; make
-nav/source links absolute (e.g. to GitHub source), and `build_site` warns on stray
-ones. Design notes: `research/reports-hfstore-migration.md`.
+`name` (default: the plot function's name) is the figure's readable basename — it ends
+up in the asset filename and the saved-file name, and on a `data-asset-name` attribute
+for provenance. The publisher, the `asset_url` verb for arbitrary data blobs, and how
+the bundle reaches the web (the `<base>` switch + the relative-links rule) all live in
+[storage.md](./storage.md#report-bundles).

--- a/.agents/skills/mi-ni/references/vis.md
+++ b/.agents/skills/mi-ni/references/vis.md
@@ -23,3 +23,42 @@ def plot_factory() -> plt.Figure:
 
 mo.Html(plot_factory())
 ```
+
+## Externalizing figures and assets (reports)
+
+By default a `themed` figure inlines as a `data:` URI — fine to view, heavy for a
+report (two PNGs per figure, light + dark). A `Publisher` instead writes each asset
+out as a content-addressed file and references it by a **relative** URL, keeping the
+report HTML light. Set one up once in the report's setup cell; figure cells don't
+change:
+
+```py
+from mini.vis import themed, use_publisher, report_bundle
+
+use_publisher(report_bundle(__file__))   # assets → this report's __marimo__/_assets/
+
+@themed(alt_text='…')
+def _plot(): ...
+mo.Html(_plot())
+```
+
+`report_bundle(__file__)` points assets at `…/__marimo__/_assets/` beside the
+exported HTML, so the relative `_assets/<sha>.png` URL resolves there. With no
+publisher, figures inline as before (a self-contained export still works). For
+arbitrary blobs a report's JS reads (a large JSON a data browser fetches, an SPA's
+data files), use the publisher directly — `asset_url` writes the bytes and returns
+the same kind of relative URL:
+
+```py
+pub = use_publisher(report_bundle(__file__))
+url = pub.asset_url(points_json, name='points.json')   # -> '_assets/<sha>.json'
+```
+
+**How it reaches the web.** The relative URL is the point: the *same* HTML works two
+ways. Opened locally, `_assets/…` resolves to the co-located files (offline; the
+figures are real PNGs you can open). Published, `scripts/build_site.py` uploads
+`_assets/` to the HF bucket and inserts one `<base href>` in the `<head>` so the same
+relative URLs resolve there — no per-URL rewriting. Because `<base>` repoints *every*
+relative URL, the rule is **the only relative URLs in a report are its assets**; make
+nav/source links absolute (e.g. to GitHub source), and `build_site` warns on stray
+ones. Design notes: `research/reports-hfstore-migration.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 .install.sh.rc
 _site/
 **/__marimo__/session/
+# Externalized report assets (figures, data blobs). Durable home is the HF bucket;
+# regenerated on export. Kept out of Git (and so out of the __marimo__ LFS filter).
+**/__marimo__/_assets/
 lightning_logs/
 wandb/
 scratch*

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -11,10 +11,15 @@ with app.setup(hide_code=True):
     import numpy as np
 
     from mini import LocalApparatus, RunState
-    from mini.vis import themed, use_publisher
+    from mini.vis import report_bundle, themed, use_publisher
 
     # The report reads results by experiment *name*, the same key the CLI uses.
     NAME = 'probe'
+
+    # Externalize every themed figure to a file beside the exported HTML, referenced
+    # by a relative URL — keeps the report light, and `build_site` repoints those URLs
+    # at the bucket (one <base> tag) when publishing. No publisher → figures inline.
+    use_publisher(report_bundle(__file__))
 
 
 @app.cell(hide_code=True)
@@ -23,19 +28,21 @@ def _():
     # Probe report
 
     This notebook is a **report**, not the experiment. The experiment in
-    [`experiment.py`](./experiment.py) resolves an activation cache that a
-    *different* experiment ([`docs/acts`](../acts/experiment.py)) published to the
-    project-scoped artifact store, summarizes it, and stores the summary as a
-    durable artifact. Run both from the command line:
+    [`experiment.py`](https://github.com/z0u/mi-ni/blob/main/docs/probe/experiment.py)
+    resolves an activation cache that a *different* experiment
+    ([`docs/acts`](https://github.com/z0u/mi-ni/blob/main/docs/acts/experiment.py))
+    published to the project-scoped artifact store, summarizes it, and stores the
+    summary as a durable artifact. Run both from the command line:
 
     ```bash
     bin/mini run docs/acts/experiment.py  --watch
     bin/mini run docs/probe/experiment.py --watch
     ```
 
-    Here we read the durable summary back through its handle, render it, and
-    **publish** the figure to a shareable URL — the report is where assets go out
-    to the web, distinct from the content-addressed store the step writes to.
+    Here we read the durable summary back through its handle and render it. The
+    figure is **externalized** to the artifact store (not inlined), so the published
+    report stays light and the bytes are served from the bucket — source links above
+    are absolute on purpose, so the report's only relative URLs are its assets.
     """)
     return
 
@@ -47,10 +54,6 @@ def _():
     # DAG, so the report can't relaunch work.
     app_ = LocalApparatus(NAME)
     store, artifacts = app_.memo_store(), app_.store()
-    # Route every themed figure in this report out to the artifact store as a web
-    # URL, so the exported HTML stays light (the figure bytes live in the bucket,
-    # not inline). With no web-serving store configured, figures inline as before.
-    use_publisher(artifacts, prefix=f'reports/{NAME}')
     done = [r for r in store.records() if r.get('fn') == 'probe_activations' and r.get('state') == RunState.DONE]
     result = store.result(done[0]['key']) if done else None
     return artifacts, result, store
@@ -91,16 +94,15 @@ def _(artifacts, result):
 def _(means, result):
     mo.stop(result is None)
 
-    # `use_publisher` (set above) routes this figure out to the artifact store: the
-    # rendered <img> points at a web URL instead of carrying the PNG inline, so the
-    # exported report stays light. `name` gives the asset a stable, shareable URL.
+    # `use_publisher` (set in the setup cell) routes this figure out to a file beside
+    # the exported HTML; the rendered <img> points at its relative URL instead of
+    # carrying the PNG inline, so the exported report stays light.
     @themed(
         alt_text=(
             'A heatmap of mean activation per neuron (x-axis) for each layer (y-axis) of the '
             'stand-in activation cache. Values cluster near zero, as expected for a synthesized '
             'standard-normal stand-in, with small layer-to-layer variation.'
         ),
-        name=f'{result["dataset"]}-neuron-means',
     )
     def _plot() -> plt.Figure:
         grid = np.vstack([means[layer] for layer in sorted(means)])

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -11,7 +11,8 @@ with app.setup(hide_code=True):
     import numpy as np
 
     from mini import LocalApparatus, RunState
-    from mini.vis import report_bundle, themed, use_publisher
+    from mini.reports import report_bundle, use_publisher
+    from mini.vis import themed
 
     # The report reads results by experiment *name*, the same key the CLI uses.
     NAME = 'probe'
@@ -98,6 +99,7 @@ def _(means, result):
     # the exported HTML; the rendered <img> points at its relative URL instead of
     # carrying the PNG inline, so the exported report stays light.
     @themed(
+        name='mean-activation',  # externalized assets save as mean-activation-{light,dark}.png
         alt_text=(
             'A heatmap of mean activation per neuron (x-axis) for each layer (y-axis) of the '
             'stand-in activation cache. Values cluster near zero, as expected for a synthesized '

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -11,7 +11,7 @@ with app.setup(hide_code=True):
     import numpy as np
 
     from mini import LocalApparatus, RunState
-    from mini.vis import themed
+    from mini.vis import themed, use_publisher
 
     # The report reads results by experiment *name*, the same key the CLI uses.
     NAME = 'probe'
@@ -47,6 +47,10 @@ def _():
     # DAG, so the report can't relaunch work.
     app_ = LocalApparatus(NAME)
     store, artifacts = app_.memo_store(), app_.store()
+    # Route every themed figure in this report out to the artifact store as a web
+    # URL, so the exported HTML stays light (the figure bytes live in the bucket,
+    # not inline). With no web-serving store configured, figures inline as before.
+    use_publisher(artifacts, prefix=f'reports/{NAME}')
     done = [r for r in store.records() if r.get('fn') == 'probe_activations' and r.get('state') == RunState.DONE]
     result = store.result(done[0]['key']) if done else None
     return artifacts, result, store
@@ -84,15 +88,19 @@ def _(artifacts, result):
 
 
 @app.cell(hide_code=True)
-def _(artifacts, means, result):
+def _(means, result):
     mo.stop(result is None)
 
+    # `use_publisher` (set above) routes this figure out to the artifact store: the
+    # rendered <img> points at a web URL instead of carrying the PNG inline, so the
+    # exported report stays light. `name` gives the asset a stable, shareable URL.
     @themed(
         alt_text=(
             'A heatmap of mean activation per neuron (x-axis) for each layer (y-axis) of the '
             'stand-in activation cache. Values cluster near zero, as expected for a synthesized '
             'standard-normal stand-in, with small layer-to-layer variation.'
-        )
+        ),
+        name=f'{result["dataset"]}-neuron-means',
     )
     def _plot() -> plt.Figure:
         grid = np.vstack([means[layer] for layer in sorted(means)])
@@ -104,24 +112,7 @@ def _(artifacts, means, result):
         # handles the colorbar; calling both clashes the layout engines.
         return fig
 
-    html = _plot()
-
-    # Publish a standalone PNG of the figure to a shareable URL. Locally this is a
-    # file:// URL under the project store; a web-reachable backend (e.g. an HF
-    # bucket) returns an https:// resolve URL for the same handle — see todo.md.
-    from io import BytesIO
-
-    grid = np.vstack([means[layer] for layer in sorted(means)])
-    fig, ax = plt.subplots(figsize=(6, 3))
-    ax.imshow(grid, aspect='auto', cmap='RdBu', vmin=-0.3, vmax=0.3)
-    ax.set_axis_off()
-    buf = BytesIO()
-    fig.savefig(buf, format='png', dpi=150, bbox_inches='tight')
-    plt.close(fig)
-    asset = artifacts.put(buf.getvalue(), name=f'{result["dataset"]}-neuron-means.png')
-    url = artifacts.publish(asset, f'reports/probe/{result["dataset"]}-neuron-means.png')
-
-    mo.md(f'{html}\n\nPublished figure: [`{url}`]({url})')
+    mo.Html(_plot())
     return
 
 

--- a/docs/probe/report.py
+++ b/docs/probe/report.py
@@ -29,9 +29,9 @@ def _():
     # Probe report
 
     This notebook is a **report**, not the experiment. The experiment in
-    [`experiment.py`](https://github.com/z0u/mi-ni/blob/main/docs/probe/experiment.py)
+    [`experiment.py`](./experiment.py)
     resolves an activation cache that a *different* experiment
-    ([`docs/acts`](https://github.com/z0u/mi-ni/blob/main/docs/acts/experiment.py))
+    ([`docs/acts`](../acts/experiment.py))
     published to the project-scoped artifact store, summarizes it, and stores the
     summary as a durable artifact. Run both from the command line:
 
@@ -42,8 +42,10 @@ def _():
 
     Here we read the durable summary back through its handle and render it. The
     figure is **externalized** to the artifact store (not inlined), so the published
-    report stays light and the bytes are served from the bucket — source links above
-    are absolute on purpose, so the report's only relative URLs are its assets.
+    report stays light and the bytes are served from the bucket. The source links
+    above are written *relative*; `build_site` resolves them to their GitHub source
+    (a sibling report would resolve to its rendered page), so the only literal
+    relative URLs left in the published report are its assets.
     """)
     return
 

--- a/research/reports-hfstore-migration.md
+++ b/research/reports-hfstore-migration.md
@@ -51,7 +51,7 @@ place here, and the only missing piece is wiring the *reports* to use it.
 
 A report is a **bundle**: one Marimo HTML document plus its heavy assets (figures,
 data blobs). The assets are externalized when *produced* and referenced by a
-**relative** URL — `_assets/<sha>.png` — written to a `_assets/` dir beside the
+**relative** URL — `_assets/<sha>/<name>.png` — written to a `_assets/` dir beside the
 exported HTML. That one decision (relative, not absolute) is what makes the same
 HTML work in every context, because *where* `_assets/…` resolves depends only on a
 single `<base href>` in the `<head>`:
@@ -98,13 +98,17 @@ images either; confirmed in `_server/export/exporter.py`, `templates.py`,
 
 The **one caveat** of a document-global `<base>`: it also repoints *author-written*
 relative links — a markdown `[experiment.py](./experiment.py)` — at the bucket,
-where they'd 404. The convention is therefore **the only relative URLs in a report
-are store assets; nav/source links are absolute** (e.g. to GitHub source). It's
-enforced cheaply: `build_site` runs `mini.reports.stray_links` over each export and
-warns about any relative URL that isn't an `_assets/…`. Conveniently, the existing
-reports' relative source links (`./experiment.py`, `../acts/…`) are *already* dead
-on Pages — `build_site` never copied `.py` files — so making them absolute fixes a
-latent bug rather than creating one.
+where they'd 404. The convention is therefore **the only relative URLs left in a report
+are store assets**. Rather than make authors hand-write absolute URLs, `build_site`
+*resolves* the author links: `mini.reports.stray_links` finds the non-asset relatives
+and a `LinkResolver` rewrites each to an absolute target — the rendered page for a
+report/`.md` the build emits, the GitHub source for a plain source file — so it
+survives the base (and stays relative in localize mode for offline nav). The absolute
+roots are derived from the git remote (`MINI_SITE_URL` / `MINI_SOURCE_URL` override);
+anything the resolver can't place is left alone with a warning. Conveniently, the
+existing reports' relative source links were *already* dead on Pages — `build_site`
+never copied `.py` files — so resolving them fixes a latent bug rather than creating
+one.
 
 ### Git size is now a non-question
 
@@ -174,13 +178,17 @@ The design consequences:
 
 The mechanism is built and verified end-to-end against the live bucket.
 
-**`mini.vis.Publisher`** (in `nb.py`) writes each asset to `_assets/<sha>.<ext>`
-and returns its relative URL; `themed` externalizes through it when one is set.
-Ergonomics first — one line in the setup cell, no change to figure cells:
+**`mini.reports.Publisher`** writes each asset to `_assets/<sha>/<name>`
+and returns its relative URL; `themed` (in `mini.vis`) externalizes through it when one
+is set. The SHA directory keeps it content-addressed; the readable leaf is what a
+browser "Save as" suggests (the bucket sets no `Content-Disposition`, so the name has
+to live in the URL). Ergonomics first — one line in the setup cell, no change to figure
+cells:
 
 ```python
 # setup cell
-from mini.vis import themed, use_publisher, report_bundle
+from mini.vis import themed
+from mini.reports import use_publisher, report_bundle
 use_publisher(report_bundle(__file__))   # assets land in this report's __marimo__/_assets
 
 # figure cell — unchanged

--- a/research/reports-hfstore-migration.md
+++ b/research/reports-hfstore-migration.md
@@ -1,0 +1,167 @@
+# Moving reports off Git LFS onto HFStore
+
+By Claude Opus 4.8
+
+An initial investigation: what's involved in publishing reports (and their
+figures) through the new `HFStore` instead of Git LFS, so an agent can run an
+experiment and publish results end-to-end. It builds on
+[the artifact-store sketch](./artifact-store.md), which already called this out as
+step 3 ("`publish` for reports and figures; move large assets off LFS").
+
+## Why move
+
+The reports are self-contained Marimo HTML exports, and they live in Git LFS:
+`.gitattributes` tracks `docs/**/__marimo__/**` (and `docs/**/large-assets/**`).
+The `__marimo__` exports today:
+
+| report | size | content |
+| --- | --- | --- |
+| `docs/__marimo__/gpt.html` | 489 KB | figure-heavy |
+| `docs/__marimo__/gpt_sweep.html` | 438 KB | figure-heavy |
+| `docs/__marimo__/themed.html` | 356 KB | a gallery of themed figures |
+| `docs/__marimo__/subline_demo.html` | 67 KB | mostly prose/code |
+| `docs/__marimo__/getting_started.html` | 65 KB | mostly prose/code |
+
+LFS is the thing blocking end-to-end publishing. An agent in Claude Code Cloud
+can't write LFS objects, so it can't commit an updated report — which means it
+can run an experiment but not publish the result. The artifact-store notes list
+the same four LFS problems (not writable from the Cloud, the 1 GB ceiling, not
+shareable mid-flight, source not readable on GitHub); the first is the one that
+stops the loop dead.
+
+The replacement is already built and, as of this investigation, **proven
+end-to-end from this environment**. A `put` → `publish` → HTTPS-fetch round trip
+against the configured bucket (`z0u/mi-ni-store`) returns the bytes verbatim with
+a correct `Content-Type`:
+
+```
+put ok: 1f085cef5ac7 size 38
+published: https://huggingface.co/buckets/z0u/mi-ni-store/resolve/published/smoke/1f085cef5ac7.txt
+fetched bytes: 38  content-type: text/plain  roundtrip match: True
+```
+
+So the egress allow-list (`*.xethub.hf.co`, `*.cdn.hf.co`) and the token are in
+place here, and the only missing piece is wiring the *reports* to use it.
+
+## The shape of the migration
+
+The plan from the sketch holds: **split at size**. Heavy bytes (figures) go to
+the bucket via `publish()` and are referenced by `https://` URL; the lightened
+report HTML — now mostly prose, code, and a little scaffolding — goes into Git,
+where it's diffable and readable on GitHub. Keep GitHub Pages as the front door;
+the served HTML just pulls its images from the bucket's CDN.
+
+Concretely, the moving parts:
+
+1. **Externalize figures** (the substance — see the next section).
+2. **`.gitattributes`**: drop both LFS rules once figures are externalized.
+   Large static assets, if we ever have them, go through `publish()` too, so the
+   `large-assets/**` rule retires alongside `__marimo__/**`.
+3. **`publish-docs.yml`**: drop `lfs: true` from the checkout. The build
+   (`build_site.py`) is unchanged — it copies the HTML, which now carries bucket
+   URLs; the viewer's browser fetches the images directly from the public bucket,
+   so Pages needs no token.
+4. **Re-export the five reports** with figures externalized and commit the
+   lightened HTML. (`themed`/`subline_demo`/`getting_started` are standalone;
+   `gpt`/`gpt_sweep` need their experiment results present to re-run.)
+5. **History**: the old LFS blobs stay in history harmlessly but count against
+   the LFS quota. Purging them is a `git filter-repo` rewrite — heavy, separable,
+   and I'd defer it rather than block the migration on it.
+
+## Will the lightened reports be small enough for Git?
+
+Your intuition is right, with a caveat worth stating precisely. The two
+figure-light reports (`getting_started`, `subline_demo`) sit at ~65 KB *with*
+Marimo's scaffolding, and that scaffolding is near-identical across every export
+(the frontend JS/CSS is referenced from a CDN, not inlined — which is why the
+floor is tens of KB, not megabytes). So a de-figured `gpt.html` should land in
+roughly that ~50–70 KB range too, and because the boilerplate is shared,
+Git's zlib + delta compression packs the set down hard. A handful of ~60 KB
+mostly-boilerplate HTML files is a non-issue for Git.
+
+The caveat: this is an estimate from the two small reports as a proxy floor, not
+a measurement of a de-figured heavy report (I can't re-export the experiment
+reports here without their run results). Worth confirming on the first real
+prototype — but I'd be surprised if it came out badly.
+
+## Externalize at production, not as a post-process
+
+This is your open question, and the Marimo internals settle it. **Externalize
+when the figure is produced, not by post-processing the exported HTML.**
+
+The reason is where the bytes end up. Our own `themed`/`themed_figure_html`
+(`src/mini/vis/nb.py`) renders each figure — *twice*, a light and a dark variant
+— to a base64 PNG and emits `<img src="data:image/png;base64,…">`. That's the
+bulk of a heavy report (two inline PNGs per figure). When Marimo exports, that
+HTML string is the cell's *output*, and it gets buried inside the session
+snapshot: a JSON object, inside a `<script>`/`<marimo-config>` block, with
+Marimo's `json_script` escaping `<`/`>`/`&` to `\uXXXX`. A figure from Marimo's
+own matplotlib formatter is nested even deeper — a data URI inside a
+JSON-string-of-a-mimebundle inside the session JSON.
+
+So a post-processing pass would have to **parse that doubly-nested, escaped JSON
+out of a `<script>` tag and reconstruct it** — a regex over `src="data:…"` won't
+find it. That's fragile against Marimo's version-specific internal layout, and
+there is no Marimo CLI flag that externalizes images for us (only `--include-code`
+and friends; `html-wasm` externalizes the *framework* assets, not notebook
+images). Confirmed by reading the installed `marimo` package
+(`_server/export/exporter.py`, `_server/templates/templates.py`,
+`_output/mpl.py`).
+
+Producing externally sidesteps all of that, because **we already own the code
+that emits the data URI**. The change is local to the figure-rendering boundary:
+instead of emitting `<img src="data:…">`, `put()` the PNG and emit
+`<img src="https://…bucket…/resolve/published/…">`. The report HTML then carries
+URLs (~100 bytes each) instead of two ~60 KB blobs per figure, and the figure
+bytes flow through the same content-addressed `publish()` path everything else
+uses — idempotent, deduped, version-independent. `docs/probe/report.py` already
+does the `put`+`publish` half (lines 121–122); it just *also* inlines the figure
+via `mo.Html`, so today it pays for both. The migration is to emit the URL
+*instead of* the inline image, not in addition.
+
+Mechanically I'd add an opt-in publish path to the vis helper rather than
+overload `themed`: a small wrapper that takes the figure(s), a store, and a
+logical path, publishes each variant, and returns the themed `<img>` markup
+pointing at the two URLs. The report cell already has the store in hand
+(`LocalApparatus(NAME).store()`), and during `./go run` export the ambient store
+resolves to `HFStore` whenever the bucket + token are set — so this works inside
+the existing export command with no new plumbing.
+
+### The local-fallback wrinkle
+
+One thing to get right: `default_store` falls back to `LocalStore` when there's
+no bucket/token (a fresh checkout, someone trying the repo, a `./go build` with
+no auth). `LocalStore.publish` returns a `file://` URL, which won't render once
+the HTML is served from Pages. So the production-time helper needs a policy: when
+the resolved store can't produce a web URL, **fall back to inlining** the data
+URI as today. That keeps offline/no-auth builds working and renderable, and only
+the authenticated path (CI, the Cloud agent) produces lightened, externalized
+reports — which is exactly the path that needs to.
+
+## What I'd build first
+
+1. The vis helper: `publish-or-inline` for `themed` figures, with the fallback
+   above. Smallest change that proves the loop; testable against `LocalStore`
+   (file URLs) and the real bucket.
+2. Convert one figure-heavy report (`gpt` or `gpt_sweep`) and **measure** the
+   de-figured HTML size to confirm the Git-size estimate.
+3. Drop the LFS rules + `lfs: true`, re-export the five reports, commit the
+   lightened HTML.
+4. Defer (separable): purging old LFS blobs from history; the private-CAS /
+   public-publish two-bucket split already tracked in `todo.md` (the bucket is
+   public today, so `publish` is fine, but the durable CAS is public too).
+
+## Open questions
+
+- **Accumulation / GC.** Every re-export publishes new content-addressed figure
+  blobs; old ones linger. This is the same CAS-only-grows problem `todo.md`
+  already flags for the store at large — reports just add a steady trickle. Not a
+  blocker, but reports make the refcount-and-sweep need concrete sooner.
+- **Stable vs. content-addressed published paths.** Publishing under a
+  content-hash path means a report's image URLs churn on every re-render (fine,
+  the HTML is regenerated too). Publishing under a stable `reports/<exp>/<fig>.png`
+  path keeps URLs constant but is last-writer-wins. The probe report uses the
+  stable form; I'd keep that for reports (the URL is meant to be shareable) and
+  rely on the CAS underneath for immutability of *content*.
+- **Measuring the real de-figured size**, per above — the one number this
+  investigation estimates rather than measures.

--- a/research/reports-hfstore-migration.md
+++ b/research/reports-hfstore-migration.md
@@ -2,11 +2,15 @@
 
 By Claude Opus 4.8
 
-An initial investigation: what's involved in publishing reports (and their
-figures) through the new `HFStore` instead of Git LFS, so an agent can run an
-experiment and publish results end-to-end. It builds on
-[the artifact-store sketch](./artifact-store.md), which already called this out as
-step 3 ("`publish` for reports and figures; move large assets off LFS").
+How we publish reports (and their figures) through the new `HFStore` instead of
+Git LFS, so an agent can run an experiment and publish results end-to-end. It
+started as an investigation and now records the decided architecture and the
+mechanism that landed; it builds on [the artifact-store sketch](./artifact-store.md),
+which called this out as step 3 ("`publish` for reports and figures; move large
+assets off LFS"). The short version: externalize each report's figures/assets as
+content-addressed files referenced by a **relative** URL, and flip one `<base
+href>` at build time to repoint them — local files when opened off disk, the HF
+bucket when served from Pages.
 
 ## Why move
 
@@ -43,100 +47,82 @@ fetched bytes: 38  content-type: text/plain  roundtrip match: True
 So the egress allow-list (`*.xethub.hf.co`, `*.cdn.hf.co`) and the token are in
 place here, and the only missing piece is wiring the *reports* to use it.
 
-## The shape of the migration
+## The architecture: a coherent bundle + a `<base>` switch
 
-The plan from the sketch holds: **split at size**. Heavy bytes (figures) go to
-the bucket via `publish()` and are referenced by `https://` URL; the lightened
-report HTML — now mostly prose, code, and a little scaffolding — goes into Git,
-where it's diffable and readable on GitHub. Keep GitHub Pages as the front door;
-the served HTML just pulls its images from the bucket's CDN.
+A report is a **bundle**: one Marimo HTML document plus its heavy assets (figures,
+data blobs). The assets are externalized when *produced* and referenced by a
+**relative** URL — `_assets/<sha>.png` — written to a `_assets/` dir beside the
+exported HTML. That one decision (relative, not absolute) is what makes the same
+HTML work in every context, because *where* `_assets/…` resolves depends only on a
+single `<base href>` in the `<head>`:
 
-Concretely, the moving parts:
+- **Opened locally** (off disk, or `./go serve`): no base tag, so `_assets/…`
+  resolves to the co-located files. Offline, and the figures are real PNG files.
+- **Published to Pages**: `build_site.py` uploads `_assets/` to the HF bucket and
+  inserts one `<base href="…/resolve/published/reports/<name>/">`. Now the *same*
+  relative URLs resolve at the bucket. Pages carries only the HTML; the bytes are
+  served from HF's CDN.
 
-1. **Externalize figures** (the substance — see the next section).
-2. **`.gitattributes`**: drop both LFS rules once figures are externalized.
-   Large static assets, if we ever have them, go through `publish()` too, so the
-   `large-assets/**` rule retires alongside `__marimo__/**`.
-3. **`publish-docs.yml`**: drop `lfs: true` from the checkout. The build
-   (`build_site.py`) is unchanged — it copies the HTML, which now carries bucket
-   URLs; the viewer's browser fetches the images directly from the public bucket,
-   so Pages needs no token.
-4. **Re-export the five reports** with figures externalized and commit the
-   lightened HTML. (`themed`/`subline_demo`/`getting_started` are standalone;
-   `gpt`/`gpt_sweep` need their experiment results present to re-run.)
-5. **History**: the old LFS blobs stay in history harmlessly but count against
-   the LFS quota. Purging them is a `git filter-repo` rewrite — heavy, separable,
-   and I'd defer it rather than block the migration on it.
+So publishing is "upload the assets + insert one tag," with **no per-URL
+rewriting** — which matters, because the asset URLs live inside Marimo's
+doubly-escaped session JSON (see below) where surgical rewriting is fragile. A
+`<base>` sidesteps that entirely: the relative URLs resolve at DOM-render time
+against the document base, so one tag repoints all of them, *including* the ones
+buried in the JSON, *and* a relative `fetch("_assets/data.json")` in an
+interactive report (it resolves against `document.baseURI` too).
 
-## Will the lightened reports be small enough for Git?
+## Why relative + `<base>`, not a rewrite
 
-Your intuition is right, with a caveat worth stating precisely. The two
-figure-light reports (`getting_started`, `subline_demo`) sit at ~65 KB *with*
-Marimo's scaffolding, and that scaffolding is near-identical across every export
-(the frontend JS/CSS is referenced from a CDN, not inlined — which is why the
-floor is tens of KB, not megabytes). So a de-figured `gpt.html` should land in
-roughly that ~50–70 KB range too, and because the boilerplate is shared,
-Git's zlib + delta compression packs the set down hard. A handful of ~60 KB
-mostly-boilerplate HTML files is a non-issue for Git.
+Two things had to be true for the `<base>` switch to be safe, and both were
+verified against a real export this session:
 
-The caveat: this is an estimate from the two small reports as a proxy floor, not
-a measurement of a de-figured heavy report (I can't re-export the experiment
-reports here without their run results). Worth confirming on the first real
-prototype — but I'd be surprised if it came out badly.
+**Marimo contributes no relative URLs of its own.** A fresh `marimo export` has
+**zero** in-page fragment anchors (`href="#…"`, the classic `<base>` footgun) and
+**zero** incidental relative `src`/`href` — every framework resource is an absolute
+`cdn.jsdelivr.net` URL, and images are data-URIs inside the session JSON. So a
+`<base>` governs *only* the relative `_assets/…` references we deliberately
+introduce. (Sweeps over `docs/__marimo__/themed.html`: 0 fragment links, 0
+relative URLs, 194 absolute.)
 
-## Externalize at production, not as a post-process
+**Externalizing at production beats post-processing.** Our `themed_figure_html`
+(`src/mini/vis/nb.py`) renders each figure *twice* (light + dark) and previously
+emitted `<img src="data:image/png;base64,…">` — the bulk of a heavy report. On
+export those strings are buried in the cell-output session snapshot: JSON, inside a
+`<script>`, with `json_script` escaping `<`/`>`/`&` to `\uXXXX` (and Marimo's own
+matplotlib images nested one level deeper still, a data URI inside a
+JSON-string-of-a-mimebundle). Trying to *extract* that base64 back out is the
+fragile path. Emitting a short relative token instead is robust — and since we own
+the code that emits it, there's nothing to parse. (No Marimo CLI flag externalizes
+images either; confirmed in `_server/export/exporter.py`, `templates.py`,
+`_output/mpl.py`.)
 
-This is your open question, and the Marimo internals settle it. **Externalize
-when the figure is produced, not by post-processing the exported HTML.**
+The **one caveat** of a document-global `<base>`: it also repoints *author-written*
+relative links — a markdown `[experiment.py](./experiment.py)` — at the bucket,
+where they'd 404. The convention is therefore **the only relative URLs in a report
+are store assets; nav/source links are absolute** (e.g. to GitHub source). It's
+enforced cheaply: `build_site` runs `mini.reports.stray_links` over each export and
+warns about any relative URL that isn't an `_assets/…`. Conveniently, the existing
+reports' relative source links (`./experiment.py`, `../acts/…`) are *already* dead
+on Pages — `build_site` never copied `.py` files — so making them absolute fixes a
+latent bug rather than creating one.
 
-The reason is where the bytes end up. Our own `themed`/`themed_figure_html`
-(`src/mini/vis/nb.py`) renders each figure — *twice*, a light and a dark variant
-— to a base64 PNG and emits `<img src="data:image/png;base64,…">`. That's the
-bulk of a heavy report (two inline PNGs per figure). When Marimo exports, that
-HTML string is the cell's *output*, and it gets buried inside the session
-snapshot: a JSON object, inside a `<script>`/`<marimo-config>` block, with
-Marimo's `json_script` escaping `<`/`>`/`&` to `\uXXXX`. A figure from Marimo's
-own matplotlib formatter is nested even deeper — a data URI inside a
-JSON-string-of-a-mimebundle inside the session JSON.
+### Git size is now a non-question
 
-So a post-processing pass would have to **parse that doubly-nested, escaped JSON
-out of a `<script>` tag and reconstruct it** — a regex over `src="data:…"` won't
-find it. That's fragile against Marimo's version-specific internal layout, and
-there is no Marimo CLI flag that externalizes images for us (only `--include-code`
-and friends; `html-wasm` externalizes the *framework* assets, not notebook
-images). Confirmed by reading the installed `marimo` package
-(`_server/export/exporter.py`, `_server/templates/templates.py`,
-`_output/mpl.py`).
+Earlier I estimated a de-figured report at ~50–70 KB (the figure-light
+`getting_started`/`subline_demo` floor, since Marimo's scaffolding is CDN-loaded,
+not inlined). With externalization that's moot: the assets aren't in Git at all
+(`_assets/` is gitignored; durable home is the bucket), and the committed HTML is
+just the light shell. The demo export below came out at 41 KB with its two figures
+moved to files.
 
-Producing externally sidesteps all of that, because **we already own the code
-that emits the data URI**. The change is local to the figure-rendering boundary:
-instead of emitting `<img src="data:…">`, `put()` the PNG and emit
-`<img src="https://…bucket…/resolve/published/…">`. The report HTML then carries
-URLs (~100 bytes each) instead of two ~60 KB blobs per figure, and the figure
-bytes flow through the same content-addressed `publish()` path everything else
-uses — idempotent, deduped, version-independent. `docs/probe/report.py` already
-does the `put`+`publish` half (lines 121–122); it just *also* inlines the figure
-via `mo.Html`, so today it pays for both. The migration is to emit the URL
-*instead of* the inline image, not in addition.
+### A note on the bucket-hosted-HTML alternative
 
-Mechanically I'd add an opt-in publish path to the vis helper rather than
-overload `themed`: a small wrapper that takes the figure(s), a store, and a
-logical path, publishes each variant, and returns the themed `<img>` markup
-pointing at the two URLs. The report cell already has the store in hand
-(`LocalApparatus(NAME).store()`), and during `./go run` export the ambient store
-resolves to `HFStore` whenever the bucket + token are set — so this works inside
-the existing export command with no new plumbing.
-
-### The local-fallback wrinkle
-
-One thing to get right: `default_store` falls back to `LocalStore` when there's
-no bucket/token (a fresh checkout, someone trying the repo, a `./go build` with
-no auth). `LocalStore.publish` returns a `file://` URL, which won't render once
-the HTML is served from Pages. So the production-time helper needs a policy: when
-the resolved store can't produce a web URL, **fall back to inlining** the data
-URI as today. That keeps offline/no-auth builds working and renderable, and only
-the authenticated path (CI, the Cloud agent) produces lightened, externalized
-reports — which is exactly the path that needs to.
+We considered serving the *HTML itself* from the bucket (no Pages). It's viable —
+HF serves `.html` as `text/html; Content-Disposition: inline` (verified), so a
+browser renders it — but relative links break there (the `resolve` URL 302s to a
+signed CDN URL, so the document base becomes that signed path). Pages-hosts-HTML +
+bucket-hosts-assets keeps the front door pretty and the `<base>` clean, so that's
+the chosen shape. A thin Pages index linking to reports stays the project's URL.
 
 ## Beyond figures: data blobs and interactive reports
 
@@ -168,80 +154,84 @@ it's the single fact that would have sunk them if it had gone the other way.
 
 The design consequences:
 
-- **One verb covers it.** A data blob is just `publish()` with a `.json`/`.bin`
-  extension instead of `.png`. The vis helper exposes this as
-  `Publisher.asset_url(data, name=…)` (see below) — the report publishes the blob,
-  gets a URL, and hands that URL to whatever JS reads it. No new store surface.
-- **The SPA's own bundle** can ride the same path (publish the JS/CSS, reference
-  by URL) or come from a CDN; either way the heavy *data* goes through `publish`,
-  and the report HTML committed to Git stays a thin shell. This is the `html-wasm`
-  shape Marimo already uses for its framework assets, pointed at the bucket.
+- **One verb covers it.** A data blob is just `Publisher.asset_url(data, name=…)`
+  with a `.json`/`.bin` extension instead of a figure — it writes the bytes to
+  `_assets/<sha>.ext` and returns the relative URL. The report hands that URL to
+  whatever JS reads it; locally it resolves to the file, published it resolves
+  (via `<base>`) to the bucket. No new store surface.
+- **The SPA's own bundle** can ride the same path (write the JS/CSS to `_assets/`,
+  reference relatively) or come from a CDN; either way the heavy *data* is an
+  asset, and the committed HTML stays a thin shell.
 - **Range requests** survive the trip: the CDN 200 advertises `Accept-Ranges` and
-  exposes `Content-Range`, so a JS viewer can fetch a slice of a big binary rather
-  than the whole thing — the partial-access story the artifact sketch wanted from
-  `tree` artifacts, now over HTTP.
-- **The local-dev caveat sharpens here.** A figure degrades gracefully (inline)
-  when there's no web store; a *data fetch* can't inline into an `<img>`, and a
-  `file://` URL won't satisfy a cross-origin `fetch()` from a served page. So the
-  interactive cases genuinely need the bucket to be live — `asset_url` returns the
-  `file://` URL for local opening, but the honest position is that SPA/data
-  reports are an authenticated-build feature, not an offline one. Worth a clear
-  error/warning when a report calls `asset_url` and the store can't serve.
+  exposes `Content-Range`, so a JS viewer can fetch a slice of a big binary — the
+  partial-access story the artifact sketch wanted from `tree` artifacts, over HTTP.
+- **The local-dev caveat.** A figure resolves to a local file offline; a
+  cross-origin `fetch()` only works once the assets are on the bucket (a `file://`
+  fetch from a served page won't). So a *running* SPA/data report is an
+  authenticated-build feature — fine, since that's the publish path anyway.
 
-## The vis helper (landed)
+## What landed
 
-`mini.vis` now has a `Publisher` and `use_publisher`, and `themed` grew an opt-in
-`publish` path. Ergonomics were the priority, so the common case is one line of
-setup and **no change to existing figure cells**:
+The mechanism is built and verified end-to-end against the live bucket.
+
+**`mini.vis.Publisher`** (in `nb.py`) writes each asset to `_assets/<sha>.<ext>`
+and returns its relative URL; `themed` externalizes through it when one is set.
+Ergonomics first — one line in the setup cell, no change to figure cells:
 
 ```python
-# setup cell — point the report's figures at the artifact store
-from mini.vis import themed, use_publisher
-use_publisher(LocalApparatus(NAME).store(), prefix=f'reports/{NAME}')
+# setup cell
+from mini.vis import themed, use_publisher, report_bundle
+use_publisher(report_bundle(__file__))   # assets land in this report's __marimo__/_assets
 
-# figure cell — unchanged; it now externalizes instead of inlining
-@themed(alt_text='…', name='loss-curve')   # name → stable URL; omit → content hash
+# figure cell — unchanged
+@themed(alt_text='…')
 def _plot(): ...
 mo.Html(_plot())
 ```
 
-- **Externalize-or-inline.** With a web-serving store each PNG (light *and* dark)
-  is `put` + `publish`ed and the `<img>` carries the URL; with no store, or a
-  local `file://`-only store, it inlines as before — so offline builds still
-  render. The decision is per-`<img>`, in `Publisher.png_url`.
-- **`asset_url(data, name=…)`** is the general-purpose verb for the data-blob and
-  SPA cases above — publish arbitrary bytes/a file under the report's prefix, get
-  a URL back.
-- **Verified end-to-end** against the real bucket: a themed figure that inlined at
-  ~27 KB of base64 now emits ~1.2 KB of HTML with two PNG URLs that serve as
-  `image/png`. `docs/probe/report.py` is converted as the worked example (it used
-  to inline *and* separately publish — now it just externalizes).
+- `report_bundle(__file__)` derives the asset dir from the notebook path
+  (`__file__` resolves during `marimo export` — verified). No publisher → figures
+  inline as self-contained `data:` URIs, so a no-frills export still works.
+- `Publisher.asset_url(data, name=…)` is the general verb for data blobs / SPAs.
 
-Tests cover the inline default, the web-URL path, the `file://` fallback, named
-vs. content-hash slugs, the `use_publisher` default, and `asset_url`.
+**`mini.reports`** has the publish-side string ops: `insert_base(html, href)` and
+`stray_links(html)` (the lint), kept dependency-light and unit-tested.
+
+**`scripts/build_site.py`** resolves the project store and picks a mode per report:
+*localize* (no bucket → copy `_assets/` into `_site` beside the HTML) or
+*externalize* (bucket → upload `_assets/` and insert the `<base>`), warning on any
+stray relative link either way.
+
+**End-to-end check** (a demo report exported with `report_bundle`): 41 KB HTML, two
+relative `_assets/<sha>.png` refs (0 inline), no stray links; localize resolved
+every ref to a file in `_site`; externalize uploaded to `z0u/mi-ni-store`, inserted
+one `<base>`, and the *same* relative ref then resolved to a live, fetchable
+`image/png`. `docs/probe/report.py` is converted as the worked example (it used to
+inline *and* separately publish; now it externalizes and its source links are
+absolute, per the convention).
 
 ## What's left
 
-1. ~~The vis helper~~ — done (above).
-2. Convert a figure-heavy report (`gpt` or `gpt_sweep`) and **measure** the
-   de-figured HTML size to confirm the Git-size estimate.
-3. Drop the LFS rules + `lfs: true`, re-export the five reports, commit the
-   lightened HTML.
-4. Defer (separable): purging old LFS blobs from history; the private-CAS /
-   public-publish two-bucket split already tracked in `todo.md` (the bucket is
-   public today, so `publish` is fine, but the durable CAS is public too).
+1. **Re-export the five real reports** with a publisher and commit the light HTML.
+   (`themed`/`subline_demo`/`getting_started` are standalone; `gpt`/`gpt_sweep`
+   need their run results.) Apply the absolute-source-links convention to each.
+2. **`.gitattributes`**: drop both LFS rules (`__marimo__/**`, `large-assets/**`)
+   so the light HTML commits to Git normally. (`_assets/` is already gitignored,
+   so exported assets never hit the LFS filter.)
+3. **`publish-docs.yml`**: drop `lfs: true`; and for the *externalize* build to run
+   in CI it needs the project installed (not just `--only-group pages`) plus the HF
+   token as a secret. Without them the CI build localizes — assets won't be on the
+   bucket — so externalization wants either the full-deps CI job or to happen at
+   export time on the agent. Worth deciding.
+4. **A Pages index/gallery** linking to the reports (keeps a stable front door).
+5. Defer: purge old LFS blobs from history (`git filter-repo`); the private-CAS /
+   public-publish two-bucket split tracked in `todo.md`.
 
 ## Open questions
 
-- **Accumulation / GC.** Every re-export publishes new content-addressed figure
-  blobs; old ones linger. This is the same CAS-only-grows problem `todo.md`
-  already flags for the store at large — reports just add a steady trickle. Not a
-  blocker, but reports make the refcount-and-sweep need concrete sooner.
-- **Stable vs. content-addressed published paths.** Publishing under a
-  content-hash path means a report's image URLs churn on every re-render (fine,
-  the HTML is regenerated too). Publishing under a stable `reports/<exp>/<fig>.png`
-  path keeps URLs constant but is last-writer-wins. The probe report uses the
-  stable form; I'd keep that for reports (the URL is meant to be shareable) and
-  rely on the CAS underneath for immutability of *content*.
-- **Measuring the real de-figured size**, per above — the one number this
-  investigation estimates rather than measures.
+- **Accumulation / GC.** Every re-export writes new content-addressed assets to the
+  bucket; old ones linger — the same CAS-only-grows problem `todo.md` flags, just
+  with a steady trickle from reports. Refcount-from-live-reports + sweep, later.
+- **Where externalization runs** (CI vs. export time) — item 3 above; the cleanest
+  answer probably ties report publishing to a `mini`-side command the agent runs,
+  rather than loading the full project into the Pages job.

--- a/research/reports-hfstore-migration.md
+++ b/research/reports-hfstore-migration.md
@@ -138,12 +138,92 @@ URI as today. That keeps offline/no-auth builds working and renderable, and only
 the authenticated path (CI, the Cloud agent) produces lightened, externalized
 reports — which is exactly the path that needs to.
 
-## What I'd build first
+## Beyond figures: data blobs and interactive reports
 
-1. The vis helper: `publish-or-inline` for `themed` figures, with the fallback
-   above. Smallest change that proves the loop; testable against `LocalStore`
-   (file URLs) and the real bucket.
-2. Convert one figure-heavy report (`gpt` or `gpt_sweep`) and **measure** the
+Figures are the common case, but the same split generalizes, and two harder cases
+are worth designing for now rather than retrofitting:
+
+- a report that ships a **large JSON or binary blob** that in-page JS browses
+  (a sortable table, a tensor viewer, an embedding explorer); and
+- an **interactive SPA visualization** that *is* the report — its own JS bundle
+  plus data files.
+
+Both reduce to the same move as a figure: `publish()` the heavy bytes, reference
+them by URL, and let the browser fetch them at view time. The one new requirement
+is that JS `fetch()`/`XHR` — unlike an `<img>` — is subject to CORS, so the
+bucket has to allow a cross-origin read from the Pages origin. **It does.** The
+bucket reflects the request `Origin` on both the `resolve` redirect and the final
+CDN response (verified from this environment):
+
+```
+$ curl -sI -H 'Origin: https://z0u.github.io' <resolve URL>
+access-control-allow-origin: https://z0u.github.io      # on the 302
+…and the CDN 200 it redirects to:
+access-control-allow-origin: *
+```
+
+So a report served from `*.github.io` can `fetch()` a published JSON straight
+from the bucket CDN. That's what makes the data-browser and SPA cases work, and
+it's the single fact that would have sunk them if it had gone the other way.
+
+The design consequences:
+
+- **One verb covers it.** A data blob is just `publish()` with a `.json`/`.bin`
+  extension instead of `.png`. The vis helper exposes this as
+  `Publisher.asset_url(data, name=…)` (see below) — the report publishes the blob,
+  gets a URL, and hands that URL to whatever JS reads it. No new store surface.
+- **The SPA's own bundle** can ride the same path (publish the JS/CSS, reference
+  by URL) or come from a CDN; either way the heavy *data* goes through `publish`,
+  and the report HTML committed to Git stays a thin shell. This is the `html-wasm`
+  shape Marimo already uses for its framework assets, pointed at the bucket.
+- **Range requests** survive the trip: the CDN 200 advertises `Accept-Ranges` and
+  exposes `Content-Range`, so a JS viewer can fetch a slice of a big binary rather
+  than the whole thing — the partial-access story the artifact sketch wanted from
+  `tree` artifacts, now over HTTP.
+- **The local-dev caveat sharpens here.** A figure degrades gracefully (inline)
+  when there's no web store; a *data fetch* can't inline into an `<img>`, and a
+  `file://` URL won't satisfy a cross-origin `fetch()` from a served page. So the
+  interactive cases genuinely need the bucket to be live — `asset_url` returns the
+  `file://` URL for local opening, but the honest position is that SPA/data
+  reports are an authenticated-build feature, not an offline one. Worth a clear
+  error/warning when a report calls `asset_url` and the store can't serve.
+
+## The vis helper (landed)
+
+`mini.vis` now has a `Publisher` and `use_publisher`, and `themed` grew an opt-in
+`publish` path. Ergonomics were the priority, so the common case is one line of
+setup and **no change to existing figure cells**:
+
+```python
+# setup cell — point the report's figures at the artifact store
+from mini.vis import themed, use_publisher
+use_publisher(LocalApparatus(NAME).store(), prefix=f'reports/{NAME}')
+
+# figure cell — unchanged; it now externalizes instead of inlining
+@themed(alt_text='…', name='loss-curve')   # name → stable URL; omit → content hash
+def _plot(): ...
+mo.Html(_plot())
+```
+
+- **Externalize-or-inline.** With a web-serving store each PNG (light *and* dark)
+  is `put` + `publish`ed and the `<img>` carries the URL; with no store, or a
+  local `file://`-only store, it inlines as before — so offline builds still
+  render. The decision is per-`<img>`, in `Publisher.png_url`.
+- **`asset_url(data, name=…)`** is the general-purpose verb for the data-blob and
+  SPA cases above — publish arbitrary bytes/a file under the report's prefix, get
+  a URL back.
+- **Verified end-to-end** against the real bucket: a themed figure that inlined at
+  ~27 KB of base64 now emits ~1.2 KB of HTML with two PNG URLs that serve as
+  `image/png`. `docs/probe/report.py` is converted as the worked example (it used
+  to inline *and* separately publish — now it just externalizes).
+
+Tests cover the inline default, the web-URL path, the `file://` fallback, named
+vs. content-hash slugs, the `use_publisher` default, and `asset_url`.
+
+## What's left
+
+1. ~~The vis helper~~ — done (above).
+2. Convert a figure-heavy report (`gpt` or `gpt_sweep`) and **measure** the
    de-figured HTML size to confirm the Git-size estimate.
 3. Drop the LFS rules + `lfs: true`, re-export the five reports, commit the
    lightened HTML.

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python
 """Build the static site from Marimo HTML output."""
 
+import os
 import re
 import shutil
-from pathlib import Path
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 
 import markdown as md_lib
 
-from mini.reports import insert_base, stray_links
+from mini.reports import insert_base, rewrite_links, stray_links
 
 WORKSPACE_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DIR = WORKSPACE_ROOT / '_site'
 DOCS_DIR = WORKSPACE_ROOT / 'docs'
 
 # The relative dir, beside each report's HTML, holding its externalized assets
-# (figures, data blobs) written by mini.vis.Publisher.
+# (figures, data blobs) written by mini.reports.Publisher.
 ASSET_LINK = '_assets'
+
+# Source suffixes that the build renders into a sibling .html page (so an author link
+# to one resolves to the rendered result, not the dead source file).
+_RENDERED_SUFFIXES = ('.py', '.ipynb', '.md')
 
 
 def prepare_dirs():
@@ -45,20 +52,133 @@ def _bundle_key(rel_parent: Path) -> str:
 def _externalize_assets(assets_dir: Path, store, key: str) -> str:
     """Upload a bundle's assets to the bucket; return the ``<base href>`` they sit under.
 
-    The relative ``_assets/<sha>.ext`` references then resolve against this base to the
-    published bucket URL — content-addressed, so ``put`` is a no-op when bytes recur.
+    The relative ``_assets/<sha>/<name>`` references then resolve against this base to
+    the published bucket URL — content-addressed, so ``put`` is a no-op when bytes
+    recur. Walks recursively so the ``<sha>/<name>`` layout is preserved under the key.
     """
-    for f in sorted(p for p in assets_dir.iterdir() if p.is_file()):
-        store.publish(store.put(f, name=f.name), f'reports/{key}/{ASSET_LINK}/{f.name}')
+    for f in sorted(p for p in assets_dir.rglob('*') if p.is_file()):
+        rel = f.relative_to(assets_dir).as_posix()
+        store.publish(store.put(f, name=f.name), f'reports/{key}/{ASSET_LINK}/{rel}')
     return f'https://huggingface.co/buckets/{store.bucket}/resolve/published/reports/{key}/'
 
 
-def copy_marimo_output():
+# ---------------------------------------------------------------------------
+# Author-link resolution
+#
+# A report's only *relative* URLs should be its store assets; an author-written link
+# (``[src](./experiment.py)``) is repointed by the asset ``<base>`` and would 404. The
+# resolver turns each such link into an absolute target — the rendered page for things
+# the build renders, the GitHub source otherwise — so it survives the base. In localize
+# mode (no base) rendered links stay relative so offline navigation still works.
+# ---------------------------------------------------------------------------
+
+_ANCHORED = re.compile(r'(?:[a-z][a-z0-9+.\-]*:|//|/|#)', re.IGNORECASE)
+
+
+def _repo_slug() -> str | None:
+    """``owner/repo`` from ``$MINI_REPO`` or the git ``origin`` remote, or ``None``."""
+    url = os.environ.get('MINI_REPO')
+    if not url:
+        try:
+            url = subprocess.run(
+                ['git', '-C', str(WORKSPACE_ROOT), 'remote', 'get-url', 'origin'],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except OSError, subprocess.CalledProcessError:
+            return None
+    m = re.search(r'[:/]([^/]+/[^/]+?)(?:\.git)?$', url)
+    return m.group(1) if m else None
+
+
+@dataclass(frozen=True)
+class LinkResolver:
+    """Maps an author-written relative link to its published target.
+
+    ``render_map`` is docs-relative *source* path → site-relative *output* path for
+    every page the build emits; ``source_files`` is every file under ``docs/`` (the
+    GitHub-source fallback). ``site_base``/``source_base`` are the absolute roots used
+    when a link must be made absolute (externalize mode).
+    """
+
+    render_map: dict[str, str]
+    source_files: frozenset[str]
+    site_base: str | None
+    source_base: str | None
+
+    @classmethod
+    def discover(cls) -> 'LinkResolver':
+        render_map: dict[str, str] = {}
+        for md in DOCS_DIR.rglob('*.md'):
+            if md.name == 'README.md':
+                continue
+            rel = md.relative_to(DOCS_DIR).as_posix()
+            render_map[rel] = PurePosixPath(rel).with_suffix('.html').as_posix()
+        for marimo_dir in DOCS_DIR.rglob('__marimo__'):
+            if not marimo_dir.is_dir():
+                continue
+            rel_parent = marimo_dir.parent.relative_to(DOCS_DIR)
+            for html in marimo_dir.rglob('*.html'):
+                if ASSET_LINK in html.relative_to(marimo_dir).parts:
+                    continue
+                stem = html.stem
+                out = (rel_parent / f'{stem}.html').as_posix()
+                # The export came from a sibling notebook; register every suffix an
+                # author might have linked (``report.py`` → its rendered ``report.html``).
+                for suffix in _RENDERED_SUFFIXES:
+                    render_map[(rel_parent / f'{stem}{suffix}').as_posix()] = out
+
+        source_files = frozenset(p.relative_to(DOCS_DIR).as_posix() for p in DOCS_DIR.rglob('*') if p.is_file())
+
+        slug = _repo_slug()
+        site_base = os.environ.get('MINI_SITE_URL')
+        source_base = os.environ.get('MINI_SOURCE_URL')
+        if slug:
+            owner, repo = slug.split('/', 1)
+            site_base = site_base or f'https://{owner}.github.io/{repo}/'
+            source_base = source_base or f'https://github.com/{slug}/blob/main/'
+        return cls(render_map, source_files, site_base, source_base)
+
+    def resolve(self, token: str, *, from_dir: str, externalizing: bool) -> str | None:
+        """The rewritten target for relative link *token* (authored under ``docs/<from_dir>``).
+
+        ``None`` means "leave it alone" — an external/absolute link, or one whose target
+        the build doesn't know how to reach (a dangling or not-yet-rendered path).
+        """
+        if not token or _ANCHORED.match(token):
+            return None
+        path_part, _, frag = token.partition('#')
+        frag = f'#{frag}' if frag else ''
+        norm = os.path.normpath(PurePosixPath(from_dir, path_part).as_posix())
+        if norm.startswith('..'):  # escaped the docs tree — not ours to resolve
+            return None
+
+        if norm in self.render_map:
+            if externalizing:
+                return None if self.site_base is None else f'{self.site_base}{self.render_map[norm]}{frag}'
+            # localize: keep it relative (resolves within _site), just swap the suffix
+            return f'{PurePosixPath(path_part).with_suffix(".html").as_posix()}{frag}'
+        if norm in self.source_files:
+            return None if self.source_base is None else f'{self.source_base}docs/{norm}{frag}'
+        return None
+
+
+def prepare_dirs_and_resolver() -> LinkResolver:
+    prepare_dirs()
+    return LinkResolver.discover()
+
+
+# ---------------------------------------------------------------------------
+
+
+def copy_marimo_output(links: LinkResolver):
     """Copy each ``__marimo__`` report's HTML to ``_site/``, resolving its asset bundle.
 
     Local store → copy ``_assets/`` beside the HTML (relative URLs resolve in ``_site``).
     HF bucket   → upload ``_assets/`` and insert one ``<base>`` so the same relative
-    URLs resolve at the bucket; ``_site`` then carries only HTML.
+    URLs resolve at the bucket; ``_site`` then carries only HTML. Author-written links
+    are resolved to absolute targets either way (so the ``<base>`` doesn't break them).
     """
     print('Copying Marimo HTML output...')
     from mini.hf_store import HFStore
@@ -72,7 +192,7 @@ def copy_marimo_output():
             continue
         rel_parent = marimo_dir.parent.relative_to(DOCS_DIR)
         assets_dir = marimo_dir / ASSET_LINK
-        has_assets = assets_dir.is_dir() and any(assets_dir.iterdir())
+        has_assets = assets_dir.is_dir() and any(assets_dir.rglob('*'))
 
         base_href = None
         if has_assets and externalizing:
@@ -85,8 +205,7 @@ def copy_marimo_output():
             dest = SITE_DIR / rel_parent / rel
             dest.parent.mkdir(parents=True, exist_ok=True)
             html = html_file.read_text('utf-8')
-            for stray in stray_links(html, link=ASSET_LINK):
-                print(f'  ! {rel}: relative link {stray!r} — make it absolute, a <base> would break it')
+            html = _resolve_html_links(html, links, from_dir=rel_parent.as_posix(), externalizing=externalizing)
             if base_href:
                 html = insert_base(html, base_href)
             dest.write_text(html, 'utf-8')
@@ -98,6 +217,18 @@ def copy_marimo_output():
             out = SITE_DIR / rel_parent / ASSET_LINK
             shutil.copytree(assets_dir, out, dirs_exist_ok=True)
             print(f'  {assets_dir.relative_to(WORKSPACE_ROOT)}/ -> {out.relative_to(WORKSPACE_ROOT)}/')
+
+
+def _resolve_html_links(html: str, links: LinkResolver, *, from_dir: str, externalizing: bool) -> str:
+    """Rewrite resolvable author links in *html*; warn on the ones left dangling."""
+    mapping: dict[str, str] = {}
+    for token in stray_links(html, link=ASSET_LINK):
+        target = links.resolve(token, from_dir=from_dir, externalizing=externalizing)
+        if target is not None:
+            mapping[token] = target
+        else:
+            print(f'  ! {from_dir or "."}: unresolved relative link {token!r} — a <base> would break it')
+    return rewrite_links(html, mapping) if mapping else html
 
 
 def copy_assets():
@@ -135,7 +266,23 @@ def copy_md_stylesheet():
     print(f'  {css_src.relative_to(WORKSPACE_ROOT)} -> {css_dest.relative_to(WORKSPACE_ROOT)}')
 
 
-def convert_markdown():
+def _rewrite_md_links(text: str, links: LinkResolver, *, from_dir: str) -> str:
+    """Resolve relative Markdown link targets (``](./experiment.py)``) before conversion.
+
+    Markdown pages never carry an asset ``<base>``, so they're resolved in *localize*
+    mode: a rendered target stays a relative ``.html`` link (clickable offline), a
+    source file becomes an absolute GitHub link, and anything else is left untouched.
+    """
+
+    def repl(m: re.Match) -> str:
+        token = m.group(1)
+        target = links.resolve(token, from_dir=from_dir, externalizing=False)
+        return f']({target})' if target is not None else m.group(0)
+
+    return re.sub(r'\]\(([^)\s]+)\)', repl, text)
+
+
+def convert_markdown(links: LinkResolver):
     """Convert all .md files in docs/ (except README.md) to .html in _site/."""
     print('Converting Markdown...')
     skip = {'README.md'}
@@ -145,8 +292,8 @@ def convert_markdown():
         rel = md_file.relative_to(DOCS_DIR).with_suffix('.html')
         dest = SITE_DIR / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
-        text = md_file.read_text('utf-8')
-        text = re.sub(r'\]\(([^)]+)\.py\)', r'](\1.html)', text)
+        from_dir = md_file.parent.relative_to(DOCS_DIR).as_posix()
+        text = _rewrite_md_links(md_file.read_text('utf-8'), links, from_dir=from_dir)
         body = md_lib.markdown(text, extensions=['extra'])
         title_match = re.search(r'^#\s+(.+)$', text, re.MULTILINE)
         title = title_match.group(1).strip() if title_match else md_file.stem
@@ -171,11 +318,11 @@ def add_nojekyll():
 
 
 def main():
-    prepare_dirs()
-    copy_marimo_output()
+    links = prepare_dirs_and_resolver()
+    copy_marimo_output(links)
     copy_assets()
     copy_md_stylesheet()
-    convert_markdown()
+    convert_markdown(links)
     add_nojekyll()
     print(f'\nSite written to {SITE_DIR.relative_to(WORKSPACE_ROOT)}/')
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -7,9 +7,15 @@ from pathlib import Path
 
 import markdown as md_lib
 
+from mini.reports import insert_base, stray_links
+
 WORKSPACE_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DIR = WORKSPACE_ROOT / '_site'
 DOCS_DIR = WORKSPACE_ROOT / 'docs'
+
+# The relative dir, beside each report's HTML, holding its externalized assets
+# (figures, data blobs) written by mini.vis.Publisher.
+ASSET_LINK = '_assets'
 
 
 def prepare_dirs():
@@ -19,19 +25,79 @@ def prepare_dirs():
     SITE_DIR.mkdir()
 
 
+def _resolve_store():
+    """The project store — an HF bucket if configured + authed, else local.
+
+    Drives the two asset modes: a bucket means *externalize* (upload + ``<base>``); a
+    local store means *localize* (copy assets beside the HTML in ``_site``).
+    """
+    from mini.store import default_store
+
+    return default_store(WORKSPACE_ROOT / '.mini' / 'store')
+
+
+def _bundle_key(rel_parent: Path) -> str:
+    """A bucket namespace for a report's assets, from its dir relative to docs/."""
+    posix = rel_parent.as_posix()
+    return posix if posix != '.' else '_root'
+
+
+def _externalize_assets(assets_dir: Path, store, key: str) -> str:
+    """Upload a bundle's assets to the bucket; return the ``<base href>`` they sit under.
+
+    The relative ``_assets/<sha>.ext`` references then resolve against this base to the
+    published bucket URL — content-addressed, so ``put`` is a no-op when bytes recur.
+    """
+    for f in sorted(p for p in assets_dir.iterdir() if p.is_file()):
+        store.publish(store.put(f, name=f.name), f'reports/{key}/{ASSET_LINK}/{f.name}')
+    return f'https://huggingface.co/buckets/{store.bucket}/resolve/published/reports/{key}/'
+
+
 def copy_marimo_output():
-    """Copy HTML from all __marimo__ dirs in docs/ to _site/, preserving relative structure."""
+    """Copy each ``__marimo__`` report's HTML to ``_site/``, resolving its asset bundle.
+
+    Local store → copy ``_assets/`` beside the HTML (relative URLs resolve in ``_site``).
+    HF bucket   → upload ``_assets/`` and insert one ``<base>`` so the same relative
+    URLs resolve at the bucket; ``_site`` then carries only HTML.
+    """
     print('Copying Marimo HTML output...')
+    from mini.hf_store import HFStore
+
+    store = _resolve_store()
+    externalizing = isinstance(store, HFStore)
+    print(f'  asset mode: {"externalize → " + store.bucket if externalizing else "localize (no bucket)"}')
+
     for marimo_dir in sorted(DOCS_DIR.rglob('__marimo__')):
         if not marimo_dir.is_dir():
             continue
         rel_parent = marimo_dir.parent.relative_to(DOCS_DIR)
+        assets_dir = marimo_dir / ASSET_LINK
+        has_assets = assets_dir.is_dir() and any(assets_dir.iterdir())
+
+        base_href = None
+        if has_assets and externalizing:
+            base_href = _externalize_assets(assets_dir, store, _bundle_key(rel_parent))
+
         for html_file in sorted(marimo_dir.rglob('*.html')):
             rel = html_file.relative_to(marimo_dir)
+            if ASSET_LINK in rel.parts:
+                continue
             dest = SITE_DIR / rel_parent / rel
             dest.parent.mkdir(parents=True, exist_ok=True)
-            print(f'  {html_file.relative_to(WORKSPACE_ROOT)} -> {dest.relative_to(WORKSPACE_ROOT)}')
-            shutil.copy2(html_file, dest)
+            html = html_file.read_text('utf-8')
+            for stray in stray_links(html, link=ASSET_LINK):
+                print(f'  ! {rel}: relative link {stray!r} — make it absolute, a <base> would break it')
+            if base_href:
+                html = insert_base(html, base_href)
+            dest.write_text(html, 'utf-8')
+            print(
+                f'  {html_file.relative_to(WORKSPACE_ROOT)} -> {dest.relative_to(WORKSPACE_ROOT)}{" [+base]" if base_href else ""}'
+            )
+
+        if has_assets and not externalizing:
+            out = SITE_DIR / rel_parent / ASSET_LINK
+            shutil.copytree(assets_dir, out, dirs_exist_ok=True)
+            print(f'  {assets_dir.relative_to(WORKSPACE_ROOT)}/ -> {out.relative_to(WORKSPACE_ROOT)}/')
 
 
 def copy_assets():

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -1,0 +1,62 @@
+"""
+Publishing exported reports: repoint their relative asset URLs at the bucket.
+
+A report (a Marimo HTML export) references its heavy assets — figures, data blobs —
+by a *relative* URL like ``_assets/<sha>.png`` (see :class:`mini.vis.Publisher`). That
+same HTML is consumed two ways:
+
+- **opened locally**, the relative URL resolves to the co-located ``_assets/`` files;
+- **served from Pages**, we want it to resolve to the assets we uploaded to the HF
+  bucket instead.
+
+The bridge is a single ``<base href>`` in the ``<head>``: it sets the document base
+that *every* relative URL resolves against, so one inserted tag repoints the whole
+report's assets at the bucket — no per-URL rewriting, and it works for the data URIs
+buried in Marimo's session JSON (they resolve at render time) and for a relative
+``fetch()`` in an interactive report alike.
+
+The catch is that ``<base>`` is document-global, so an author-written relative *link*
+(a markdown ``[src](./experiment.py)``) would be repointed too — and 404 against the
+bucket. :func:`stray_links` finds those at build time so they can be made absolute;
+the convention is *the only relative URLs in a report are store assets*.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ['relative_urls', 'stray_links', 'insert_base']
+
+# Matches the value of an ``src=`` / ``href=`` attribute, whether it sits in plain
+# HTML (``src="…"``) or JSON-escaped inside Marimo's ``<script>`` session blob
+# (``src=\"…\"``) — hence the optional leading backslash and stopping at a backslash.
+_URL_ATTR = re.compile(r'(?:src|href)\s*=\s*\\?["\']([^"\'\\]+)')
+
+# A URL is "external/anchored" (not a relative path we'd resolve against a base) if it
+# carries a scheme (``https:``, ``data:``, ``mailto:``…), is protocol-relative (``//``),
+# or is a bare fragment (``#cell-id``).
+_ANCHORED = re.compile(r'(?:[a-z][a-z0-9+.\-]*:|//|#)', re.IGNORECASE)
+
+
+def relative_urls(html: str) -> list[str]:
+    """Every relative ``src``/``href`` URL in *html* (escaped-in-JSON or not, in order)."""
+    return [u for u in _URL_ATTR.findall(html) if u and not _ANCHORED.match(u)]
+
+
+def stray_links(html: str, *, link: str = '_assets') -> list[str]:
+    """Relative URLs that are *not* store assets — the ones a ``<base>`` would break.
+
+    These are author-written nav/source links (``./experiment.py``) that should be
+    absolute. Returned sorted and de-duplicated so a build can warn about them.
+    """
+    prefix = f'{link}/'
+    return sorted({u for u in relative_urls(html) if not u.startswith(prefix)})
+
+
+def insert_base(html: str, href: str) -> str:
+    """Insert a single ``<base href>`` as the first thing in ``<head>``.
+
+    Placed before any resource reference so it governs all of them. Idempotent enough
+    for a build step: it rewrites the first ``<head>`` only.
+    """
+    return re.sub(r'(<head[^>]*>)', lambda m: f'{m.group(1)}\n    <base href="{href}" />', html, count=1)

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -1,31 +1,143 @@
 """
-Publishing exported reports: repoint their relative asset URLs at the bucket.
+Report bundles: produce a report's assets as relative URLs, then repoint them.
 
-A report (a Marimo HTML export) references its heavy assets — figures, data blobs —
-by a *relative* URL like ``_assets/<sha>.png`` (see :class:`mini.vis.Publisher`). That
-same HTML is consumed two ways:
+A report is a **bundle** — one Marimo HTML document plus its heavy assets (figures,
+data blobs). The two halves of the bundle protocol both live here:
+
+**Produce.** A :class:`Publisher` writes each asset out as a content-addressed file
+beside the exported HTML and hands back a *relative* URL like
+``_assets/<sha>/<name>.png``. The path carries the content hash (so identical bytes
+are written once and shared) *and* a readable leaf (so a browser saving the asset
+suggests a sensible filename — the URL's last segment, since the bucket sets no
+``Content-Disposition``). ``themed`` figures externalize through a publisher when one
+is set; :meth:`Publisher.asset_url` is the general verb for any blob.
+
+**Publish.** That same HTML is consumed two ways:
 
 - **opened locally**, the relative URL resolves to the co-located ``_assets/`` files;
 - **served from Pages**, we want it to resolve to the assets we uploaded to the HF
   bucket instead.
 
-The bridge is a single ``<base href>`` in the ``<head>``: it sets the document base
-that *every* relative URL resolves against, so one inserted tag repoints the whole
-report's assets at the bucket — no per-URL rewriting, and it works for the data URIs
-buried in Marimo's session JSON (they resolve at render time) and for a relative
-``fetch()`` in an interactive report alike.
+The bridge is a single ``<base href>`` in the ``<head>`` (:func:`insert_base`): it
+sets the document base that *every* relative URL resolves against, so one inserted
+tag repoints the whole report's assets at the bucket — no per-URL rewriting, and it
+works for the data URIs buried in Marimo's session JSON and a relative ``fetch()``
+alike.
 
 The catch is that ``<base>`` is document-global, so an author-written relative *link*
 (a markdown ``[src](./experiment.py)``) would be repointed too — and 404 against the
-bucket. :func:`stray_links` finds those at build time so they can be made absolute;
-the convention is *the only relative URLs in a report are store assets*.
+bucket. :func:`stray_links` finds those at build time; :func:`rewrite_links` turns
+them into absolute targets (their rendered page, or their source) so they survive the
+base. The convention is *the only relative URLs left in a report are store assets*.
 """
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 
-__all__ = ['relative_urls', 'stray_links', 'insert_base']
+__all__ = [
+    'Publisher',
+    'report_bundle',
+    'use_publisher',
+    'current_publisher',
+    'relative_urls',
+    'stray_links',
+    'rewrite_links',
+    'insert_base',
+]
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Produce: writing a report's assets as files referenced by a relative URL
+# ---------------------------------------------------------------------------
+
+
+def _safe_leaf(name: str) -> str:
+    """A filesystem/URL-safe leaf filename from *name* (its readable download name)."""
+    leaf = re.sub(r'[^A-Za-z0-9._-]', '-', PurePosixPath(name).name)
+    return leaf or 'asset'
+
+
+@dataclass(frozen=True)
+class Publisher:
+    """Writes a report's heavy assets out as content-addressed files beside the
+    exported HTML, referenced by a **relative** URL.
+
+    Each blob is written under ``asset_dir`` (conventionally ``…/__marimo__/_assets``)
+    at ``<sha256>/<name>``: the SHA directory is the content address (identical bytes
+    land in one place, written once), and the readable *name* is the leaf — so a
+    browser "Save as" suggests that name (it derives the filename from the URL's last
+    segment, the bucket setting no ``Content-Disposition``). The reference is
+    ``<link>/<sha>/<name>``; because it's relative, the same HTML resolves to the local
+    files when opened off disk and to the HF bucket when published (a single
+    ``<base href>`` is inserted at build time — see ``scripts/build_site.py``).
+    """
+
+    asset_dir: Path
+    link: str = '_assets'
+
+    def asset_url(self, data: bytes | Path, *, name: str) -> str:
+        """Write *data* (bytes or a file) as ``<sha>/<name>`` and return its relative URL.
+
+        Content-addressed by the SHA directory and write-once, so re-running a report
+        reuses identical bytes rather than piling up copies. *name* is the readable
+        download filename (carry the extension — it sets the served media type).
+        """
+        blob = bytes(data) if isinstance(data, (bytes, bytearray)) else Path(data).read_bytes()
+        leaf = _safe_leaf(name)
+        rel = f'{hashlib.sha256(blob).hexdigest()}/{leaf}'
+        dest = self.asset_dir / rel
+        if not dest.exists():  # content-addressed: identical bytes + name already written
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dest.with_name(f'{leaf}.tmp')
+            tmp.write_bytes(blob)
+            tmp.replace(dest)  # atomic, so a concurrent reader never sees a partial file
+        return f'{self.link}/{rel}'
+
+
+def report_bundle(notebook_file: str | Path, *, link: str = '_assets') -> Publisher:
+    """A :class:`Publisher` writing assets beside a report's exported HTML.
+
+    Marimo exports ``docs/<…>/report.py`` to ``docs/<…>/__marimo__/report.html``; this
+    points assets at ``docs/<…>/__marimo__/<link>/`` so the relative ``<link>/…`` URL
+    resolves next to that HTML. Call it from the report's setup cell with ``__file__``::
+
+        use_publisher(report_bundle(__file__))
+    """
+    out_dir = Path(notebook_file).resolve().parent / '__marimo__'
+    return Publisher(asset_dir=out_dir / link, link=link)
+
+
+_default_publisher: Publisher | None = None
+
+
+def use_publisher(publisher: Publisher | None) -> Publisher | None:
+    """Set the report-wide default publisher; call once in a report's setup cell.
+
+    Every ``@themed`` figure then externalizes through it with no per-figure argument.
+    Pass a :class:`Publisher` (usually from :func:`report_bundle`), or ``None`` to clear
+    it (figures inline as self-contained ``data:`` URIs). Returns it, e.g. to call
+    :meth:`~Publisher.asset_url` for a data blob.
+    """
+    global _default_publisher
+    _default_publisher = publisher
+    return publisher
+
+
+def current_publisher() -> Publisher | None:
+    """The report-wide default publisher set by :func:`use_publisher` (or ``None``)."""
+    return _default_publisher
+
+
+# ---------------------------------------------------------------------------
+# Publish: repoint a report's relative URLs at the bucket
+# ---------------------------------------------------------------------------
 
 # Matches the value of an ``src=`` / ``href=`` attribute, whether it sits in plain
 # HTML (``src="…"``) or JSON-escaped inside Marimo's ``<script>`` session blob
@@ -47,10 +159,27 @@ def stray_links(html: str, *, link: str = '_assets') -> list[str]:
     """Relative URLs that are *not* store assets — the ones a ``<base>`` would break.
 
     These are author-written nav/source links (``./experiment.py``) that should be
-    absolute. Returned sorted and de-duplicated so a build can warn about them.
+    absolute. Returned sorted and de-duplicated so a build can resolve or warn on them.
     """
     prefix = f'{link}/'
     return sorted({u for u in relative_urls(html) if not u.startswith(prefix)})
+
+
+def rewrite_links(html: str, mapping: dict[str, str]) -> str:
+    r"""Replace each relative URL in *mapping* (token → absolute target) throughout *html*.
+
+    Targets the URL only where it sits as a quoted attribute value, in both plain
+    (``href="../a/report.py"``) and JSON-escaped (``href=\"../a/report.py\"``) form,
+    and either quote style — the same shapes :func:`relative_urls` matches. The
+    replacement is an absolute URL (no quotes/backslashes of its own), so it's valid in
+    either context; anchoring on the surrounding quotes keeps a short token from
+    matching inside an unrelated string.
+    """
+    for token, target in mapping.items():
+        for q in ('"', "'"):
+            html = html.replace(f'{q}{token}{q}', f'{q}{target}{q}')  # plain
+            html = html.replace(f'\\{q}{token}\\{q}', f'\\{q}{target}\\{q}')  # escaped-in-JSON
+    return html
 
 
 def insert_base(html: str, href: str) -> str:

--- a/src/mini/vis/__init__.py
+++ b/src/mini/vis/__init__.py
@@ -1,10 +1,12 @@
-from .nb import themed
+from .nb import Publisher, themed, use_publisher
 from .plt import use_style
 from .theme import light_dark, use_theme
 
 __all__ = [
+    'Publisher',
     'light_dark',
     'themed',
+    'use_publisher',
     'use_style',
     'use_theme',
 ]

--- a/src/mini/vis/__init__.py
+++ b/src/mini/vis/__init__.py
@@ -1,10 +1,11 @@
-from .nb import Publisher, themed, use_publisher
+from .nb import Publisher, report_bundle, themed, use_publisher
 from .plt import use_style
 from .theme import light_dark, use_theme
 
 __all__ = [
     'Publisher',
     'light_dark',
+    'report_bundle',
     'themed',
     'use_publisher',
     'use_style',

--- a/src/mini/vis/__init__.py
+++ b/src/mini/vis/__init__.py
@@ -1,13 +1,10 @@
-from .nb import Publisher, report_bundle, themed, use_publisher
+from .nb import themed
 from .plt import use_style
 from .theme import light_dark, use_theme
 
 __all__ = [
-    'Publisher',
     'light_dark',
-    'report_bundle',
     'themed',
-    'use_publisher',
     'use_style',
     'use_theme',
 ]

--- a/src/mini/vis/nb.py
+++ b/src/mini/vis/nb.py
@@ -3,29 +3,32 @@ Notebook utilities for rendering themed matplotlib figures as HTML.
 
 A report's figures are heavy (a themed plot is *two* PNGs, light and dark). Inlined
 as ``data:`` URIs they bloat the exported HTML — the bytes Git LFS used to carry.
-A :class:`Publisher` routes them through the artifact :class:`~mini.store.Store`
-instead: each PNG is ``put`` + ``publish``ed and the ``<img>`` points at its web
-URL, so the report HTML stays light enough to live in Git. Set one up once per
-report and every ``@themed`` figure externalizes with no per-figure ceremony::
+A :class:`Publisher` instead writes each blob out as a content-addressed file beside
+the report and references it by a **relative** URL, so the report HTML stays light.
+Set one up once per report and every ``@themed`` figure externalizes with no
+per-figure ceremony::
 
     # in the report's setup cell
-    from mini import LocalApparatus
-    from mini.vis import themed, use_publisher
-    use_publisher(LocalApparatus(NAME).store(), prefix=f'reports/{NAME}')
+    from mini.vis import themed, use_publisher, report_bundle
+    use_publisher(report_bundle(__file__))
 
     # in a figure cell — unchanged
     @themed(alt_text='…')
     def _plot(): ...
     mo.Html(_plot())
 
-Without a publisher (or with a local-only store that can't serve web URLs) figures
-fall back to inlining, so an offline ``./go build`` still renders.
+The relative reference is the point: the *same* HTML works both ways. Opened locally
+it resolves to the co-located ``_assets/`` files (offline, and the figures are real
+PNG files); published, ``scripts/build_site.py`` uploads those files to the HF bucket
+and inserts a single ``<base href>`` so the very same relative URLs resolve there. A
+report with no publisher inlines as self-contained ``data:`` URIs, as before.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path, PurePosixPath
 from textwrap import dedent
@@ -38,11 +41,10 @@ from collections.abc import Sequence
 
 from matplotlib.figure import Figure
 
-from mini.store import Store
 from mini.vis.plt import Stylesheet
 
 
-__all__ = ['themed', 'themed_figure_html', 'Publisher', 'use_publisher']
+__all__ = ['themed', 'themed_figure_html', 'Publisher', 'use_publisher', 'report_bundle']
 
 P = ParamSpec('P')
 R = TypeVar('R')
@@ -52,73 +54,76 @@ log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Publishing report assets to web URLs
+# Publishing report assets as files referenced by a relative URL
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class Publisher:
-    """Routes report assets (figures, data blobs) to a :class:`~mini.store.Store`'s
-    published web URLs, under a shared ``prefix``.
+    """Writes a report's heavy assets out as content-addressed files beside the
+    exported HTML, referenced by a **relative** URL.
 
-    The same content-addressed ``publish`` the store uses for any artifact, scoped
-    to a report's asset namespace. Use :meth:`png_url` for themed figures (it signals
-    a graceful inline fallback) and :meth:`asset_url` for arbitrary blobs a report's
-    JS reads — a large JSON a data-browser widget fetches, an SPA's data files.
+    Each blob is written once, keyed by its SHA-256, under ``asset_dir``
+    (conventionally ``…/__marimo__/_assets``); the reference is ``<link>/<sha><ext>``.
+    Because it's relative, the same HTML resolves to the local files when opened off
+    disk and to the HF bucket when published (a single ``<base href>`` is inserted at
+    build time — see ``scripts/build_site.py``). Use :meth:`asset_url` for any blob (a
+    JSON a data-browser widget fetches, an SPA's data files); :meth:`png_url` is the
+    figure-shaped wrapper :func:`themed` calls.
     """
 
-    store: Store | None = None
-    prefix: str = 'reports'
+    asset_dir: Path
+    link: str = '_assets'
 
-    def asset_url(self, data: bytes | Path, *, name: str) -> str | None:
-        """Publish bytes (or a file) at ``<prefix>/<name>`` and return its URL.
+    def asset_url(self, data: bytes | Path, *, name: str) -> str:
+        """Write *data* (bytes or a file) as ``<sha><ext>`` and return its relative URL.
 
-        ``None`` only when no store is configured. A web-serving backend (an HF
-        bucket) returns an ``https://`` URL the browser can fetch cross-origin; a
-        local store returns a ``file://`` URL — fine when opening the HTML straight
-        off disk, but it won't fetch from a *served* page, which is why figures
-        inline instead of relying on it (see :meth:`png_url`).
+        Content-addressed and write-once, so re-running a report reuses identical
+        bytes rather than piling up copies. *name* only supplies the extension (which
+        sets the served media type); the SHA names the file.
         """
-        if self.store is None:
-            return None
-        art = self.store.put(data, name=PurePosixPath(name).name)
-        return self.store.publish(art, f'{self.prefix}/{name}')
+        blob = bytes(data) if isinstance(data, (bytes, bytearray)) else Path(data).read_bytes()
+        filename = f'{hashlib.sha256(blob).hexdigest()}{PurePosixPath(name).suffix}'
+        dest = self.asset_dir / filename
+        if not dest.exists():  # content-addressed: identical bytes already written
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dest.with_name(f'{filename}.tmp')
+            tmp.write_bytes(blob)
+            tmp.replace(dest)  # atomic, so a concurrent reader never sees a partial file
+        return f'{self.link}/{filename}'
 
-    def png_url(self, data: bytes, *, slug: str) -> str | None:
-        """Publish a PNG and return a *web* URL, or ``None`` to inline it instead.
-
-        Narrower than :meth:`asset_url` on purpose: an ``<img>`` only benefits from
-        externalizing if the URL actually serves over the wire, so a missing store
-        *or* a non-web (``file://``) store both yield ``None`` — the caller inlines.
-        """
-        url = self.asset_url(data, name=f'{slug}.png')
-        return url if (url and url.startswith('https://')) else None
+    def png_url(self, data: bytes) -> str:
+        """Write a PNG and return its relative URL (the figure-shaped :meth:`asset_url`)."""
+        return self.asset_url(data, name='figure.png')
 
 
-def _as_publisher(publisher: Publisher | Store | None) -> Publisher | None:
-    if isinstance(publisher, Publisher):
-        return publisher
-    return Publisher(publisher) if publisher is not None else None
+def report_bundle(notebook_file: str | Path, *, link: str = '_assets') -> Publisher:
+    """A :class:`Publisher` writing assets beside a report's exported HTML.
+
+    Marimo exports ``docs/<…>/report.py`` to ``docs/<…>/__marimo__/report.html``; this
+    points assets at ``docs/<…>/__marimo__/<link>/`` so the relative ``<link>/…`` URL
+    resolves next to that HTML. Call it from the report's setup cell with ``__file__``::
+
+        use_publisher(report_bundle(__file__))
+    """
+    out_dir = Path(notebook_file).resolve().parent / '__marimo__'
+    return Publisher(asset_dir=out_dir / link, link=link)
 
 
 _default_publisher: Publisher | None = None
 
 
-def use_publisher(publisher: Publisher | Store | None, *, prefix: str | None = None) -> Publisher | None:
+def use_publisher(publisher: Publisher | None) -> Publisher | None:
     """Set the report-wide default publisher; call once in a report's setup cell.
 
-    Every ``@themed`` figure then externalizes through it with no per-figure
-    argument. Pass a :class:`~mini.store.Store` (optionally with ``prefix``) for the
-    common case, a :class:`Publisher` to reuse a configured one, or ``None`` to clear
-    it (figures inline). Returns the resolved publisher (e.g. to call
-    :meth:`~Publisher.asset_url` on it for a data blob).
+    Every ``@themed`` figure then externalizes through it with no per-figure argument.
+    Pass a :class:`Publisher` (usually from :func:`report_bundle`), or ``None`` to clear
+    it (figures inline as self-contained ``data:`` URIs). Returns it, e.g. to call
+    :meth:`~Publisher.asset_url` for a data blob.
     """
     global _default_publisher
-    pub = _as_publisher(publisher)
-    if pub is not None and prefix is not None:
-        pub = replace(pub, prefix=prefix)
-    _default_publisher = pub
-    return pub
+    _default_publisher = publisher
+    return publisher
 
 
 # ---------------------------------------------------------------------------
@@ -132,8 +137,7 @@ def themed(
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
-    publish: Publisher | Store | None = ...,
-    name: str | None = ...,
+    publish: Publisher | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
 ) -> Callable[P, str]: ...
@@ -145,8 +149,7 @@ def themed(
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
-    publish: Publisher | Store | None = ...,
-    name: str | None = ...,
+    publish: Publisher | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
 ) -> Callable[[Callable[P, Figure]], Callable[P, str]]: ...
@@ -157,8 +160,7 @@ def themed(
     *,
     alt_text: str | None = None,
     max_width: str | None = None,
-    publish: Publisher | Store | None = None,
-    name: str | None = None,
+    publish: Publisher | None = None,
     light_styles: Sequence[Stylesheet] = ('base', 'light'),
     dark_styles: Sequence[Stylesheet] = ('base', 'dark'),
 ) -> Callable[P, str] | Callable[[Callable[P, Figure]], Callable[P, str]]:
@@ -178,10 +180,9 @@ def themed(
 
         themed(plot_lr_finder, alt_text='LR finder')(lr_history, lr_config)
 
-    By default the figure is inlined as a ``data:`` URI. To externalize it to a web
-    URL (and keep the report HTML light), set a default with :func:`use_publisher`,
-    or pass ``publish=`` a :class:`Publisher`/:class:`~mini.store.Store` here. ``name``
-    gives the figure a stable URL slug; omitted, a content hash names it.
+    By default the figure is inlined as a ``data:`` URI. To externalize it (keeping the
+    report HTML light), set a default :class:`Publisher` with :func:`use_publisher`, or
+    pass ``publish=`` one here.
     """
 
     def decorator(fn: Callable[P, Figure]) -> Callable[P, str]:
@@ -196,14 +197,12 @@ def themed(
                 msg = f'{fn.__name__} returned None'
                 raise ValueError(msg)
 
-            pub = _as_publisher(publish) if publish is not None else _default_publisher
             return themed_figure_html(
                 light_fig,
                 dark_fig,
                 alt_text=alt_text,
                 max_width=max_width,
-                publish=pub,
-                name=name,
+                publish=publish if publish is not None else _default_publisher,
             )
 
         return wrapper
@@ -221,16 +220,14 @@ def themed_figure_html(
     alt_text: str | None = None,
     max_width: str | None = None,
     publish: Publisher | None = None,
-    name: str | None = None,
     **savefig_kwargs: str | int | bool,
 ) -> str:
     """Render light/dark matplotlib figures as an HTML figure element.
 
-    With ``publish`` set, each PNG is externalized to a web URL (falling back to an
-    inline ``data:`` URI when the store can't serve one); otherwise both inline.
+    With ``publish`` set, each PNG is written out and referenced by a relative URL;
+    otherwise both inline as ``data:`` URIs.
     """
     import base64
-    import hashlib
     import html
     import secrets
     from io import BytesIO
@@ -255,17 +252,13 @@ def themed_figure_html(
         plt.close(light_fig)
         plt.close(dark_fig)
 
-    # One slug base groups the light/dark pair; a content hash keeps the URL stable
-    # by content when the author doesn't name it.
-    base = name or hashlib.sha256(light_png + dark_png).hexdigest()[:12]
-
-    def _src(data: bytes, slug: str) -> str:
-        if publish is not None and (url := publish.png_url(data, slug=slug)):
-            return url
+    def _src(data: bytes) -> str:
+        if publish is not None:
+            return publish.png_url(data)
         return f'data:image/png;base64,{base64.b64encode(data).decode("ascii")}'
 
-    light_uri = _src(light_png, f'{base}-light')
-    dark_uri = _src(dark_png, f'{base}-dark')
+    light_uri = _src(light_png)
+    dark_uri = _src(dark_png)
 
     escaped_alt = html.escape(alt_text or 'Plot')
     style = f'max-width: {max_width};' if max_width is not None else ''

--- a/src/mini/vis/nb.py
+++ b/src/mini/vis/nb.py
@@ -2,14 +2,15 @@
 Notebook utilities for rendering themed matplotlib figures as HTML.
 
 A report's figures are heavy (a themed plot is *two* PNGs, light and dark). Inlined
-as ``data:`` URIs they bloat the exported HTML — the bytes Git LFS used to carry.
-A :class:`Publisher` instead writes each blob out as a content-addressed file beside
-the report and references it by a **relative** URL, so the report HTML stays light.
-Set one up once per report and every ``@themed`` figure externalizes with no
-per-figure ceremony::
+as ``data:`` URIs they bloat the exported HTML — the bytes Git LFS used to carry. A
+:class:`~mini.reports.Publisher` instead writes each blob out as a content-addressed
+file beside the report and references it by a **relative** URL, so the report HTML
+stays light. Set one up once per report and every ``@themed`` figure externalizes with
+no per-figure ceremony::
 
     # in the report's setup cell
-    from mini.vis import themed, use_publisher, report_bundle
+    from mini.vis import themed
+    from mini.reports import use_publisher, report_bundle
     use_publisher(report_bundle(__file__))
 
     # in a figure cell — unchanged
@@ -21,16 +22,14 @@ The relative reference is the point: the *same* HTML works both ways. Opened loc
 it resolves to the co-located ``_assets/`` files (offline, and the figures are real
 PNG files); published, ``scripts/build_site.py`` uploads those files to the HF bucket
 and inserts a single ``<base href>`` so the very same relative URLs resolve there. A
-report with no publisher inlines as self-contained ``data:`` URIs, as before.
+report with no publisher inlines as self-contained ``data:`` URIs, as before. The
+publisher and the bundle protocol live in :mod:`mini.reports`.
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
-from dataclasses import dataclass
 from functools import wraps
-from pathlib import Path, PurePosixPath
 from textwrap import dedent
 from typing import Callable, ParamSpec, TypeVar, overload
 
@@ -41,89 +40,17 @@ from collections.abc import Sequence
 
 from matplotlib.figure import Figure
 
+from mini.reports import Publisher, current_publisher
 from mini.vis.plt import Stylesheet
 
 
-__all__ = ['themed', 'themed_figure_html', 'Publisher', 'use_publisher', 'report_bundle']
+__all__ = ['themed', 'themed_figure_html']
 
 P = ParamSpec('P')
 R = TypeVar('R')
 
 
 log = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Publishing report assets as files referenced by a relative URL
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class Publisher:
-    """Writes a report's heavy assets out as content-addressed files beside the
-    exported HTML, referenced by a **relative** URL.
-
-    Each blob is written once, keyed by its SHA-256, under ``asset_dir``
-    (conventionally ``…/__marimo__/_assets``); the reference is ``<link>/<sha><ext>``.
-    Because it's relative, the same HTML resolves to the local files when opened off
-    disk and to the HF bucket when published (a single ``<base href>`` is inserted at
-    build time — see ``scripts/build_site.py``). Use :meth:`asset_url` for any blob (a
-    JSON a data-browser widget fetches, an SPA's data files); :meth:`png_url` is the
-    figure-shaped wrapper :func:`themed` calls.
-    """
-
-    asset_dir: Path
-    link: str = '_assets'
-
-    def asset_url(self, data: bytes | Path, *, name: str) -> str:
-        """Write *data* (bytes or a file) as ``<sha><ext>`` and return its relative URL.
-
-        Content-addressed and write-once, so re-running a report reuses identical
-        bytes rather than piling up copies. *name* only supplies the extension (which
-        sets the served media type); the SHA names the file.
-        """
-        blob = bytes(data) if isinstance(data, (bytes, bytearray)) else Path(data).read_bytes()
-        filename = f'{hashlib.sha256(blob).hexdigest()}{PurePosixPath(name).suffix}'
-        dest = self.asset_dir / filename
-        if not dest.exists():  # content-addressed: identical bytes already written
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            tmp = dest.with_name(f'{filename}.tmp')
-            tmp.write_bytes(blob)
-            tmp.replace(dest)  # atomic, so a concurrent reader never sees a partial file
-        return f'{self.link}/{filename}'
-
-    def png_url(self, data: bytes) -> str:
-        """Write a PNG and return its relative URL (the figure-shaped :meth:`asset_url`)."""
-        return self.asset_url(data, name='figure.png')
-
-
-def report_bundle(notebook_file: str | Path, *, link: str = '_assets') -> Publisher:
-    """A :class:`Publisher` writing assets beside a report's exported HTML.
-
-    Marimo exports ``docs/<…>/report.py`` to ``docs/<…>/__marimo__/report.html``; this
-    points assets at ``docs/<…>/__marimo__/<link>/`` so the relative ``<link>/…`` URL
-    resolves next to that HTML. Call it from the report's setup cell with ``__file__``::
-
-        use_publisher(report_bundle(__file__))
-    """
-    out_dir = Path(notebook_file).resolve().parent / '__marimo__'
-    return Publisher(asset_dir=out_dir / link, link=link)
-
-
-_default_publisher: Publisher | None = None
-
-
-def use_publisher(publisher: Publisher | None) -> Publisher | None:
-    """Set the report-wide default publisher; call once in a report's setup cell.
-
-    Every ``@themed`` figure then externalizes through it with no per-figure argument.
-    Pass a :class:`Publisher` (usually from :func:`report_bundle`), or ``None`` to clear
-    it (figures inline as self-contained ``data:`` URIs). Returns it, e.g. to call
-    :meth:`~Publisher.asset_url` for a data blob.
-    """
-    global _default_publisher
-    _default_publisher = publisher
-    return publisher
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +64,7 @@ def themed(
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
+    name: str | None = ...,
     publish: Publisher | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
@@ -149,6 +77,7 @@ def themed(
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
+    name: str | None = ...,
     publish: Publisher | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
@@ -160,6 +89,7 @@ def themed(
     *,
     alt_text: str | None = None,
     max_width: str | None = None,
+    name: str | None = None,
     publish: Publisher | None = None,
     light_styles: Sequence[Stylesheet] = ('base', 'light'),
     dark_styles: Sequence[Stylesheet] = ('base', 'dark'),
@@ -181,8 +111,10 @@ def themed(
         themed(plot_lr_finder, alt_text='LR finder')(lr_history, lr_config)
 
     By default the figure is inlined as a ``data:`` URI. To externalize it (keeping the
-    report HTML light), set a default :class:`Publisher` with :func:`use_publisher`, or
-    pass ``publish=`` one here.
+    report HTML light), set a default :class:`~mini.reports.Publisher` with
+    :func:`~mini.reports.use_publisher`, or pass ``publish=`` one here. *name* is the
+    externalized figure's readable basename (it ends up in the asset filename and the
+    download name); it defaults to the plot function's name.
     """
 
     def decorator(fn: Callable[P, Figure]) -> Callable[P, str]:
@@ -202,7 +134,8 @@ def themed(
                 dark_fig,
                 alt_text=alt_text,
                 max_width=max_width,
-                publish=publish if publish is not None else _default_publisher,
+                name=name or getattr(fn, '__name__', '').lstrip('_') or 'figure',
+                publish=publish if publish is not None else current_publisher(),
             )
 
         return wrapper
@@ -219,13 +152,16 @@ def themed_figure_html(
     close_fig: bool = True,
     alt_text: str | None = None,
     max_width: str | None = None,
+    name: str | None = None,
     publish: Publisher | None = None,
     **savefig_kwargs: str | int | bool,
 ) -> str:
     """Render light/dark matplotlib figures as an HTML figure element.
 
-    With ``publish`` set, each PNG is written out and referenced by a relative URL;
-    otherwise both inline as ``data:`` URIs.
+    With ``publish`` set, each PNG is written out and referenced by a relative URL
+    (named ``<name>-light.png`` / ``<name>-dark.png`` so a saved file reads sensibly);
+    otherwise both inline as ``data:`` URIs. *name* is also surfaced as a
+    ``data-asset-name`` attribute on each ``<img>`` for provenance.
     """
     import base64
     import html
@@ -252,14 +188,17 @@ def themed_figure_html(
         plt.close(light_fig)
         plt.close(dark_fig)
 
-    def _src(data: bytes) -> str:
+    asset_name = name or 'figure'
+
+    def _src(data: bytes, theme: str) -> str:
         if publish is not None:
-            return publish.png_url(data)
+            return publish.asset_url(data, name=f'{asset_name}-{theme}.png')
         return f'data:image/png;base64,{base64.b64encode(data).decode("ascii")}'
 
-    light_uri = _src(light_png)
-    dark_uri = _src(dark_png)
+    light_uri = _src(light_png, 'light')
+    dark_uri = _src(dark_png, 'dark')
 
+    escaped_name = html.escape(asset_name)
     escaped_alt = html.escape(alt_text or 'Plot')
     style = f'max-width: {max_width};' if max_width is not None else ''
     escaped_style = html.escape(style)
@@ -312,8 +251,8 @@ def themed_figure_html(
         """)
     figure_html = dedent(f"""
         <figure class="{figure_class}">
-            <img class="mini-themed-img-light" src="{light_uri}" alt="{escaped_alt}" style="{escaped_style}" />
-            <img class="mini-themed-img-dark" src="{dark_uri}" alt="{escaped_alt}" style="{escaped_style}" />
+            <img class="mini-themed-img-light" src="{light_uri}" alt="{escaped_alt}" style="{escaped_style}" data-asset-name="{escaped_name}" />
+            <img class="mini-themed-img-dark" src="{dark_uri}" alt="{escaped_alt}" style="{escaped_style}" data-asset-name="{escaped_name}" />
         </figure>
         """)
 

--- a/src/mini/vis/nb.py
+++ b/src/mini/vis/nb.py
@@ -1,11 +1,33 @@
 """
 Notebook utilities for rendering themed matplotlib figures as HTML.
+
+A report's figures are heavy (a themed plot is *two* PNGs, light and dark). Inlined
+as ``data:`` URIs they bloat the exported HTML — the bytes Git LFS used to carry.
+A :class:`Publisher` routes them through the artifact :class:`~mini.store.Store`
+instead: each PNG is ``put`` + ``publish``ed and the ``<img>`` points at its web
+URL, so the report HTML stays light enough to live in Git. Set one up once per
+report and every ``@themed`` figure externalizes with no per-figure ceremony::
+
+    # in the report's setup cell
+    from mini import LocalApparatus
+    from mini.vis import themed, use_publisher
+    use_publisher(LocalApparatus(NAME).store(), prefix=f'reports/{NAME}')
+
+    # in a figure cell — unchanged
+    @themed(alt_text='…')
+    def _plot(): ...
+    mo.Html(_plot())
+
+Without a publisher (or with a local-only store that can't serve web URLs) figures
+fall back to inlining, so an offline ``./go build`` still renders.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, replace
 from functools import wraps
+from pathlib import Path, PurePosixPath
 from textwrap import dedent
 from typing import Callable, ParamSpec, TypeVar, overload
 
@@ -16,10 +38,11 @@ from collections.abc import Sequence
 
 from matplotlib.figure import Figure
 
+from mini.store import Store
 from mini.vis.plt import Stylesheet
 
 
-__all__ = ['themed', 'themed_figure_html']
+__all__ = ['themed', 'themed_figure_html', 'Publisher', 'use_publisher']
 
 P = ParamSpec('P')
 R = TypeVar('R')
@@ -28,12 +51,89 @@ R = TypeVar('R')
 log = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Publishing report assets to web URLs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Publisher:
+    """Routes report assets (figures, data blobs) to a :class:`~mini.store.Store`'s
+    published web URLs, under a shared ``prefix``.
+
+    The same content-addressed ``publish`` the store uses for any artifact, scoped
+    to a report's asset namespace. Use :meth:`png_url` for themed figures (it signals
+    a graceful inline fallback) and :meth:`asset_url` for arbitrary blobs a report's
+    JS reads — a large JSON a data-browser widget fetches, an SPA's data files.
+    """
+
+    store: Store | None = None
+    prefix: str = 'reports'
+
+    def asset_url(self, data: bytes | Path, *, name: str) -> str | None:
+        """Publish bytes (or a file) at ``<prefix>/<name>`` and return its URL.
+
+        ``None`` only when no store is configured. A web-serving backend (an HF
+        bucket) returns an ``https://`` URL the browser can fetch cross-origin; a
+        local store returns a ``file://`` URL — fine when opening the HTML straight
+        off disk, but it won't fetch from a *served* page, which is why figures
+        inline instead of relying on it (see :meth:`png_url`).
+        """
+        if self.store is None:
+            return None
+        art = self.store.put(data, name=PurePosixPath(name).name)
+        return self.store.publish(art, f'{self.prefix}/{name}')
+
+    def png_url(self, data: bytes, *, slug: str) -> str | None:
+        """Publish a PNG and return a *web* URL, or ``None`` to inline it instead.
+
+        Narrower than :meth:`asset_url` on purpose: an ``<img>`` only benefits from
+        externalizing if the URL actually serves over the wire, so a missing store
+        *or* a non-web (``file://``) store both yield ``None`` — the caller inlines.
+        """
+        url = self.asset_url(data, name=f'{slug}.png')
+        return url if (url and url.startswith('https://')) else None
+
+
+def _as_publisher(publisher: Publisher | Store | None) -> Publisher | None:
+    if isinstance(publisher, Publisher):
+        return publisher
+    return Publisher(publisher) if publisher is not None else None
+
+
+_default_publisher: Publisher | None = None
+
+
+def use_publisher(publisher: Publisher | Store | None, *, prefix: str | None = None) -> Publisher | None:
+    """Set the report-wide default publisher; call once in a report's setup cell.
+
+    Every ``@themed`` figure then externalizes through it with no per-figure
+    argument. Pass a :class:`~mini.store.Store` (optionally with ``prefix``) for the
+    common case, a :class:`Publisher` to reuse a configured one, or ``None`` to clear
+    it (figures inline). Returns the resolved publisher (e.g. to call
+    :meth:`~Publisher.asset_url` on it for a data blob).
+    """
+    global _default_publisher
+    pub = _as_publisher(publisher)
+    if pub is not None and prefix is not None:
+        pub = replace(pub, prefix=prefix)
+    _default_publisher = pub
+    return pub
+
+
+# ---------------------------------------------------------------------------
+# Themed figures
+# ---------------------------------------------------------------------------
+
+
 @overload
 def themed(
     plot: Callable[P, Figure],
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
+    publish: Publisher | Store | None = ...,
+    name: str | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
 ) -> Callable[P, str]: ...
@@ -45,6 +145,8 @@ def themed(
     *,
     alt_text: str | None = ...,
     max_width: str | None = ...,
+    publish: Publisher | Store | None = ...,
+    name: str | None = ...,
     light_styles: Sequence[Stylesheet] = ...,
     dark_styles: Sequence[Stylesheet] = ...,
 ) -> Callable[[Callable[P, Figure]], Callable[P, str]]: ...
@@ -55,6 +157,8 @@ def themed(
     *,
     alt_text: str | None = None,
     max_width: str | None = None,
+    publish: Publisher | Store | None = None,
+    name: str | None = None,
     light_styles: Sequence[Stylesheet] = ('base', 'light'),
     dark_styles: Sequence[Stylesheet] = ('base', 'dark'),
 ) -> Callable[P, str] | Callable[[Callable[P, Figure]], Callable[P, str]]:
@@ -73,6 +177,11 @@ def themed(
         def plot(): ...
 
         themed(plot_lr_finder, alt_text='LR finder')(lr_history, lr_config)
+
+    By default the figure is inlined as a ``data:`` URI. To externalize it to a web
+    URL (and keep the report HTML light), set a default with :func:`use_publisher`,
+    or pass ``publish=`` a :class:`Publisher`/:class:`~mini.store.Store` here. ``name``
+    gives the figure a stable URL slug; omitted, a content hash names it.
     """
 
     def decorator(fn: Callable[P, Figure]) -> Callable[P, str]:
@@ -87,11 +196,14 @@ def themed(
                 msg = f'{fn.__name__} returned None'
                 raise ValueError(msg)
 
+            pub = _as_publisher(publish) if publish is not None else _default_publisher
             return themed_figure_html(
                 light_fig,
                 dark_fig,
                 alt_text=alt_text,
                 max_width=max_width,
+                publish=pub,
+                name=name,
             )
 
         return wrapper
@@ -108,10 +220,17 @@ def themed_figure_html(
     close_fig: bool = True,
     alt_text: str | None = None,
     max_width: str | None = None,
+    publish: Publisher | None = None,
+    name: str | None = None,
     **savefig_kwargs: str | int | bool,
 ) -> str:
-    """Render light/dark matplotlib figures as an HTML figure element."""
+    """Render light/dark matplotlib figures as an HTML figure element.
+
+    With ``publish`` set, each PNG is externalized to a web URL (falling back to an
+    inline ``data:`` URI when the store can't serve one); otherwise both inline.
+    """
     import base64
+    import hashlib
     import html
     import secrets
     from io import BytesIO
@@ -124,18 +243,29 @@ def themed_figure_html(
     }
     save_args = defaults | savefig_kwargs
 
-    def _to_data_uri(fig: Figure) -> str:
+    def _png_bytes(fig: Figure) -> bytes:
         img_io = BytesIO()
         fig.savefig(img_io, format='png', facecolor=fig.get_facecolor(), **save_args)  # ty:ignore[invalid-argument-type]
-        payload = base64.b64encode(img_io.getvalue()).decode('ascii')
-        return f'data:image/png;base64,{payload}'
+        return img_io.getvalue()
 
-    light_uri = _to_data_uri(light_fig)
-    dark_uri = _to_data_uri(dark_fig)
+    light_png = _png_bytes(light_fig)
+    dark_png = _png_bytes(dark_fig)
 
     if close_fig:
         plt.close(light_fig)
         plt.close(dark_fig)
+
+    # One slug base groups the light/dark pair; a content hash keeps the URL stable
+    # by content when the author doesn't name it.
+    base = name or hashlib.sha256(light_png + dark_png).hexdigest()[:12]
+
+    def _src(data: bytes, slug: str) -> str:
+        if publish is not None and (url := publish.png_url(data, slug=slug)):
+            return url
+        return f'data:image/png;base64,{base64.b64encode(data).decode("ascii")}'
+
+    light_uri = _src(light_png, f'{base}-light')
+    dark_uri = _src(dark_png, f'{base}-dark')
 
     escaped_alt = html.escape(alt_text or 'Plot')
     style = f'max-width: {max_width};' if max_width is not None else ''

--- a/tests/mini/test_experiments_e2e.py
+++ b/tests/mini/test_experiments_e2e.py
@@ -30,6 +30,17 @@ REPO = Path(__file__).resolve().parents[2]
 DEMOS = sorted(REPO.glob('docs/*/experiment.py'))
 
 
+@pytest.fixture(autouse=True)
+def _local_store_only(monkeypatch: pytest.MonkeyPatch):
+    """Exercise the *local* project store, hermetically.
+
+    These demos test orchestration + the on-disk store; an ambient ``MINI_STORE_BUCKET``
+    (a configured HF bucket) would divert their put/get to the network and break the
+    local-CAS assertions. The bucket backend has its own coverage in ``test_hf_store``.
+    """
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+
+
 def _drive(exp: Experiment, app: LocalApparatus, timeout: float = 60.0):
     """Tick the DAG to completion (launch detached work, resume on memo hits)."""
     deadline = time.monotonic() + timeout

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -1,0 +1,48 @@
+from mini.reports import insert_base, relative_urls, stray_links
+
+# Mimics a Marimo export: absolute CDN links + escaped data/asset URLs inside the JSON
+# session blob, an author markdown link, and a relative asset reference.
+SAMPLE = (
+    '<!DOCTYPE html><html><head>'
+    '<link rel="icon" href="https://cdn.jsdelivr.net/npm/x/favicon.ico" />'
+    '</head><body>'
+    '<script>{"cells":[{"outputs":[{"html":"<img src=\\"_assets/abc123.png\\" />'
+    '<a href=\\"./experiment.py\\">src</a>'
+    '<a href=\\"../acts/experiment.py\\">other</a>"}]}]}</script>'
+    '<img src="data:image/png;base64,AAAA" />'
+    '<a href="#section">jump</a>'
+    '</body></html>'
+)
+
+
+def test_relative_urls_finds_only_relative():
+    urls = set(relative_urls(SAMPLE))
+    assert urls == {'_assets/abc123.png', './experiment.py', '../acts/experiment.py'}
+    # absolute, data:, and fragment URLs are excluded
+    assert 'https://cdn.jsdelivr.net/npm/x/favicon.ico' not in urls
+    assert not any(u.startswith('data:') or u.startswith('#') for u in urls)
+
+
+def test_stray_links_flags_author_links_not_assets():
+    strays = stray_links(SAMPLE)
+    assert strays == ['../acts/experiment.py', './experiment.py']  # sorted, deduped
+    assert '_assets/abc123.png' not in strays  # the asset is allowed
+
+
+def test_stray_links_empty_when_only_assets():
+    html = '<img src="_assets/a.png"><img src=\\"_assets/b.png\\"><a href="https://x/y">x</a>'
+    assert stray_links(html) == []
+
+
+def test_insert_base_adds_one_tag_in_head():
+    out = insert_base('<html><head><meta></head><body></body></html>', 'https://h/r/name/')
+    assert out.count('<base ') == 1
+    assert '<head>\n    <base href="https://h/r/name/" />' in out
+    # base precedes the first resource so it governs it
+    assert out.index('<base') < out.index('<meta')
+
+
+def test_insert_base_only_first_head():
+    # A literal "<head>" appearing later (e.g. in escaped content) is not touched.
+    out = insert_base('<head></head><script>"\\u003chead\\u003e"</script>', 'https://h/')
+    assert out.count('<base ') == 1

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -1,4 +1,4 @@
-from mini.reports import insert_base, relative_urls, stray_links
+from mini.reports import insert_base, relative_urls, rewrite_links, stray_links
 
 # Mimics a Marimo export: absolute CDN links + escaped data/asset URLs inside the JSON
 # session blob, an author markdown link, and a relative asset reference.
@@ -32,6 +32,30 @@ def test_stray_links_flags_author_links_not_assets():
 def test_stray_links_empty_when_only_assets():
     html = '<img src="_assets/a.png"><img src=\\"_assets/b.png\\"><a href="https://x/y">x</a>'
     assert stray_links(html) == []
+
+
+def test_rewrite_links_handles_plain_and_escaped():
+    # The author links from SAMPLE, mapped to absolute targets, must be replaced in
+    # both their plain and JSON-escaped (\") forms; the asset ref is left alone.
+    mapping = {
+        './experiment.py': 'https://github.com/o/r/blob/main/docs/probe/experiment.py',
+        '../acts/experiment.py': 'https://github.com/o/r/blob/main/docs/acts/experiment.py',
+    }
+    out = rewrite_links(SAMPLE, mapping)
+    assert '\\"https://github.com/o/r/blob/main/docs/probe/experiment.py\\"' in out
+    assert '\\"https://github.com/o/r/blob/main/docs/acts/experiment.py\\"' in out
+    assert 'experiment.py\\"' not in out.replace('docs/probe/experiment.py', '').replace(
+        'docs/acts/experiment.py', ''
+    )  # no original relative token survives
+    assert '_assets/abc123.png' in out  # the asset reference is untouched
+
+
+def test_rewrite_links_only_replaces_attribute_values():
+    # A bare token sitting in text (not as a quoted attribute value) is left alone.
+    html = 'see href="a/b.py" but the word a/b.py in prose stays'
+    out = rewrite_links(html, {'a/b.py': 'https://x/a/b.html'})
+    assert 'href="https://x/a/b.html"' in out
+    assert 'the word a/b.py in prose stays' in out
 
 
 def test_insert_base_adds_one_tag_in_head():

--- a/tests/mini/vis/test_nb.py
+++ b/tests/mini/vis/test_nb.py
@@ -1,14 +1,32 @@
+from pathlib import Path
 from unittest.mock import patch
 
 from mini.vis.theme import light_dark
 import matplotlib
 import matplotlib.pyplot as plt
+import pytest
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from mini.vis.nb import themed
+from mini.store import LocalStore
+from mini.vis.nb import Publisher, themed, use_publisher
 
 matplotlib.use('Agg')
+
+
+class _WebStore(LocalStore):
+    """A LocalStore that pretends to serve over the web (https publish URLs)."""
+
+    def publish(self, art, path):  # type: ignore[override]
+        return f'https://buckets.example/resolve/published/{path}'
+
+
+@pytest.fixture(autouse=True)
+def _clear_default_publisher():
+    """Keep the module-level default from leaking between tests."""
+    use_publisher(None)
+    yield
+    use_publisher(None)
 
 
 def _dummy_plot(x: int, y: int) -> Figure:
@@ -55,3 +73,49 @@ def test_decorator_factory():
     result = plot(1)
     assert 'alt="Factory plot"' in result
     assert 'mini-themed-img-light' in result
+
+
+def test_default_inlines_as_data_uri():
+    result = themed(_dummy_plot)(1, 2)
+    assert result.count('src="data:image/png;base64,') == 2
+    assert 'https://' not in result
+
+
+def test_publish_externalizes_to_web_urls(tmp_path: Path):
+    pub = Publisher(_WebStore(tmp_path / 'store'), prefix='reports/demo')
+    result = themed(_dummy_plot, publish=pub)(1, 2)
+    # Both variants reference web URLs, not inline data, and stay grouped by slug.
+    assert 'src="data:image' not in result
+    assert 'https://buckets.example/resolve/published/reports/demo/' in result
+    assert '-light.png' in result
+    assert '-dark.png' in result
+
+
+def test_named_figure_gives_stable_slug(tmp_path: Path):
+    pub = Publisher(_WebStore(tmp_path / 'store'))
+    result = themed(_dummy_plot, publish=pub, name='loss-curve')(1, 2)
+    assert 'reports/loss-curve-light.png' in result
+    assert 'reports/loss-curve-dark.png' in result
+
+
+def test_local_store_falls_back_to_inline(tmp_path: Path):
+    # A non-web store can't serve an <img> over the wire, so figures inline.
+    pub = Publisher(LocalStore(tmp_path / 'store'))
+    result = themed(_dummy_plot, publish=pub)(1, 2)
+    assert result.count('src="data:image/png;base64,') == 2
+
+
+def test_use_publisher_default_is_picked_up(tmp_path: Path):
+    use_publisher(_WebStore(tmp_path / 'store'), prefix='reports/auto')
+    result = themed(_dummy_plot)(1, 2)  # no per-figure publish=
+    assert 'https://buckets.example/resolve/published/reports/auto/' in result
+
+
+def test_asset_url_publishes_arbitrary_bytes(tmp_path: Path):
+    pub = Publisher(_WebStore(tmp_path / 'store'), prefix='reports/demo')
+    url = pub.asset_url(b'{"hello": "world"}', name='data/points.json')
+    assert url == 'https://buckets.example/resolve/published/reports/demo/data/points.json'
+
+
+def test_asset_url_without_store_is_none():
+    assert Publisher(None).asset_url(b'x', name='a.json') is None

--- a/tests/mini/vis/test_nb.py
+++ b/tests/mini/vis/test_nb.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,17 +9,9 @@ import pytest
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from mini.store import LocalStore
-from mini.vis.nb import Publisher, themed, use_publisher
+from mini.vis.nb import Publisher, report_bundle, themed, use_publisher
 
 matplotlib.use('Agg')
-
-
-class _WebStore(LocalStore):
-    """A LocalStore that pretends to serve over the web (https publish URLs)."""
-
-    def publish(self, art, path):  # type: ignore[override]
-        return f'https://buckets.example/resolve/published/{path}'
 
 
 @pytest.fixture(autouse=True)
@@ -78,44 +71,54 @@ def test_decorator_factory():
 def test_default_inlines_as_data_uri():
     result = themed(_dummy_plot)(1, 2)
     assert result.count('src="data:image/png;base64,') == 2
-    assert 'https://' not in result
+    assert '_assets/' not in result
 
 
-def test_publish_externalizes_to_web_urls(tmp_path: Path):
-    pub = Publisher(_WebStore(tmp_path / 'store'), prefix='reports/demo')
+def test_publish_externalizes_to_relative_urls(tmp_path: Path):
+    pub = Publisher(tmp_path / '__marimo__' / '_assets')
     result = themed(_dummy_plot, publish=pub)(1, 2)
-    # Both variants reference web URLs, not inline data, and stay grouped by slug.
+    # Both variants reference relative _assets/ URLs, not inline data.
     assert 'src="data:image' not in result
-    assert 'https://buckets.example/resolve/published/reports/demo/' in result
-    assert '-light.png' in result
-    assert '-dark.png' in result
+    srcs = re.findall(r'src="([^"]+)"', result)
+    assert len(srcs) == 2
+    assert all(re.fullmatch(r'_assets/[0-9a-f]{64}\.png', s) for s in srcs), srcs
+    # …and the referenced files actually exist on disk and are valid PNGs.
+    for s in srcs:
+        f = tmp_path / '__marimo__' / s
+        assert f.exists() and f.read_bytes()[:4] == b'\x89PNG'
 
 
-def test_named_figure_gives_stable_slug(tmp_path: Path):
-    pub = Publisher(_WebStore(tmp_path / 'store'))
-    result = themed(_dummy_plot, publish=pub, name='loss-curve')(1, 2)
-    assert 'reports/loss-curve-light.png' in result
-    assert 'reports/loss-curve-dark.png' in result
+def test_distinct_light_dark_files(tmp_path: Path):
+    pub = Publisher(tmp_path / '_assets')
+    result = themed(_dummy_plot)(1, 2)  # inline (no publisher) → control
+    assert 'data:image' in result
+    out = themed(_dummy_plot, publish=pub)(1, 2)
+    srcs = set(re.findall(r'src="([^"]+)"', out))
+    assert len(srcs) == 2  # light and dark hash differently → two files
 
 
-def test_local_store_falls_back_to_inline(tmp_path: Path):
-    # A non-web store can't serve an <img> over the wire, so figures inline.
-    pub = Publisher(LocalStore(tmp_path / 'store'))
-    result = themed(_dummy_plot, publish=pub)(1, 2)
-    assert result.count('src="data:image/png;base64,') == 2
+def test_content_addressed_write_once(tmp_path: Path):
+    pub = Publisher(tmp_path)
+    u1 = pub.asset_url(b'same-bytes', name='a.json')
+    u2 = pub.asset_url(b'same-bytes', name='b.json')
+    assert u1 == u2  # identical content → identical URL, written once
+    assert len(list(tmp_path.glob('*.json'))) == 1
 
 
 def test_use_publisher_default_is_picked_up(tmp_path: Path):
-    use_publisher(_WebStore(tmp_path / 'store'), prefix='reports/auto')
+    use_publisher(Publisher(tmp_path / '_assets'))
     result = themed(_dummy_plot)(1, 2)  # no per-figure publish=
-    assert 'https://buckets.example/resolve/published/reports/auto/' in result
+    assert re.search(r'src="_assets/[0-9a-f]{64}\.png"', result)
 
 
-def test_asset_url_publishes_arbitrary_bytes(tmp_path: Path):
-    pub = Publisher(_WebStore(tmp_path / 'store'), prefix='reports/demo')
-    url = pub.asset_url(b'{"hello": "world"}', name='data/points.json')
-    assert url == 'https://buckets.example/resolve/published/reports/demo/data/points.json'
+def test_asset_url_writes_file_and_returns_relative_url(tmp_path: Path):
+    pub = Publisher(tmp_path / '_assets')
+    url = pub.asset_url(b'{"hello": "world"}', name='points.json')
+    assert re.fullmatch(r'_assets/[0-9a-f]{64}\.json', url)
+    assert (tmp_path / url).read_bytes() == b'{"hello": "world"}'
 
 
-def test_asset_url_without_store_is_none():
-    assert Publisher(None).asset_url(b'x', name='a.json') is None
+def test_report_bundle_targets_marimo_dir():
+    pub = report_bundle('/proj/docs/probe/report.py')
+    assert pub.asset_dir == Path('/proj/docs/probe/__marimo__/_assets')
+    assert pub.link == '_assets'

--- a/tests/mini/vis/test_nb.py
+++ b/tests/mini/vis/test_nb.py
@@ -9,7 +9,8 @@ import pytest
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from mini.vis.nb import Publisher, report_bundle, themed, use_publisher
+from mini.reports import Publisher, report_bundle, use_publisher
+from mini.vis.nb import themed
 
 matplotlib.use('Agg')
 
@@ -81,11 +82,22 @@ def test_publish_externalizes_to_relative_urls(tmp_path: Path):
     assert 'src="data:image' not in result
     srcs = re.findall(r'src="([^"]+)"', result)
     assert len(srcs) == 2
-    assert all(re.fullmatch(r'_assets/[0-9a-f]{64}\.png', s) for s in srcs), srcs
+    # Path is <sha>/<readable leaf>: the sha addresses the content, the leaf (derived
+    # from the plot fn name) is what a "Save as" suggests.
+    assert all(re.fullmatch(r'_assets/[0-9a-f]{64}/dummy_plot-(light|dark)\.png', s) for s in srcs), srcs
     # …and the referenced files actually exist on disk and are valid PNGs.
     for s in srcs:
         f = tmp_path / '__marimo__' / s
         assert f.exists() and f.read_bytes()[:4] == b'\x89PNG'
+
+
+def test_name_overrides_the_asset_leaf(tmp_path: Path):
+    pub = Publisher(tmp_path / '_assets')
+    result = themed(_dummy_plot, name='loss-curve', publish=pub)(1, 2)
+    srcs = re.findall(r'src="([^"]+)"', result)
+    assert all(re.fullmatch(r'_assets/[0-9a-f]{64}/loss-curve-(light|dark)\.png', s) for s in srcs), srcs
+    # The readable name is also surfaced for provenance.
+    assert result.count('data-asset-name="loss-curve"') == 2
 
 
 def test_distinct_light_dark_files(tmp_path: Path):
@@ -99,22 +111,23 @@ def test_distinct_light_dark_files(tmp_path: Path):
 
 def test_content_addressed_write_once(tmp_path: Path):
     pub = Publisher(tmp_path)
-    u1 = pub.asset_url(b'same-bytes', name='a.json')
-    u2 = pub.asset_url(b'same-bytes', name='b.json')
-    assert u1 == u2  # identical content → identical URL, written once
-    assert len(list(tmp_path.glob('*.json'))) == 1
+    u1 = pub.asset_url(b'same-bytes', name='pts.json')
+    u2 = pub.asset_url(b'same-bytes', name='pts.json')
+    assert u1 == u2  # identical content + name → identical URL, written once
+    assert len(list(tmp_path.rglob('*.json'))) == 1
 
 
 def test_use_publisher_default_is_picked_up(tmp_path: Path):
     use_publisher(Publisher(tmp_path / '_assets'))
     result = themed(_dummy_plot)(1, 2)  # no per-figure publish=
-    assert re.search(r'src="_assets/[0-9a-f]{64}\.png"', result)
+    assert re.search(r'src="_assets/[0-9a-f]{64}/dummy_plot-light\.png"', result)
 
 
 def test_asset_url_writes_file_and_returns_relative_url(tmp_path: Path):
     pub = Publisher(tmp_path / '_assets')
     url = pub.asset_url(b'{"hello": "world"}', name='points.json')
-    assert re.fullmatch(r'_assets/[0-9a-f]{64}\.json', url)
+    # <sha>/<name>: addressed by content, named for a readable download.
+    assert re.fullmatch(r'_assets/[0-9a-f]{64}/points\.json', url)
     assert (tmp_path / url).read_bytes() == b'{"hello": "world"}'
 
 

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -1,0 +1,71 @@
+"""Tests for the static-site builder's author-link resolver (pure policy)."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    'build_site', Path(__file__).resolve().parent.parent / 'scripts' / 'build_site.py'
+)
+assert _SPEC and _SPEC.loader
+build_site = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(build_site)
+
+
+@pytest.fixture
+def resolver() -> 'build_site.LinkResolver':
+    return build_site.LinkResolver(
+        render_map={
+            'probe/report.py': 'probe/report.html',
+            'acts/report.py': 'acts/report.html',
+            'guide.md': 'guide.html',
+        },
+        source_files=frozenset({'probe/experiment.py', 'acts/experiment.py', 'probe/report.py'}),
+        site_base='https://o.github.io/r/',
+        source_base='https://github.com/o/r/blob/main/',
+    )
+
+
+def test_rendered_link_is_absolute_pages_url_when_externalizing(resolver):
+    got = resolver.resolve('../acts/report.py', from_dir='probe', externalizing=True)
+    assert got == 'https://o.github.io/r/acts/report.html'
+
+
+def test_rendered_link_stays_relative_when_localizing(resolver):
+    # No <base> locally, so a relative .html link navigates within _site.
+    got = resolver.resolve('../acts/report.py', from_dir='probe', externalizing=False)
+    assert got == '../acts/report.html'
+
+
+def test_source_file_resolves_to_github(resolver):
+    got = resolver.resolve('./experiment.py', from_dir='probe', externalizing=True)
+    assert got == 'https://github.com/o/r/blob/main/docs/probe/experiment.py'
+
+
+def test_fragment_is_preserved(resolver):
+    got = resolver.resolve('../acts/report.py#cell-3', from_dir='probe', externalizing=True)
+    assert got == 'https://o.github.io/r/acts/report.html#cell-3'
+
+
+def test_external_and_anchored_links_are_left_alone(resolver):
+    assert resolver.resolve('https://example.com', from_dir='probe', externalizing=True) is None
+    assert resolver.resolve('#section', from_dir='probe', externalizing=True) is None
+    assert resolver.resolve('/absolute', from_dir='probe', externalizing=True) is None
+
+
+def test_unknown_target_is_unresolved(resolver):
+    assert resolver.resolve('./nope.py', from_dir='probe', externalizing=True) is None
+
+
+def test_missing_bases_degrade_to_unresolved():
+    r = build_site.LinkResolver(
+        render_map={'acts/report.py': 'acts/report.html'},
+        source_files=frozenset({'probe/experiment.py'}),
+        site_base=None,
+        source_base=None,
+    )
+    # Externalizing needs an absolute target; with no base it can't make one.
+    assert r.resolve('../acts/report.py', from_dir='probe', externalizing=True) is None
+    # …but localize still keeps rendered links relative (no base needed).
+    assert r.resolve('../acts/report.py', from_dir='probe', externalizing=False) == '../acts/report.html'


### PR DESCRIPTION
Sets up publishing reports through HFStore instead of Git LFS, so an experiment can be run and its results published end-to-end by humans and AI. This PR lands the **architecture and the helper**; migrating the five existing reports is a follow-up.

## The model

A report is a bundle: HTML plus content-addressed assets written to a sibling `_assets/` dir and referenced by a **relative** URL `_assets/<sha>/<name>` (the sha addresses the content; the readable `name` is the leaf, so a saved file gets a sensible filename). The same HTML works two ways via one `<base>`: opened locally it resolves to the co-located files; published, `build_site` uploads `_assets/` to the bucket and inserts the tag so the same URLs resolve there. No per-URL rewriting (the URLs live inside Marimo's escaped session JSON), and it covers dynamic `fetch()` too.

## What's here

- `mini.reports` — the whole bundle protocol in one module: `Publisher` + `report_bundle(__file__)` + `use_publisher` on the produce side (externalize `themed` figures, and `asset_url` for any data blob, to relative `_assets/<sha>/<name>`; no publisher → inline as before), and `insert_base` + `stray_links` + `rewrite_links` on the publish side.
- `mini.vis.themed` — calls the publisher when one is set; gained a `name=` override and emits `data-asset-name` for provenance.
- `scripts/build_site.py` — per report: localize (copy assets) vs externalize (upload + `<base>`); **resolves author-written relative links** to their published target (rendered page, else GitHub source; warns on the unplaceable).
- `docs/probe/report.py` converted as the worked example — uses relative source links, `_assets/` gitignored.
- `research/reports-hfstore-migration.md` — the decided design + findings.
- mi-ni skill docs updated (vis.md / storage.md / authoring.md) to match.

## Verified

End-to-end against the live bucket: a demo export drops its figures to relative `_assets/<sha>/<name>.png`; localize resolves them in `_site`; externalize uploads and the same refs resolve to fetchable `image/png` via the inserted base tag. Marimo exports carry no fragment anchors / no incidental relative URLs (so `<base>` is safe); HF reflects `Origin` for cross-origin fetch. Full suite + lint/format/types clean.

## Design-review updates (this revision)

Resolving the threads on the first pass:

- **Publisher moved out of `vis` into `mini.reports`** — it handles arbitrary blobs, not just figures, so it belongs with the publish-side ops, not in visualization. Docs moved to `storage.md` accordingly.
- **Readable asset names** — paths are now `_assets/<sha>/<name>`: content-addressed *and* a sensible download name. The HF bucket exposes no per-object `Content-Disposition`, so the name has to live in the URL; `name=` is kept (now load-bearing) rather than narrowed to `ext`, and figures also carry `data-asset-name`.
- **Author links resolved, not hand-written** — `build_site` rewrites relative nav/source links to their published target, so reports link `./experiment.py` / `../acts/report.py` and the build does the rest (absolute Pages/GitHub under `<base>`, relative `.html` locally). Roots derive from the git remote; `MINI_SITE_URL` / `MINI_SOURCE_URL` override.
- Local-store e2e tests isolated from an ambient `MINI_STORE_BUCKET`.

## Deferred

- Re-export the 5 reports with a publisher and commit the light HTML.
- Drop the LFS rules (`.gitattributes`) and `lfs: true` (`publish-docs.yml`).
- A Pages index/gallery; purge old LFS blobs from history.
- Whether to keep committing the exported HTML at all (vs. a dedicated build dir) — settle when migrating the reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)