### PR TITLE
Publish device-themed reports at clean directory URLs

### DIFF
--- a/.agents/skills/mi-ni/references/apparatus.md
+++ b/.agents/skills/mi-ni/references/apparatus.md
@@ -48,13 +48,13 @@ app_type = mo.cli_args().get('app', 'local')   # a marimo radio in edit mode; a 
 app = ModalApparatus('demo').w(gpu='L4') if app_type == 'modal' else LocalApparatus('demo')
 ```
 
-Export it headless with `./go run`, passing notebook options after a `--`:
+Export it headless with `./go export`, passing notebook options after a `--`:
 
 ```bash
-./go run docs/gpt.py -- --app=modal --arch=ngpt
+./go export docs/gpt.py -- --app=modal --arch=ngpt
 ```
 
-The `--` delimits notebook options from `./go`'s own args (and `./go` forwards them to `marimo export`). It's optional — `./go run docs/gpt.py --app=modal` also works — but explicit is clearer.
+The `--` delimits notebook options from `./go`'s own args (and `./go` forwards them to `marimo export`). It's optional — `./go export docs/gpt.py --app=modal` also works — but explicit is clearer.
 
 **Syntax gotcha:** the options are flags — marimo's `cli_args()` only parses `--key=value` or `--key value`. A bare `key=value` parses to *nothing*, so the notebook silently falls back to its default (here `local`) with no error. Confirm which backend actually ran from the logs — a Modal run prints `Creating Modal image …` then `Running … on Modal`; a local one prints `Running … locally`.
 

--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -150,7 +150,7 @@ exports each report to `.mini/exports/<key>/` and mirrors that bundle to the buc
 token). `scripts/build_site.py` (read-only; CI) then *pulls* each synced bundle, resolves
 author links against the repo, and inserts one `<base href="…/exports/<key>/">` in the
 `<head>` so the relative `_assets/…` URLs resolve at the bucket — no per-URL rewriting,
-no bucket writes. The same HTML opened locally (after `./go run`, which exports the
+no bucket writes. The same HTML opened locally (after `./go export`, which exports the
 bundle) resolves `_assets/…` to the co-located files (offline; real PNGs), because the
 build *localizes* when there's no bucket. Each report is one independently syncable
 bundle, served at `<key>/`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ def _loss_chart() -> plt.Figure: ...
 ```
 
 ```bash
-./go run     docs/pipeline/report.py   # export the bundle locally (offline preview)
+./go export  docs/pipeline/report.py   # export the bundle locally (offline preview)
 ./go publish docs/pipeline/report.py   # export + mirror to the bucket (needs ./go auth)
 ./go serve                             # build the static site and serve it
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ HF bucket under `exports/<key>/`, where `<key>` is the notebook's docs-relative 
 without suffix (`docs/getting_started.py` → `getting_started`, `docs/foo/bar.py` →
 `foo/bar`). `./go build` then assembles `_site/` from the synced bundles, serving each
 report at `_site/<key>/index.html` (URL `<key>/`). With no bucket, the build *localizes*
-from `.mini/exports/` (produced by `./go run`) so it works offline.
+from `.mini/exports/` (produced by `./go export`) so it works offline.
 
 **Markdown files** (`.md`) are converted to HTML and written to `_site/` at the
 same relative path. Links to a report's `.py` are automatically rewritten to its

--- a/go
+++ b/go
@@ -47,7 +47,9 @@ case "${1:-all}" in
             "$SCRIPT_DIR/check.sh" --lint --format --typecheck --test
         fi
         ;;
-    r|run)
+    e|export|r|run)
+        # `run` is a deprecated alias: it collides with `mini run` (which executes
+        # compute) whereas this only exports a static bundle. Prefer `export`.
         shift
         if is_marimo_notebook "${1:-}"; then
             # Export the report to its bundle (.mini/exports/<key>/); preview via ./go build.
@@ -73,7 +75,9 @@ case "${1:-all}" in
         shift
         uv run "$SCRIPT_DIR/build_site.py" "$@"
         ;;
-    clean)
+    scrub|clean)
+        # `clean` is a deprecated alias: in most build tools it deletes outputs, but
+        # this scrubs terminal control sequences and redacts Modal URLs. Prefer `scrub`.
         shift
         "$SCRIPT_DIR/clean_docs.py" "$@"
         ;;
@@ -84,19 +88,20 @@ case "${1:-all}" in
     *)
         # Important: heredoc indented with tab characters.
         cat <<-EOF 1>&2
-			Usage: $0 {check|lint|format|types|tests|run|open|publish|build|clean|serve}
+			Usage: $0 {check|lint|format|types|tests|export|open|publish|build|scrub|serve}
 			  install:           install dependencies (uv sync) and git hooks
 			  check  [...args]:  run all checks in parallel (--lint --format --typecheck --test --fix)
 			  format [...args]:  format code (ruff format)
 			  lint   [...args]:  run linters (ruff check)
 			  types  [...args]:  check types (ty)
 			  tests  [...args]:  run tests (pytest)
-			  run    [...args]:  export a Marimo report to its bundle, or run anything else through uv
+			  export [...args]:  export a Marimo report to its bundle, or run anything else through uv
 			  open   [...args]:  open a Marimo notebook in Marimo, or anything else in \$EDITOR
 			  publish [...nbs]:  export reports and mirror their bundles to the HF bucket
 			  build  [...args]:  build the static site (from synced bundles, or local for offline)
-			  clean  [...args]:  clean Marimo HTML/session output (apply control chars)
+			  scrub  [...args]:  scrub terminal control sequences / redact Modal URLs from Marimo HTML
 			  serve:             build and serve at http://localhost:8000
+			  (aliases: \`run\`→\`export\`, \`clean\`→\`scrub\` — deprecated)
 			EOF
         exit 1
         ;;

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -7,7 +7,7 @@ the bucket under ``exports/<key>/``. This build is the deterministic, read-only 
 it pulls each synced bundle, resolves author links against the *repo*, inserts one
 ``<base>`` pointing at the bucket, and writes ``_site/<key>/index.html``. With no
 bucket it *localizes* instead — reads the bundles from ``.mini/exports/`` (produced by
-``./go run``) and copies their assets beside the HTML so the site works offline.
+``./go export``) and copies their assets beside the HTML so the site works offline.
 """
 
 import os
@@ -20,7 +20,15 @@ from pathlib import Path, PurePosixPath
 
 import markdown as md_lib
 
-from mini.reports import export_dir, export_key, insert_base, report_notebooks, rewrite_links, stray_links
+from mini.reports import (
+    export_dir,
+    export_key,
+    insert_base,
+    report_notebooks,
+    rewrite_links,
+    set_theme,
+    stray_links,
+)
 
 WORKSPACE_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DIR = WORKSPACE_ROOT / '_site'
@@ -65,6 +73,16 @@ def _resolve_store():
 # ---------------------------------------------------------------------------
 
 _ANCHORED = re.compile(r'(?:[a-z][a-z0-9+.\-]*:|//|/|#)', re.IGNORECASE)
+
+
+def _strip_index(url: str) -> str:
+    """Drop a trailing ``index.html`` so a report reads ``<key>/`` not ``<key>/index.html``.
+
+    GitHub Pages serves the directory form, and it's the nicer canonical/shareable URL.
+    Operates before any ``#fragment`` and leaves non-index pages (``foo.html``) untouched.
+    Used only when publishing — offline (``file://``) navigation keeps the explicit file.
+    """
+    return re.sub(r'(^|/)index\.html(?=$|#)', r'\1', url)
 
 
 def _repo_slug() -> str | None:
@@ -159,7 +177,7 @@ class LinkResolver:
         if norm in self.render_map:
             out = self.render_map[norm]
             if externalizing:
-                return None if self.site_base is None else f'{self.site_base}{out}{frag}'
+                return None if self.site_base is None else f'{self.site_base}{_strip_index(out)}{frag}'
             # localize: keep it relative, resolved from where this page renders (out_dir)
             rel = os.path.relpath(out, out_dir or '.')
             return f'{PurePosixPath(rel).as_posix()}{frag}'
@@ -202,12 +220,13 @@ def build_reports(links: LinkResolver, store, externalizing: bool):
             else:
                 bundle = export_dir(nb)
                 if not (bundle / 'index.html').exists():
-                    print(f'  ! {key}: not exported locally — run `./go run {nb_rel}` (skipping)')
+                    print(f'  ! {key}: not exported locally — run `./go export {nb_rel}` (skipping)')
                     continue
                 base_href = None
 
             html = (bundle / 'index.html').read_text('utf-8')
             html = _resolve_html_links(html, links, from_dir=from_dir, out_dir=key, externalizing=externalizing)
+            html = set_theme(html)  # follow the visitor's device, not the exporter's setting
             if base_href:
                 html = insert_base(html, base_href)
             dest = SITE_DIR / key / 'index.html'
@@ -266,23 +285,27 @@ def copy_md_stylesheet():
     print(f'  {css_src.relative_to(WORKSPACE_ROOT)} -> {css_dest.relative_to(WORKSPACE_ROOT)}')
 
 
-def _rewrite_md_links(text: str, links: LinkResolver, *, from_dir: str) -> str:
+def _rewrite_md_links(text: str, links: LinkResolver, *, from_dir: str, pretty: bool) -> str:
     """Resolve relative Markdown link targets (``](./experiment.py)``) before conversion.
 
     Markdown pages never carry an asset ``<base>``, so they're resolved in *localize*
     mode: a rendered target stays a relative link (clickable offline), a source file
-    becomes an absolute GitHub link, and anything else is left untouched.
+    becomes an absolute GitHub link, and anything else is left untouched. When publishing
+    (``pretty``), a report link drops its ``index.html`` so it reads ``<key>/``; offline
+    builds keep the explicit file so ``file://`` navigation still works.
     """
 
     def repl(m: re.Match) -> str:
         token = m.group(1)
         target = links.resolve(token, from_dir=from_dir, out_dir=from_dir, externalizing=False)
-        return f']({target})' if target is not None else m.group(0)
+        if target is None:
+            return m.group(0)
+        return f']({_strip_index(target) if pretty else target})'
 
     return re.sub(r'\]\(([^)\s]+)\)', repl, text)
 
 
-def convert_markdown(links: LinkResolver):
+def convert_markdown(links: LinkResolver, externalizing: bool):
     """Convert all .md files in docs/ (except README.md) to .html in _site/."""
     print('Converting Markdown...')
     skip = {'README.md'}
@@ -294,7 +317,7 @@ def convert_markdown(links: LinkResolver):
         dest.parent.mkdir(parents=True, exist_ok=True)
         from_dir = md_file.parent.relative_to(DOCS_DIR).as_posix()
         from_dir = '' if from_dir == '.' else from_dir
-        text = _rewrite_md_links(md_file.read_text('utf-8'), links, from_dir=from_dir)
+        text = _rewrite_md_links(md_file.read_text('utf-8'), links, from_dir=from_dir, pretty=externalizing)
         body = md_lib.markdown(text, extensions=['extra'])
         title_match = re.search(r'^#\s+(.+)$', text, re.MULTILINE)
         title = title_match.group(1).strip() if title_match else md_file.stem
@@ -328,7 +351,7 @@ def main():
     build_reports(links, store, externalizing)
     copy_assets()
     copy_md_stylesheet()
-    convert_markdown(links)
+    convert_markdown(links, externalizing)
     add_nojekyll()
     print(f'\nSite written to {SITE_DIR.relative_to(WORKSPACE_ROOT)}/')
 

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -288,14 +288,51 @@ def insert_base(html: str, href: str) -> str:
 # (no nested objects), so ``[^{}]*?`` stays within it; ``count=1`` guards the rest.
 _DISPLAY_THEME = re.compile(r'("display"\s*:\s*\{[^{}]*?"theme"\s*:\s*")(?:light|dark|system)(")')
 
+# What the document declares to the browser, so the UA paints its chrome (the canvas
+# behind the page, scrollbars, form controls) in the right scheme from the very first
+# paint — before any stylesheet or script runs.
+_COLOR_SCHEME = {'system': 'light dark', 'light': 'light', 'dark': 'dark'}
+
+# Runs synchronously as the first thing in <body> — before first paint, since Marimo's
+# stylesheets are render-blocking and already loaded by then. It sets the same body
+# markup Marimo applies (class="<t> <t>-theme" data-theme="<t>"), so the page paints in
+# the device theme straight away instead of flashing light and correcting once Marimo's
+# bundle mounts. Marimo recomputes the same value for a ``system`` config, so its later
+# take-over is a no-op (no second repaint).
+_FLASH_GUARD = (
+    '<script>'
+    '(function(){'
+    'var t=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";'
+    'document.body.classList.add(t,t+"-theme");'
+    'document.body.dataset.theme=t;'
+    '})();'
+    '</script>'
+)
+
 
 def set_theme(html: str, theme: str = 'system') -> str:
-    """Rewrite the theme baked into a Marimo export so a published report follows the device.
+    """Rewrite a Marimo export's theme so a published report follows the device, flicker-free.
 
     Marimo bakes the *exporting* machine's ``display.theme`` into the mount config and a
     bit of JS applies it on load (``<body class="light light-theme" data-theme="light">``).
     For a report served to other people that hard-codes one author's preference; rewriting
-    it to ``system`` makes the frontend honor the visitor's ``prefers-color-scheme``
-    instead. A no-op if no theme is present (e.g. a non-Marimo page).
+    it to ``system`` makes the frontend honor the visitor's ``prefers-color-scheme``.
+
+    Because that JS only runs once Marimo's bundle mounts, the page would otherwise paint
+    light first and flip — so for ``system`` we also declare ``<meta name="color-scheme">``
+    (UA chrome) and inject a tiny blocking :data:`_FLASH_GUARD` (the content) to get the
+    right theme on the first paint. A no-op if no theme is present (a non-Marimo page).
     """
-    return _DISPLAY_THEME.sub(lambda m: f'{m.group(1)}{theme}{m.group(2)}', html, count=1)
+    html, n = _DISPLAY_THEME.subn(lambda m: f'{m.group(1)}{theme}{m.group(2)}', html, count=1)
+    if not n:
+        return html  # not a Marimo export — nothing to theme
+    scheme = _COLOR_SCHEME.get(theme, 'light dark')
+    html = re.sub(
+        r'(<head[^>]*>)',
+        lambda m: f'{m.group(1)}\n    <meta name="color-scheme" content="{scheme}" />',
+        html,
+        count=1,
+    )
+    if theme == 'system':
+        html = re.sub(r'(<body[^>]*>)', lambda m: f'{m.group(1)}\n    {_FLASH_GUARD}', html, count=1)
+    return html

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -53,6 +53,7 @@ __all__ = [
     'stray_links',
     'rewrite_links',
     'insert_base',
+    'set_theme',
 ]
 
 # Markers that identify the project root (mirrors mini.runs._ROOT_MARKERS).
@@ -281,3 +282,20 @@ def insert_base(html: str, href: str) -> str:
     for a build step: it rewrites the first ``<head>`` only.
     """
     return re.sub(r'(<head[^>]*>)', lambda m: f'{m.group(1)}\n    <base href="{href}" />', html, count=1)
+
+
+# The ``display.theme`` inside Marimo's frozen mount config. The block is flat JSON
+# (no nested objects), so ``[^{}]*?`` stays within it; ``count=1`` guards the rest.
+_DISPLAY_THEME = re.compile(r'("display"\s*:\s*\{[^{}]*?"theme"\s*:\s*")(?:light|dark|system)(")')
+
+
+def set_theme(html: str, theme: str = 'system') -> str:
+    """Rewrite the theme baked into a Marimo export so a published report follows the device.
+
+    Marimo bakes the *exporting* machine's ``display.theme`` into the mount config and a
+    bit of JS applies it on load (``<body class="light light-theme" data-theme="light">``).
+    For a report served to other people that hard-codes one author's preference; rewriting
+    it to ``system`` makes the frontend honor the visitor's ``prefers-color-scheme``
+    instead. A no-op if no theme is present (e.g. a non-Marimo page).
+    """
+    return _DISPLAY_THEME.sub(lambda m: f'{m.group(1)}{theme}{m.group(2)}', html, count=1)

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -81,8 +81,10 @@ def test_insert_base_only_first_head():
     assert out.count('<base ') == 1
 
 
-# Mimics the flat display block in Marimo's frozen mount config.
-_MOUNT = '<script>{"config": {"display": {"cell_output": "below", "theme": "light"}, "save": {}}}</script>'
+# Mimics a Marimo export: the flat display block in the frozen mount config, plus the
+# <head>/<body> the flicker guard hooks into.
+_MOUNT_CONFIG = '<script>{"config": {"display": {"cell_output": "below", "theme": "light"}, "save": {}}}</script>'
+_MOUNT = f'<html><head><meta charset="utf-8" /></head><body>{_MOUNT_CONFIG}<div id="root"></div></body></html>'
 
 
 def test_set_theme_rewrites_display_theme():
@@ -94,8 +96,21 @@ def test_set_theme_rewrites_display_theme():
     assert '"save": {}' in out
 
 
-def test_set_theme_accepts_existing_dark_and_custom_target():
-    assert '"theme": "dark"' in set_theme(_MOUNT.replace('"light"', '"dark"'), theme='dark')
+def test_set_theme_system_suppresses_flicker():
+    out = set_theme(_MOUNT)
+    # color-scheme meta (UA chrome) goes in <head>; the blocking guard (content) in <body>
+    assert '<meta name="color-scheme" content="light dark" />' in out
+    assert 'prefers-color-scheme: dark' in out
+    assert out.index('color-scheme" content') < out.index('</head>')
+    assert out.index('<body>') < out.index('prefers-color-scheme')
+
+
+def test_set_theme_fixed_target_skips_the_flash_guard():
+    out = set_theme(_MOUNT.replace('"light"', '"dark"'), theme='dark')
+    assert '"theme": "dark"' in out
+    # a baked theme doesn't flash, so no blocking script — just declare the scheme
+    assert '<meta name="color-scheme" content="dark" />' in out
+    assert 'prefers-color-scheme' not in out
 
 
 def test_set_theme_is_noop_without_a_theme():

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -5,6 +5,7 @@ from mini.reports import (
     relative_urls,
     report_notebooks,
     rewrite_links,
+    set_theme,
     stray_links,
 )
 
@@ -78,6 +79,28 @@ def test_insert_base_only_first_head():
     # A literal "<head>" appearing later (e.g. in escaped content) is not touched.
     out = insert_base('<head></head><script>"\\u003chead\\u003e"</script>', 'https://h/')
     assert out.count('<base ') == 1
+
+
+# Mimics the flat display block in Marimo's frozen mount config.
+_MOUNT = '<script>{"config": {"display": {"cell_output": "below", "theme": "light"}, "save": {}}}</script>'
+
+
+def test_set_theme_rewrites_display_theme():
+    out = set_theme(_MOUNT)
+    assert '"theme": "system"' in out
+    assert '"theme": "light"' not in out
+    # only the display theme changed; the rest of the config is intact
+    assert '"cell_output": "below"' in out
+    assert '"save": {}' in out
+
+
+def test_set_theme_accepts_existing_dark_and_custom_target():
+    assert '"theme": "dark"' in set_theme(_MOUNT.replace('"light"', '"dark"'), theme='dark')
+
+
+def test_set_theme_is_noop_without_a_theme():
+    html = '<html><head></head><body></body></html>'
+    assert set_theme(html) == html
 
 
 _APP = 'import marimo\napp = marimo.App()\n'

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -13,6 +13,21 @@ build_site = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(build_site)
 
 
+@pytest.mark.parametrize(
+    'url, want',
+    [
+        ('probe/report/index.html', 'probe/report/'),
+        ('probe/report/index.html#cell-3', 'probe/report/#cell-3'),
+        ('index.html', ''),
+        ('../acts/report/index.html', '../acts/report/'),
+        ('guide.html', 'guide.html'),  # not an index page — untouched
+        ('reindex.html', 'reindex.html'),  # only a whole index.html segment is stripped
+    ],
+)
+def test_strip_index(url, want):
+    assert build_site._strip_index(url) == want
+
+
 @pytest.fixture
 def resolver() -> 'build_site.LinkResolver':
     # Reports render to <key>/index.html (per-report dirs); markdown to <name>.html.
@@ -29,8 +44,9 @@ def resolver() -> 'build_site.LinkResolver':
 
 
 def test_rendered_link_is_absolute_pages_url_when_externalizing(resolver):
+    # Published links drop index.html — GitHub Pages serves the directory form.
     got = resolver.resolve('../acts/report.py', from_dir='probe', out_dir='probe/report', externalizing=True)
-    assert got == 'https://o.github.io/r/acts/report/index.html'
+    assert got == 'https://o.github.io/r/acts/report/'
 
 
 def test_rendered_link_stays_relative_when_localizing(resolver):
@@ -47,7 +63,7 @@ def test_source_file_resolves_to_github(resolver):
 
 def test_fragment_is_preserved(resolver):
     got = resolver.resolve('../acts/report.py#cell-3', from_dir='probe', out_dir='probe/report', externalizing=True)
-    assert got == 'https://o.github.io/r/acts/report/index.html#cell-3'
+    assert got == 'https://o.github.io/r/acts/report/#cell-3'
 
 
 def test_repo_source_link_outside_docs_resolves_to_github(resolver):


### PR DESCRIPTION
Two improvements to the notebook publish pipeline, plus follow-up tidy-ups to the ./go task runner.

- Theme: Marimo bakes the exporting machine's display.theme into each export and applies it via JS on load, so a published report hard-coded one author's light/dark preference. build_site now rewrites it to "system" (new mini.reports.set_theme) so the served page follows the visitor's prefers-color-scheme.

- URLs: published report links dropped their /index.html — GitHub Pages serves the directory form, and <key>/ is the nicer canonical/shareable URL. Applied to externalized report links and to Markdown nav links when publishing; offline (file://) builds keep the explicit file so local navigation works.

- ./go: rename `run`->`export` (it exports a static bundle; `run` collided with `mini run`, which executes compute) and `clean`->`scrub` (it scrubs terminal sequences / redacts Modal URLs, not deletes build outputs). Old names kept as deprecated aliases; docs updated.


Claude-Session: https://claude.ai/code/session_01KNtwdmNqaNgxK7oULwGPR1