### PR TITLE
Track requested keys so superseded records can't poison a run

### DIFF
--- a/.agents/skills/mi-ni/references/memoization.md
+++ b/.agents/skills/mi-ni/references/memoization.md
@@ -45,11 +45,21 @@ into a task's inputs so the same inputs really do produce the same result.
 <!-- prettier-ignore -->
 | You want to… | Do this | What re-runs |
 | --- | --- | --- |
-| Fix a bug in a step | Edit the fn, `mini run` | That step (new source key); siblings stay hits |
+| Fix a bug in a step | Edit the fn, `mini run` | Every call of that fn — one step, or a whole `map` (all cells share its source); *other* steps stay hits |
 | Add a config to a sweep | Append to `configs`, `mini run` | Only the new key |
-| Remove a config | Delete it from `configs` | Nothing — it's just not requested |
+| Remove a config | Delete it from `configs` | Nothing — its old record shows `(superseded)` |
 | Re-run a finished step | Edit the fn, or pass `version=` | That step |
 | Recover a failed step | `mini logs`, fix, `mini retry` | The reset (FAILED/CANCELLED) tasks |
+
+### Superseded records
+
+Records are keyed by content, so an edited fn or a removed config leaves its old
+record behind under a key no wake will request again. Each tick persists the set
+of keys the DAG requested; the read commands aggregate over that set, showing
+the orphans as `(superseded)` without letting them poison the run's state — a
+completed run reads DONE even if an old key once settled FAILED. `retry` skips
+superseded records too (resetting one would plant a phantom that never runs);
+target one explicitly with `--key` if you really mean it.
 
 ### Failure is terminal by design
 

--- a/.agents/skills/mi-ni/references/running.md
+++ b/.agents/skills/mi-ni/references/running.md
@@ -61,7 +61,11 @@ money on Modal). And editing a **shared helper** invalidates *every* task that
 calls it. Three rules keep the blast radius bounded:
 
 1. **Only hotfix terminal (FAILED/CANCELLED) tasks** — their worker is already
-   dead. Fix the fn, then `retry --key <key>`; blast radius is one task.
+   dead. For a transient failure, don't edit: `retry --key <key>` re-runs just
+   that task (blast radius is one task). Editing the fn re-keys **every call of
+   it** — for a `map`, the *whole fan-out* re-runs, not just the failed cell
+   (the old records then show `(superseded)`). That's fine for a single-step fn;
+   for a big sweep it's a real recompute cost — weigh it, or escalate.
 2. **If anything is in-flight, `cancel` first, then fix.** Never edit under a
    live worker. (`cancel` is store-scoped — it also stops orphaned old-version
    workers, which keep showing as `RUNNING` in `status`.)

--- a/.claude/agents/experiment-monitor.md
+++ b/.claude/agents/experiment-monitor.md
@@ -64,8 +64,11 @@ Editing code re-runs work and can double-spend (detached old-key workers aren't
 killed by a re-run). So:
 
 1. **Only hotfix terminal (FAILED/CANCELLED) tasks** — their worker is dead.
-   Fix the failing fn, then `bin/mini retry <exp> --key <key>`. Blast radius is
-   one task.
+   For a transient failure, don't edit: `bin/mini retry <exp> --key <key>`
+   re-runs just that task. Editing a fn re-keys **every call of it** — for a
+   `map`, the whole fan-out re-runs, not just the failed cell. Edit only when
+   the fn backs a single step or the sweep is cheap to re-run; otherwise
+   escalate.
 2. **If anything is in-flight, `bin/mini cancel <exp>` first**, then fix. Never
    edit under a live worker.
 3. **Only ever edit the single failing task fn.** Never a shared helper,

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -124,6 +124,23 @@ def _rec_state(rec: dict) -> RunState:
     return RunState(rec['state']) if rec.get('state') else RunState.PENDING
 
 
