### PR TITLE
Exclude source-only example notebooks (gpt.py) from the published report set

### DIFF
--- a/docs/gpt.py
+++ b/docs/gpt.py
@@ -31,6 +31,12 @@ with app.setup(hide_code=True):
 
     log = logging.getLogger('notebook')
 
+    # mini:source-only — this notebook trains inline (a full run on every execution), so
+    # it doesn't fit the read-from-store report model the site build assumes. It's excluded
+    # from the published report set: the build never runs it, and links to it (e.g. from
+    # docs/index.md) resolve to its GitHub source rather than a rendered page. Run it
+    # interactively with `./go open docs/gpt.py` (pick the Modal apparatus for the GPU).
+
     # Externalize every themed figure to a file beside the exported HTML, referenced
     # by a relative URL — keeps the report light, and `build_site` repoints those URLs
     # at the bucket (one <base> tag) when publishing. No publisher → figures inline.

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -20,7 +20,7 @@ from pathlib import Path, PurePosixPath
 
 import markdown as md_lib
 
-from mini.reports import export_dir, export_key, insert_base, rewrite_links, stray_links
+from mini.reports import export_dir, export_key, insert_base, report_notebooks, rewrite_links, stray_links
 
 WORKSPACE_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DIR = WORKSPACE_ROOT / '_site'
@@ -33,15 +33,6 @@ ASSET_LINK = '_assets'
 # Source suffixes that the build renders into a report page (so an author link to one
 # resolves to the rendered result, not the dead source file).
 _RENDERED_SUFFIXES = ('.py', '.ipynb', '.md')
-
-
-def report_notebooks(docs: Path) -> list[Path]:
-    """Every Marimo report notebook under *docs* (a ``.py`` that declares ``marimo.App(``).
-
-    The notebooks are the only source of truth for the report set — a report is on the
-    site iff its ``.py`` is in the repo and its bundle is synced/exported.
-    """
-    return sorted(p for p in docs.rglob('*.py') if 'marimo.App(' in p.read_text('utf-8', errors='ignore'))
 
 
 def prepare_dirs():

--- a/scripts/export_reports.py
+++ b/scripts/export_reports.py
@@ -18,17 +18,29 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))  # so `import clean_docs` (sibling) works
 
 from clean_docs import clean_html  # noqa: E402
-from mini.reports import export_dir, export_key  # noqa: E402
+from mini.reports import export_dir, export_key, is_report_notebook, report_notebooks  # noqa: E402
 
 ROOT = Path(__file__).parent.parent.resolve()
 DOCS = ROOT / 'docs'
 
 
-def report_notebooks(paths: list[str]) -> list[Path]:
-    """The notebooks to export — the given ones, or every report under ``docs/``."""
-    if paths:
-        return [Path(p).resolve() for p in paths]
-    return sorted(p for p in DOCS.rglob('*.py') if 'marimo.App(' in p.read_text('utf-8', errors='ignore'))
+def notebooks_to_export(paths: list[str]) -> list[Path]:
+    """The report notebooks to export — the given ones, or every report under ``docs/``.
+
+    Source-only example notebooks (``# mini:source-only``, e.g. ``docs/gpt.py``) are
+    skipped even when named explicitly: the site links to their GitHub source rather than
+    running them, so exporting one (which re-runs its inline compute) is never intended.
+    """
+    if not paths:
+        return report_notebooks(DOCS)
+    keep = []
+    for p in paths:
+        path = Path(p).resolve()
+        if is_report_notebook(path):
+            keep.append(path)
+        else:
+            print(f'  skip {path.name}: source-only example, not a rendered report — open it with `./go open`')
+    return keep
 
 
 def export_one(nb: Path) -> Path:
@@ -55,7 +67,7 @@ def main() -> None:
     ap.add_argument('notebooks', nargs='*', help='report notebooks (default: all under docs/)')
     args = ap.parse_args()
 
