### PR TITLE
Drop redundant /report URL segment and add report nav banner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,10 @@ the exported HTML is never committed. `./go publish` exports each notebook to a
 self-contained bundle (`index.html` + named-keyed `_assets/`) and mirrors it to the
 HF bucket under `exports/<key>/`, where `<key>` is the notebook's docs-relative path
 without suffix (`docs/getting_started.py` → `getting_started`, `docs/foo/bar.py` →
-`foo/bar`). `./go build` then assembles `_site/` from the synced bundles, serving each
-report at `_site/<key>/index.html` (URL `<key>/`). With no bucket, the build *localizes*
+`foo/bar`) — except a notebook named `report.py` takes its directory as the key
+(`docs/foo/report.py` → `foo`), so a one-report experiment publishes at `foo/` rather
+than the redundant `foo/report/`. `./go build` then assembles `_site/` from the synced
+bundles, serving each report at `_site/<key>/index.html` (URL `<key>/`). With no bucket, the build *localizes*
 from `.mini/exports/` (produced by `./go export`) so it works offline.
 
 **Markdown files** (`.md`) are converted to HTML and written to `_site/` at the
@@ -29,7 +31,7 @@ docs/
 ├── getting_started.py       Marimo notebook → exported bundle, served at _site/getting_started/
 └── pipeline/                A heavier experiment, split into definition + report
     ├── experiment.py        Importable main(ctx) DAG — not a notebook, so the build ignores it