+def _print_records(store: MemoStore, records: list[dict] | None = None) -> tuple[list[dict], list[dict]]:
+    """Print every record — current first, superseded marked — and return the split.
+
+    A superseded record's key is one the last tick no longer requested (its fn was
+    edited, its config removed). It stays visible (it may hold a result someone
+    cares about, or an orphaned worker still burning), but it is *not* part of the
+    run's state: aggregates and the failed-task hint consider current records only,
+    so a completed run reads DONE even when an old key settled FAILED.
+    """
+    current, stale = store.split_current(store.records() if records is None else records)
+    for rec in current:
+        print(_memo_line(rec))
+    for rec in stale:
+        print(f'{_memo_line(rec)}  (superseded)')
+    return current, stale
+
+
 def _memo_line(rec: dict) -> str:
     """One status line for a memoized task record (shared by `run`/`status`)."""
     state = _rec_state(rec)
@@ -178,21 +195,18 @@ def _run(exp, apparatus: Apparatus, args: argparse.Namespace) -> None:
     if store.budget_expired():  # over budget — settle in-flight work, don't launch a new stage
         cancelled = apparatus.enforce_budget(store)
         print(f'{exp.name}:')
-        for rec in store.records():
-            print(_memo_line(rec))
+        _print_records(store)
         print(f'⊘ wall-clock budget elapsed — cancelled {len(cancelled)} in-flight task(s); run settled CANCELLED')
         return
     try:
         done, payload = tick(exp, apparatus)
     except ExceptionGroup, TaskFailed:  # a depended-on task settled terminally
         done, payload = False, None
-    records = apparatus.memo_store().records()
     print(f'{exp.name}:')
-    for rec in records:
-        print(_memo_line(rec))
+    current, _ = _print_records(store)
     if done:
         print(f'✓ complete: {payload}')
-    elif failed := [r for r in records if _rec_state(r) in (RunState.FAILED, RunState.CANCELLED)]:
+    elif failed := [r for r in current if _rec_state(r) in (RunState.FAILED, RunState.CANCELLED)]:
         print(f'✗ {len(failed)} task(s) failed (terminal) — fix, then: python -m mini retry {args.path}')
         print(f'   see a traceback with:  python -m mini logs {exp.name} <key>')
     else:
@@ -229,10 +243,15 @@ def cmd_ls(args: argparse.Namespace) -> None:
         print('no experiments yet (run one with: python -m mini run <path>)')
         return
     for name in names:
-        states = [_rec_state(r) for r in MemoStore(root / name).records()]
+        store = MemoStore(root / name)
+        current, stale = store.split_current(store.records())
+        states = [_rec_state(r) for r in current]
         agg = _aggregate_state(states)
         done = sum(s == RunState.DONE for s in states)
-        print(f'{name:16} {_GLYPH.get(agg, "?")} {agg:9} {done}/{len(states)} tasks')
+        line = f'{name:16} {_GLYPH.get(agg, "?")} {agg:9} {done}/{len(states)} tasks'
+        if stale:
+            line += f'  (+{len(stale)} superseded)'
+        print(line)
 
 
 def cmd_status(args: argparse.Namespace) -> None:
@@ -243,13 +262,13 @@ def cmd_status(args: argparse.Namespace) -> None:
     recs = store.records()
     if not recs:
         raise SystemExit(f'no tasks found for experiment {args.name!r}')
-    state = _aggregate_state([_rec_state(r) for r in recs])
-    header = f'{args.name}  —  {state}  ({len(recs)} tasks)'
+    current, _ = store.split_current(recs)
+    state = _aggregate_state([_rec_state(r) for r in current])
+    header = f'{args.name}  —  {state}  ({len(current)} tasks)'
     if suffix := _budget_suffix(store):
         header += f'  ·  {suffix}'
     print(header)
-    for rec in recs:
-        print(_memo_line(rec))
+    _print_records(store, recs)
 
 
 def cmd_watch(args: argparse.Namespace) -> None:
@@ -278,12 +297,15 @@ def cmd_results(args: argparse.Namespace) -> None:
     recs = store.records()
     if not recs:
         raise SystemExit(f'no tasks found for experiment {args.name!r}')
-    for rec in recs:
+    current, stale = store.split_current(recs)
+    for rec in current:
         key = rec['key']
         if _rec_state(rec) == RunState.DONE:
             print(f'{key}  {store.result(key)}')
         else:
             print(f'{key}  ({_rec_state(rec)} — no result)')