-    nbs = report_notebooks(args.notebooks)
+    nbs = notebooks_to_export(args.notebooks)
     if not nbs:
         sys.exit('No report notebooks found under docs/.')
 

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -44,6 +44,9 @@ __all__ = [
     'report_bundle',
     'export_key',
     'export_dir',
+    'is_report_notebook',
+    'report_notebooks',
+    'SOURCE_ONLY_MARKER',
     'use_publisher',
     'current_publisher',
     'relative_urls',
@@ -155,6 +158,39 @@ def export_dir(notebook_file: str | Path) -> Path:
     """
     p = Path(notebook_file).resolve()
     return _project_root(p) / '.mini' / 'exports' / export_key(p)
+
+
+# A docs notebook carrying this marker is a source-only *example*, not a rendered
+# report: the build skips it (never runs its inline compute) and links to it resolve
+# to its GitHub source instead of a site page. For notebooks that don't fit the
+# read-from-store report model — e.g. ``docs/gpt.py`` trains inline on every run, so
+# exporting it would re-run the whole experiment. Put it in a cell the notebook tool
+# preserves (e.g. the setup block), since the text is matched literally.
+SOURCE_ONLY_MARKER = 'mini:source-only'
+
+
+def is_report_notebook(path: str | Path) -> bool:
+    """Whether *path* is a Marimo report the site renders.
+
+    A report is a ``.py`` that declares ``marimo.App(`` and is *not* flagged
+    ``# mini:source-only`` (:data:`SOURCE_ONLY_MARKER`): the marker opts a notebook out
+    of the published set, so the build neither runs nor renders it and links to it fall
+    back to its GitHub source. The notebooks are the only source of truth for the report
+    set — a report is on the site iff its ``.py`` is in the repo and its bundle is synced.
+    """
+    p = Path(path)
+    if p.suffix != '.py':
+        return False
+    try:
+        text = p.read_text('utf-8', errors='ignore')
+    except OSError:
+        return False
+    return 'marimo.App(' in text and SOURCE_ONLY_MARKER not in text
+
+
+def report_notebooks(docs: str | Path) -> list[Path]:
+    """Every Marimo report notebook under *docs* (sorted); see :func:`is_report_notebook`."""
+    return sorted(p for p in Path(docs).rglob('*.py') if is_report_notebook(p))
 
 
 def report_bundle(notebook_file: str | Path, *, link: str = '_assets') -> Publisher:

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -1,4 +1,12 @@
-from mini.reports import insert_base, relative_urls, rewrite_links, stray_links
+from mini.reports import (
+    SOURCE_ONLY_MARKER,
+    insert_base,
+    is_report_notebook,
+    relative_urls,
+    report_notebooks,
+    rewrite_links,
+    stray_links,
+)
 
 # Mimics a Marimo export: absolute CDN links + escaped data/asset URLs inside the JSON
 # session blob, an author markdown link, and a relative asset reference.
@@ -70,3 +78,36 @@ def test_insert_base_only_first_head():
     # A literal "<head>" appearing later (e.g. in escaped content) is not touched.
     out = insert_base('<head></head><script>"\\u003chead\\u003e"</script>', 'https://h/')
     assert out.count('<base ') == 1
+
+
+_APP = 'import marimo\napp = marimo.App()\n'
+
+
+def test_is_report_notebook_detects_marimo_app(tmp_path):
+    nb = tmp_path / 'report.py'
+    nb.write_text(_APP)
+    assert is_report_notebook(nb)
+
+
+def test_is_report_notebook_excludes_non_app_and_non_py(tmp_path):
+    plain = tmp_path / 'mod.py'
+    plain.write_text('x = 1\n')
+    assert not is_report_notebook(plain)
+    assert not is_report_notebook(tmp_path / 'notes.md')  # non-.py
+    assert not is_report_notebook(tmp_path / 'missing.py')  # absent
+
+
+def test_source_only_marker_opts_out(tmp_path):
+    nb = tmp_path / 'example.py'
+    nb.write_text(f'import marimo\n# {SOURCE_ONLY_MARKER} — heavy inline compute\napp = marimo.App()\n')
+    assert not is_report_notebook(nb)
+
+
+def test_report_notebooks_skips_source_only(tmp_path):
+    (tmp_path / 'report.py').write_text(_APP)
+    (tmp_path / 'sub').mkdir()
+    (tmp_path / 'sub' / 'nested.py').write_text(_APP)
+    (tmp_path / 'example.py').write_text(f'# {SOURCE_ONLY_MARKER}\n{_APP}')
+    (tmp_path / 'plain.py').write_text('x = 1\n')
+    found = {p.relative_to(tmp_path).as_posix() for p in report_notebooks(tmp_path)}
+    assert found == {'report.py', 'sub/nested.py'}

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -102,6 +102,22 @@ def test_unknown_target_is_unresolved(resolver):
     assert resolver.resolve('./nope.py', from_dir='probe', out_dir='probe/report', externalizing=True) is None
 
 
+def test_source_only_report_link_resolves_to_github():
+    # A source-only example (e.g. gpt.py) is absent from render_map but still a file under
+    # docs/, so a link to it (as from docs/index.md) falls through to the GitHub source
+    # rather than a rendered page that would never exist. Markdown resolves in localize mode.
+    r = build_site.LinkResolver(
+        render_map={'pipeline/report.py': 'pipeline/report/index.html'},
+        source_files=frozenset({'gpt.py', 'pipeline/report.py'}),
+        site_base='https://o.github.io/r/',
+        source_base='https://github.com/o/r/blob/main/',
+    )
+    assert (
+        r.resolve('./gpt.py', from_dir='', out_dir='', externalizing=False)
+        == 'https://github.com/o/r/blob/main/docs/gpt.py'
+    )
+
+
 def test_missing_bases_degrade_to_unresolved():
     r = build_site.LinkResolver(
         render_map={'acts/report.py': 'acts/report/index.html'},


### PR DESCRIPTION
## Description

Stacked on top of #30. While exercising the reworked site-export pipeline, `docs/gpt.py` turned out not to fit the export model the other reports use.

The pipeline assumes a report is **cheap to run headlessly** — the model is "the experiment writes results to the store; the report only reads + renders" (`gpt-sweep`, `pipeline`, `probe` all follow this). `gpt.py` breaks it: it trains **inline** (`app.arun` → download → LR finder → a full 100-epoch run → generate) on every execution, and `marimo export html` *runs the notebook*. The export call passes no CLI args, so even though the notebook can target Modal interactively, export always falls back to the **local** apparatus — i.e. `./go publish docs/gpt.py` would attempt a 100-epoch training on CPU. It also left a dead link: `docs/index.md` links every report, so an unpublished `gpt.py` resolved to a `gpt/index.html` that never exists.

This marks `gpt.py` as a **source-only example** so the site links to its GitHub source instead of rendering it:

- Add a `# mini:source-only` marker and centralize the report-set predicate as `is_report_notebook` / `report_notebooks` in `mini.reports` (it was duplicated in `build_site.py` and `export_reports.py`).
- A marked notebook is dropped from the report set, so the build never runs it. Because `source_files` is computed from *all* `docs/` files independently of `render_map`, links to it fall through the **existing** GitHub-source branch — no new resolver logic.
- Mark `docs/gpt.py`. `export_reports.py` also skips a source-only notebook passed explicitly (so it can't be re-run by accident).

Verified end-to-end against the `z0u/mi-ni-store` bucket: published the 6 read/render reports, ran the CI-style externalize build (each report gets a `<base>` at `exports/<key>/`, relative `_assets/` repointed there, author links rewritten to absolute GitHub source), and confirmed a published figure resolves to a live 200 on the bucket CDN. The landing page now links the nanoGPT demo at `https://github.com/z0u/mi-ni/blob/main/docs/gpt.py`.

Note: the three data-reports currently render as "no results yet" placeholders because their experiments haven't been run in this environment — a data-availability matter, not a pipeline issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qsz4nSqz4Q6TShCjyu16gQ)_