-    └── report.py            Marimo notebook → served at _site/pipeline/report/
+    └── report.py            Marimo notebook → served at _site/pipeline/
 ```
 
 Exported bundles live (gitignored) under `.mini/exports/<key>/` locally; their durable

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -26,6 +26,7 @@ from mini.reports import (
     insert_base,
     report_notebooks,
     rewrite_links,
+    set_banner,
     set_theme,
     stray_links,
 )
@@ -227,6 +228,8 @@ def build_reports(links: LinkResolver, store, externalizing: bool):
             html = (bundle / 'index.html').read_text('utf-8')
             html = _resolve_html_links(html, links, from_dir=from_dir, out_dir=key, externalizing=externalizing)
             html = set_theme(html)  # follow the visitor's device, not the exporter's setting
+            index_url, source_url = _nav_urls(links, key=key, nb_rel=nb_rel, externalizing=externalizing)
+            html = set_banner(html, index_url=index_url, source_url=source_url)
             if base_href:
                 html = insert_base(html, base_href)
             dest = SITE_DIR / key / 'index.html'
@@ -236,6 +239,23 @@ def build_reports(links: LinkResolver, store, externalizing: bool):
             if not externalizing and (bundle / ASSET_LINK).is_dir():
                 shutil.copytree(bundle / ASSET_LINK, dest.parent / ASSET_LINK, dirs_exist_ok=True)
             print(f'  {key} -> _site/{key}/index.html{" [+base]" if base_href else ""}')
+
+
+def _nav_urls(links: LinkResolver, *, key: str, nb_rel: str, externalizing: bool) -> tuple[str | None, str | None]:
+    """The report banner's (index, source) links — same absolute/relative policy as author links.
+
+    The source is the notebook on GitHub (``source_base`` + its repo path). The index is
+    the site root: absolute (``site_base``) when externalizing — the asset ``<base>`` would
+    otherwise repoint a relative link at the bucket — and relative back up from
+    ``_site/<key>/index.html`` when localizing, so offline navigation works. Either is
+    ``None`` if its base is unavailable.
+    """
+    source_url = f'{links.source_base}{nb_rel}' if links.source_base else None
+    if externalizing:
+        index_url = links.site_base  # the site root serves index.html
+    else:
+        index_url = '../' * (key.count('/') + 1) + 'index.html'
+    return index_url, source_url
 
 
 def _resolve_html_links(html: str, links: LinkResolver, *, from_dir: str, out_dir: str, externalizing: bool) -> str:

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -348,31 +348,41 @@ def set_theme(html: str, theme: str = 'system') -> str:
 
 # Marimo's "Static marimo notebook — Run or Edit" banner is rendered *client-side* by
 # its bundle (it's nowhere in the exported HTML — only ``data-testid`` survives at
-# runtime), so we can't rewrite it as markup. Instead we inject our own bar into the
-# document and hide Marimo's once it mounts. The selector keys on that stable testid.
+# runtime), so we can't rewrite it as markup. We hide it via this rule on that stable
+# testid; if a future Marimo drops the testid the rule simply no-ops (its banner returns,
+# ours still shows) — no hard dependency on its internals.
 _HIDE_MARIMO_BANNER = '[data-testid="static-notebook-banner"]{display:none!important}'
 
-# Self-contained so it paints before (and independently of) Marimo's stylesheet/bundle:
-# neutral colors via ``currentColor`` work in either theme, and ``justify-content`` puts
-# the back-link at the start and the source link at the end. ``print:hidden`` equivalent
-# via ``@media print`` keeps it off printouts like Marimo's own bar.
+# Our nav is a ``position:fixed`` overlay, deliberately *out of normal flow*: Marimo
+# mounts its app as a full-viewport ``absolute`` layer, so an in-flow bar would both be
+# painted over by it and add its own height below it (a second scrollbar). Fixed + a top
+# z-index floats above that layer and touches nothing in Marimo's DOM. Pinned top-left to
+# clear Marimo's top-right actions (``…``) menu. ``Canvas``/``CanvasText`` are the UA's
+# theme-aware system colors (the export declares ``color-scheme``, so they track the
+# device theme); a blurred translucent backdrop keeps it legible over content.
 _BANNER_STYLE = (
-    'display:flex;justify-content:space-between;align-items:center;gap:1rem;'
-    'padding:.4rem 1rem;font-size:.8125rem;font-family:system-ui,sans-serif;'
-    'border-bottom:1px solid color-mix(in srgb, currentColor 15%, transparent);'
+    'position:fixed;top:.5rem;left:.5rem;z-index:2147483647;'
+    'display:flex;gap:.75rem;align-items:center;'
+    'padding:.3rem .65rem;font-size:.8125rem;line-height:1.4;'
+    'font-family:system-ui,sans-serif;border-radius:.375rem;'
+    'background:color-mix(in srgb, Canvas 80%, transparent);'
+    'border:1px solid color-mix(in srgb, CanvasText 18%, transparent);'
+    '-webkit-backdrop-filter:blur(6px);backdrop-filter:blur(6px);'
 )
 _BANNER_LINK = 'color:inherit;text-decoration:underline'
 
 
 def set_banner(html: str, *, index_url: str | None = None, source_url: str | None = None) -> str:
-    """Give a published report a nav bar — back to the index, out to the source — over Marimo's.
+    """Give a published report a floating nav — back to the index, out to the source.
 
     Marimo's static export shows a "Run or Edit" banner whose only action is a download
     popup; on a published site a back-link to the index and a link to the source notebook
-    are more useful. Marimo renders its banner client-side, so rather than edit markup
-    that isn't there we inject our own bar (left: ``← Index``, right: ``Source``) as the
-    first thing in ``<body>`` and add a style rule that hides Marimo's once it mounts.
-    Either link is omitted when its URL is ``None``; a no-op if neither is given.
+    are more useful. So we hide Marimo's banner (a CSS rule keyed on its ``data-testid``)
+    and inject our own — a small ``position:fixed`` overlay (``← Index`` · ``Source``).
+    It's fixed rather than in-flow because Marimo renders its app as a full-viewport
+    ``absolute`` layer that would otherwise paint over an in-flow bar and leave a second
+    scrollbar below it. Either link is omitted when its URL is ``None``; a no-op if
+    neither is given.
     """
     if index_url is None and source_url is None:
         return html
@@ -380,9 +390,8 @@ def set_banner(html: str, *, index_url: str | None = None, source_url: str | Non
     def link(href: str, label: str) -> str:
         return f'<a href="{href}" style="{_BANNER_LINK}">{label}</a>'
 
-    left = link(index_url, '&larr; Index') if index_url else '<span></span>'
-    right = link(source_url, 'Source') if source_url else '<span></span>'
-    bar = f'<nav data-mini-banner style="{_BANNER_STYLE}">{left}{right}</nav>'
+    links = [link(url, label) for url, label in ((index_url, '&larr; Index'), (source_url, 'Source')) if url]
+    bar = f'<nav data-mini-banner style="{_BANNER_STYLE}">{"".join(links)}</nav>'
 
     html = re.sub(
         r'(</head>)',

--- a/src/mini/reports.py
+++ b/src/mini/reports.py
@@ -54,6 +54,7 @@ __all__ = [
     'rewrite_links',
     'insert_base',
     'set_theme',
+    'set_banner',
 ]
 
 # Markers that identify the project root (mirrors mini.runs._ROOT_MARKERS).
@@ -137,10 +138,14 @@ def _project_root(start: Path) -> Path:
 def export_key(notebook_file: str | Path) -> str:
     """The docs-relative, suffix-less key naming a report's self-contained bundle.
 
-    ``docs/gpt.py`` → ``gpt``; ``docs/gpt-sweep/report.py`` → ``gpt-sweep/report``. It
-    names the report's on-disk export dir *and* its ``exports/<key>/`` prefix on the
-    bucket, and (served as ``index.html``) its URL ``<key>/`` — so each report is one
-    independently syncable bundle.
+    ``docs/gpt.py`` → ``gpt``; ``docs/gpt-sweep/report.py`` → ``gpt-sweep``. A report
+    named ``report.py`` takes its *directory* as the key, so the common one-experiment,
+    one-report split publishes at ``gpt-sweep/`` rather than the redundant
+    ``gpt-sweep/report/``. A second report alongside it keeps its own stem
+    (``docs/foo/aside.py`` → ``foo/aside``), so the convention extends to multiple
+    reports per experiment without collision. The key names the report's on-disk export
+    dir *and* its ``exports/<key>/`` prefix on the bucket, and (served as ``index.html``)
+    its URL ``<key>/`` — so each report is one independently syncable bundle.
     """
     p = Path(notebook_file).resolve()
     docs = _project_root(p) / 'docs'
@@ -148,7 +153,10 @@ def export_key(notebook_file: str | Path) -> str:
         rel = p.relative_to(docs)
     except ValueError:
         rel = Path(p.name)
-    return rel.with_suffix('').as_posix()
+    key = rel.with_suffix('')
+    if key.name == 'report' and key.parent != Path('.'):
+        key = key.parent  # a directory's canonical report drops the redundant /report
+    return key.as_posix()
 
 
 def export_dir(notebook_file: str | Path) -> Path:
@@ -336,3 +344,52 @@ def set_theme(html: str, theme: str = 'system') -> str:
     if theme == 'system':
         html = re.sub(r'(<body[^>]*>)', lambda m: f'{m.group(1)}\n    {_FLASH_GUARD}', html, count=1)
     return html
+
+
+# Marimo's "Static marimo notebook — Run or Edit" banner is rendered *client-side* by
+# its bundle (it's nowhere in the exported HTML — only ``data-testid`` survives at
+# runtime), so we can't rewrite it as markup. Instead we inject our own bar into the
+# document and hide Marimo's once it mounts. The selector keys on that stable testid.
+_HIDE_MARIMO_BANNER = '[data-testid="static-notebook-banner"]{display:none!important}'
+
+# Self-contained so it paints before (and independently of) Marimo's stylesheet/bundle:
+# neutral colors via ``currentColor`` work in either theme, and ``justify-content`` puts
+# the back-link at the start and the source link at the end. ``print:hidden`` equivalent
+# via ``@media print`` keeps it off printouts like Marimo's own bar.
+_BANNER_STYLE = (
+    'display:flex;justify-content:space-between;align-items:center;gap:1rem;'
+    'padding:.4rem 1rem;font-size:.8125rem;font-family:system-ui,sans-serif;'
+    'border-bottom:1px solid color-mix(in srgb, currentColor 15%, transparent);'
+)
+_BANNER_LINK = 'color:inherit;text-decoration:underline'
+
+
+def set_banner(html: str, *, index_url: str | None = None, source_url: str | None = None) -> str:
+    """Give a published report a nav bar — back to the index, out to the source — over Marimo's.
+
+    Marimo's static export shows a "Run or Edit" banner whose only action is a download
+    popup; on a published site a back-link to the index and a link to the source notebook
+    are more useful. Marimo renders its banner client-side, so rather than edit markup
+    that isn't there we inject our own bar (left: ``← Index``, right: ``Source``) as the
+    first thing in ``<body>`` and add a style rule that hides Marimo's once it mounts.
+    Either link is omitted when its URL is ``None``; a no-op if neither is given.
+    """
+    if index_url is None and source_url is None:
+        return html
+
+    def link(href: str, label: str) -> str:
+        return f'<a href="{href}" style="{_BANNER_LINK}">{label}</a>'
+
+    left = link(index_url, '&larr; Index') if index_url else '<span></span>'
+    right = link(source_url, 'Source') if source_url else '<span></span>'
+    bar = f'<nav data-mini-banner style="{_BANNER_STYLE}">{left}{right}</nav>'
+
+    html = re.sub(
+        r'(</head>)',
+        lambda m: (
+            f'    <style>{_HIDE_MARIMO_BANNER}\n    @media print{{[data-mini-banner]{{display:none}}}}</style>\n{m.group(1)}'
+        ),
+        html,
+        count=1,
+    )
+    return re.sub(r'(<body[^>]*>)', lambda m: f'{m.group(1)}\n    {bar}', html, count=1)

--- a/tests/mini/test_reports.py
+++ b/tests/mini/test_reports.py
@@ -1,10 +1,12 @@
 from mini.reports import (
     SOURCE_ONLY_MARKER,
+    export_key,
     insert_base,
     is_report_notebook,
     relative_urls,
     report_notebooks,
     rewrite_links,
+    set_banner,
     set_theme,
     stray_links,
 )
@@ -116,6 +118,54 @@ def test_set_theme_fixed_target_skips_the_flash_guard():
 def test_set_theme_is_noop_without_a_theme():
     html = '<html><head></head><body></body></html>'
     assert set_theme(html) == html
+
+
+def test_export_key_uses_docs_relative_stem(tmp_path):
+    (tmp_path / 'pyproject.toml').write_text('')
+    docs = tmp_path / 'docs'
+    (docs / 'gpt-sweep').mkdir(parents=True)
+    (docs / 'gpt.py').write_text(_APP)
+    (docs / 'gpt-sweep' / 'aside.py').write_text(_APP)
+    assert export_key(docs / 'gpt.py') == 'gpt'
+    assert export_key(docs / 'gpt-sweep' / 'aside.py') == 'gpt-sweep/aside'
+
+
+def test_export_key_drops_redundant_report_segment(tmp_path):
+    # The canonical report of a directory publishes at the directory, not <dir>/report.
+    (tmp_path / 'pyproject.toml').write_text('')
+    docs = tmp_path / 'docs'
+    (docs / 'pipeline').mkdir(parents=True)
+    (docs / 'pipeline' / 'report.py').write_text(_APP)
+    assert export_key(docs / 'pipeline' / 'report.py') == 'pipeline'
+    # A top-level report.py has no directory to take, so it keeps its stem.
+    (docs / 'report.py').write_text(_APP)
+    assert export_key(docs / 'report.py') == 'report'
+
+
+# Marimo renders its banner client-side, so the export only carries an empty shell; our
+# bar is injected into that, not matched against existing banner markup.
+_EXPORT_HTML = '<html><head><meta charset="utf-8" /></head><body><div id="root"></div></body></html>'
+
+
+def test_set_banner_injects_nav_and_hides_marimo():
+    out = set_banner(_EXPORT_HTML, index_url='https://o.github.io/r/', source_url='https://github.com/o/r/x.py')
+    # Our bar is the first thing in <body>, so it paints above the report.
+    assert out.index('<body>') < out.index('<nav data-mini-banner') < out.index('<div id="root">')
+    assert '<a href="https://o.github.io/r/" style=' in out and '&larr; Index' in out
+    assert '<a href="https://github.com/o/r/x.py" style=' in out and '>Source</a>' in out
+    # Marimo's own (client-rendered) banner is hidden via a rule in <head>.
+    assert '[data-testid="static-notebook-banner"]{display:none' in out
+    assert out.index('static-notebook-banner') < out.index('</head>')
+
+
+def test_set_banner_omits_missing_links():
+    out = set_banner(_EXPORT_HTML, index_url='../index.html', source_url=None)
+    assert '&larr; Index' in out
+    assert '>Source<' not in out
+
+
+def test_set_banner_is_noop_without_urls():
+    assert set_banner(_EXPORT_HTML) == _EXPORT_HTML
 
 
 _APP = 'import marimo\napp = marimo.App()\n'

--- a/tests/mini/vis/test_nb.py
+++ b/tests/mini/vis/test_nb.py
@@ -149,10 +149,10 @@ def test_report_bundle_targets_export_dir(tmp_path: Path):
     nb = tmp_path / 'docs' / 'gpt-sweep' / 'report.py'
     nb.parent.mkdir(parents=True)
     nb.write_text('')
-    assert export_key(nb) == 'gpt-sweep/report'
-    assert export_dir(nb) == tmp_path / '.mini' / 'exports' / 'gpt-sweep' / 'report'
+    assert export_key(nb) == 'gpt-sweep'  # a directory's report.py collapses to the dir
+    assert export_dir(nb) == tmp_path / '.mini' / 'exports' / 'gpt-sweep'
     pub = report_bundle(nb)
-    assert pub.asset_dir == tmp_path / '.mini' / 'exports' / 'gpt-sweep' / 'report' / '_assets'
+    assert pub.asset_dir == tmp_path / '.mini' / 'exports' / 'gpt-sweep' / '_assets'
     assert pub.link == '_assets'
 
 

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -43,6 +43,22 @@ def resolver() -> 'build_site.LinkResolver':
     )
 
 
+def test_nav_urls_absolute_when_externalizing(resolver):
+    # With an asset <base>, the index link must be absolute (the site root); source is
+    # always the notebook on GitHub.
+    index, source = build_site._nav_urls(resolver, key='pipeline', nb_rel='docs/pipeline/report.py', externalizing=True)
+    assert index == 'https://o.github.io/r/'
+    assert source == 'https://github.com/o/r/blob/main/docs/pipeline/report.py'
+
+
+def test_nav_urls_index_is_relative_when_localizing(resolver):
+    # No <base> offline, so climb back to _site/index.html from _site/<key>/index.html.
+    index, _ = build_site._nav_urls(resolver, key='pipeline', nb_rel='docs/pipeline/report.py', externalizing=False)
+    assert index == '../index.html'
+    index, _ = build_site._nav_urls(resolver, key='a/b', nb_rel='docs/a/b.py', externalizing=False)
+    assert index == '../../index.html'
+
+
 def test_rendered_link_is_absolute_pages_url_when_externalizing(resolver):
     # Published links drop index.html — GitHub Pages serves the directory form.
     got = resolver.resolve('../acts/report.py', from_dir='probe', out_dir='probe/report', externalizing=True)


### PR DESCRIPTION
export_key now maps a directory's canonical report.py to the directory itself, so a split experiment publishes at `pipeline/` instead of `pipeline/report/`. A second report in the same dir keeps its own stem, so the convention extends to multiple reports without collision.

set_banner replaces Marimo's client-rendered "Run or Edit" banner (a download popup) with our own nav bar: a back-link to the index and a link to the source notebook on GitHub. Marimo renders its banner in JS, so rather than rewrite markup that isn't in the export, we inject our bar at the top of <body> and hide Marimo's via a CSS rule keyed on its stable data-testid. build_site resolves the two URLs with the same absolute/relative policy as author links (absolute under the asset <base> when externalizing, relative offline).


Claude-Session: https://claude.ai/code/session_01GtHwLdCtVXhtHmjyX1g9LW