+    if stale:  # results under keys the DAG no longer requests would mislead a gather
+        print(f'({len(stale)} superseded record(s) omitted — see: status)')
 
 
 def cmd_logs(args: argparse.Namespace) -> None:

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -236,6 +236,30 @@ class MemoStore:
         """Merge run-level metadata (e.g. ``deadline_at``) into the reserved record."""
         self.records_backend.merge(META_KEY, fields)
 
+    def requested_keys(self) -> list[str] | None:
+        """The keys the DAG requested on its last tick, or ``None`` if never recorded.
+
+        Records are content-keyed, so an edited fn or a removed config leaves its old
+        record behind under a key no wake will request again. This manifest is what
+        lets a read-only view (``status``/``ls``/``watch``) aggregate over the run's
+        *current* records and mark the rest superseded — without re-running ``main``
+        (reads must never tick). ``None`` (a store written before the manifest, or a
+        run never ticked) means "unknown": treat every record as current.
+        """
+        return self.meta().get('requested')
+
+    def split_current(self, records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Split *records* into ``(current, superseded)`` against the requested set.
+
+        With no manifest, everything is current (nothing to judge against).
+        """
+        requested = self.requested_keys()
+        if requested is None:
+            return records, []
+        wanted = set(requested)
+        current = [r for r in records if r['key'] in wanted]
+        return current, [r for r in records if r['key'] not in wanted]
+
     def deadline(self) -> float | None:
         """The run's wall-clock deadline (epoch seconds), or ``None`` if unbudgeted."""
         return self.meta().get('deadline_at')

--- a/src/mini/monitor.py
+++ b/src/mini/monitor.py
@@ -111,8 +111,13 @@ def watch(
             records = cache.records(store)
             apparatus.reap_dead(store, records)  # settle vanished workers — read-only path, never relaunches
             _refresh(progress, bars, records)
-            if records and all(_rec_state(r) in SETTLED for r in records):
-                return records
+            # Settle on the *current* records only: a superseded key (fn edited,
+            # config removed) will never be requested again, so waiting on its
+            # record would watch forever. Split each poll — another process may
+            # tick (and re-key) while we watch.
+            current, _ = store.split_current(records)
+            if current and all(_rec_state(r) in SETTLED for r in current):
+                return current
             time.sleep(poll)
 
 

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -128,6 +128,12 @@ class Ctx:
         self.roles = roles or {}
         self.launched: list[str] = []
         self.pending: list[str] = []
+        # Every key this wake resolved (hit, in-flight, or launched) — the DAG's
+        # *requested set*. A record whose key a wake no longer requests (its fn was
+        # edited, its config removed) is superseded: still on disk, but not part of
+        # the run's state. ``tick`` persists this so read-only views can tell the two
+        # apart without re-running ``main``.
+        self.requested: list[str] = []
 
     def _route(self, on: Apparatus | None, role: str | None) -> Apparatus:
         """Resolve which apparatus a step runs on: ``role`` label, ``on=``, or default."""
@@ -148,6 +154,7 @@ class Ctx:
         spawn so a ``map`` fans out in one ``spawn_tasks`` call.
         """
         key = fingerprint(fn, args, version)
+        self.requested.append(key)
         state = self.store.state(key)
         to_launch: tuple[str, Callable, tuple, list] | None = None
         if state is None:  # never run; FAILED/CANCELLED are terminal (retry takes intent)
@@ -273,6 +280,13 @@ def tick(experiment: Experiment, apparatus: Apparatus) -> tuple[bool, Any]:
         result = experiment.orchestration()(ctx)
     except Pending as p:
         return False, str(p)
+    finally:
+        # Persist the requested set (even on Pending/TaskFailed) so read-only views
+        # can split current records from superseded ones. ``main`` replays from the
+        # top each wake, so the set is complete up to the suspension point; keys past
+        # it aren't known yet and their old records read as superseded until a later
+        # wake requests them again — honest, since an upstream edit may re-key them.
+        store.set_meta(requested=list(dict.fromkeys(ctx.requested)))
     return True, result
 
 
@@ -284,12 +298,20 @@ def retry(store: MemoStore, key: str | None = None) -> list[str]:
     ``tick`` then relaunches. Pass *key* to retry one task; otherwise all
     failed/cancelled tasks. Returns the keys reset (a `DONE` task is never reset —
     edit the fn or bump ``version=`` to force that). DONE results stay memo hits.
+
+    Superseded records — keys the last tick no longer requested (their fn was
+    edited, their config removed) — are skipped: no tick will ever relaunch them,
+    so resetting one just plants a phantom forever-pending record. An explicit
+    *key* overrides (deliberate intent beats the manifest).
     """
+    requested = store.requested_keys()
     targets: list[str] = []
     for rec in store.records():
         k = rec['key']
         if key is not None and k != key:
             continue
+        if key is None and requested is not None and k not in requested:
+            continue  # superseded — the DAG no longer requests this key
         state = RunState(rec['state']) if rec.get('state') else None
         if state in (RunState.FAILED, RunState.CANCELLED):
             store.reset(k)

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -68,6 +68,46 @@ def test_ls_and_status_surface_memo_experiments(tmp_path: Path, monkeypatch, cap
     assert 'train-' in status_out and '2 tasks' in status_out  # per-task memo records
 
 
+def test_status_and_ls_report_done_despite_superseded_failure(tmp_path: Path, monkeypatch, capsys):
+    """The scenario a monitor agent hits: a task fails, the fn is edited (re-keying
+    every cell), and the run completes under the new keys. ``status``/``ls`` must
+    report the *run* as done — aggregating over the requested set — with the
+    orphaned old records shown but marked, not poisoning the state a poller acts on."""
+    monkeypatch.chdir(tmp_path)
+
+    def bad(x):
+        raise RuntimeError('bug')
+
+    def good(x):
+        return x
+
+    def sweep(fn):
+        return Experiment(name='super', main=lambda ctx: ctx.map(fn, [(1,)]))
+
+    app = LocalApparatus('super')  # default data_dir → .mini/super
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:  # drive the buggy version to its failure
+        try:
+            tick(sweep(bad), app)
+        except ExceptionGroup:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError('map never surfaced the failure')
+    _drive(sweep(good), LocalApparatus('super'))  # the "hotfix": new source, new keys
+
+    from mini.__main__ import cmd_ls, cmd_status
+
+    cmd_status(argparse.Namespace(name='super', app='local'))
+    status_out = capsys.readouterr().out
+    assert '—  done  (1 tasks)' in status_out  # aggregate ignores the orphan
+    assert '(superseded)' in status_out  # …but the orphan stays visible, marked
+
+    cmd_ls(argparse.Namespace())
+    ls_out = capsys.readouterr().out
+    assert 'done' in ls_out and '+1 superseded' in ls_out
+
+
 def test_cancel_stops_running_task(tmp_path: Path):
     def slow(x):
         import time

--- a/tests/mini/test_orchestration.py
+++ b/tests/mini/test_orchestration.py
@@ -315,6 +315,74 @@ def test_prune_and_memo_hits_across_config_edits(tmp_path: Path):
     assert {p.name for p in counts.iterdir()} == {'1', '2', '3'}  # 1 retained, never re-run
 
 
+def test_tick_persists_requested_keys(tmp_path: Path):
+    """Each tick records the keys the DAG requested (the ``__run__`` manifest), so
+    read-only views can split current records from superseded ones without
+    re-running ``main`` (reads must never tick)."""
+
+    def work(x):
+        return x * 10
+
+    def sweep(items):
+        return Experiment(name='req', main=lambda ctx: ctx.map(work, [(i,) for i in items]))
+
+    data_dir = tmp_path / 'req'
+    _drive(sweep([1, 2]), LocalApparatus('req', data_dir=data_dir))
+    store = MemoStore(data_dir)
+    assert set(store.requested_keys() or []) == {r['key'] for r in store.records()}
+
+    # Prune a config: its record survives on disk, but the manifest no longer
+    # requests it — so the run's *current* view is just the surviving cell.
+    _drive(sweep([2]), LocalApparatus('req', data_dir=data_dir))
+    current, stale = store.split_current(store.records())
+    assert len(current) == 1 and len(stale) == 1
+
+
+def test_superseded_records_are_excluded_and_not_retried(tmp_path: Path):
+    """Editing a task fn re-keys every cell that calls it, orphaning the old
+    records. The orphaned FAILED record must not poison the run: ``retry`` skips
+    it (resetting it would plant a phantom no tick ever relaunches), and the
+    manifest marks it superseded for read-only views. Explicit ``--key`` intent
+    still beats the manifest."""
+
+    def bad(x):
+        if x == 2:
+            raise RuntimeError('bug')
+        return x * 10
+
+    def good(x):
+        return x * 10
+
+    def sweep(fn):
+        return Experiment(name='hotfix', main=lambda ctx: ctx.map(fn, [(1,), (2,)]))
+
+    data_dir = tmp_path / 'hotfix'
+    exp, app = sweep(bad), LocalApparatus('hotfix', data_dir=data_dir)
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            tick(exp, app)
+        except ExceptionGroup:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError('map never surfaced the failure')
+    store = app.memo_store()
+    (failed_key,) = [r['key'] for r in store.records() if r.get('state') == RunState.FAILED]
+
+    # The "hotfix": the fixed fn has new source, so every cell re-keys and the old
+    # records are superseded. The fixed sweep completes despite the old failure.
+    assert _drive(sweep(good), LocalApparatus('hotfix', data_dir=data_dir)) == [10, 20]
+    assert retry(store) == []  # the orphaned FAILED is skipped, not reset
+    assert store.state(failed_key) == RunState.FAILED  # left as-is — no phantom pending
+
+    current, stale = store.split_current(store.records())
+    assert failed_key in {r['key'] for r in stale}
+    assert all(r.get('state') == RunState.DONE for r in current)
+
+    assert retry(store, key=failed_key) == [failed_key]  # explicit key overrides
+
+
 def test_per_step_apparatus_uses_its_hooks(tmp_path: Path):
     """``on=`` routes a step to a different apparatus — here proven via its hooks."""
 


### PR DESCRIPTION
Persist each tick's requested-key set so read-only views can tell current records from superseded ones.

Records are content-keyed, so editing a task fn or removing a config orphans the old record under a key no wake will ever request again. Those orphans corrupted the run's aggregate state, breaking the poll-until-terminal contract the monitor agent and scheduled routines rely on. Reproduced live with a 3-cell sweep where one cell fails and the fn is then fixed:

- After fix + `run`: the DAG printed `✓ complete` while `ls` reported the experiment `✗ failed` — forever.
- After fix + `retry`: the orphaned FAILED record reset to a phantom `pending` that no tick relaunches, so `status` reported `running` — forever. A scheduled routine's self-removal ("when status shows a terminal state") would never fire.

**The fix.** `Ctx` records every key it resolves (hit, in-flight, or launched); `tick` persists that set into the existing `__run__` meta record — no new infra, and `main` replays from the top each wake so the set is complete up to the suspension point. Read-side consumers split records against it:

- `status` / `ls` / `run` aggregate over current records only; orphans stay visible but marked `(superseded)` — they may hold results, or an orphaned worker still burning.
- `results` omits superseded records from the gather (with a count), so a stale result can't sneak into an analysis.
- `mini watch` settles on the current set, so a read-only watch of a re-keyed run terminates.
- `retry` skips superseded records — resetting one just plants a phantom — while an explicit `--key` still overrides (deliberate intent beats the manifest).

Stores without a manifest (written before this change, or never ticked) treat every record as current, so existing runs read exactly as before. The manifest also gives GC (#15) its root set for free.

**Docs.** Corrects the "blast radius is one task" hotfix claim in `running.md` and the monitor agent: editing a fn re-keys *every call of it*, so a `map`'s whole fan-out re-runs — `retry --key` without an edit is the only one-task path. (A bounded per-cell fix mechanism is a separate design question.)

**Tested** with new orchestration + CLI tests covering the manifest, supersession, retry-skip, and the exact status/ls scenario above; full suite green (200 passed). Also verified live end-to-end: the repro that showed `running` forever now reads `done (3 tasks) (+3 superseded)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)