### PR TITLE
Harden the memo fingerprint and add mini explain

### DIFF
--- a/.agents/skills/mi-ni/references/memoization.md
+++ b/.agents/skills/mi-ni/references/memoization.md
@@ -15,13 +15,40 @@ key = fingerprint(source(fn) + source(project fns/classes fn calls, transitively
   wake is a fresh process, so it would miss the cache _every wake_. The source
   fingerprint is deterministic across processes.
 - **Transitive over your own code.** It includes the source of the project
-  functions and classes `fn` references, so editing a helper your task calls
-  invalidates the task. **Site-packages and the mini framework are excluded**, so
-  library churn (or editing mini itself) doesn't bust your cache.
-- **Inputs are part of the key.** `pickle`-stable inputs (dict/list/tuple/str/num)
-  fingerprint deterministically.
+  functions and classes `fn` references — by bare name, as a module attribute
+  (`utils.helper()`), from inside a nested lambda/comprehension, or from a method
+  of a class the task uses — plus **plain module-level values** the code reads (a
+  module-level `LR`, a config table), so editing any of them invalidates the task.
+  **Site-packages and the mini framework are excluded**, so library churn (or
+  editing mini itself) doesn't bust your cache.
+- **Inputs are part of the key.** Plain data (dict/list/tuple/str/num, dataclasses,
+  pydantic models, enums, `Artifact`s) fingerprints deterministically; a *function*
+  passed as data keys by its source, not its identity. An input with no stable
+  encoding (an object whose repr embeds its address) logs a loud warning — it can
+  never cache, so the task would relaunch every wake.
 - **`version=` is an explicit override** added to the hash — bump it to force a
   re-run without editing code.
+
+### What the fingerprint cannot see
+
+Coverage is biased toward over-invalidation (a spurious re-run is visible and
+bounded; a stale hit silently poisons results), but some dependencies are
+invisible by nature — fold them into the *inputs* instead:
+
+- **Files read at runtime.** Pass an `Artifact` handle (keys by content), not a
+  path the task opens.
+- **Env vars and machine state.** Pass them as arguments if they affect the result.
+- **Attributes on instances** (`self.x` set elsewhere, monkeypatching) and values
+  with no stable JSON encoding — not tracked; keep task behavior in code and plain
+  data.
+
+### `mini explain`: why did this re-run?
+
+Each launched record stores its fingerprint evidence — code hash, input hash, and
+a short hash per tracked dependency. `mini explain <name> <key>` prints them and
+diffs the record against its sibling (the same fn under another key), naming
+exactly what moved: `inputs: unchanged · helper: changed`. Use it whenever a memo
+hit or miss surprises you.
 
 Why not key on inputs alone? Because after you fix a bug, pure input-keying
 returns the _stale, buggy_ result — the opposite of what the loop needs. Source

--- a/.agents/skills/mi-ni/references/running.md
+++ b/.agents/skills/mi-ni/references/running.md
@@ -51,7 +51,9 @@ record under `env`.
 relaunch them (a deterministic failure shouldn't busy-loop). Recover on purpose:
 `bin/mini logs <exp> <key>` to read the traceback, fix, then `bin/mini retry
 <exp>` (`--key <key>` for one). To re-run a `DONE` task, edit its fn or bump
-`version=` — a memo hit is never silently re-run.
+`version=` — a memo hit is never silently re-run. If a re-run or memo hit
+*surprises* you, `bin/mini explain <exp> <key>` shows the key's evidence and
+diffs it against its sibling record (code vs. inputs, per-dependency).
 
 ### Hotfix safety (avoid double-spending)
 

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -14,6 +14,7 @@ agent (or you) can drive, poll, and gather without holding a session open:
     python -m mini status pipeline                             # per-task state + metrics, by NAME
     python -m mini results pipeline                            # per-task results
     python -m mini logs   pipeline <key>                       # a failed task's traceback
+    python -m mini explain pipeline <key>                      # why this key: code/input hashes, dep diff
     python -m mini cancel pipeline                             # stop in-flight tasks
 
 State is addressed by experiment NAME (one memo store per experiment). Read
@@ -312,6 +313,53 @@ def cmd_logs(args: argparse.Namespace) -> None:
     print(_store_for(args.name, args).error(args.key))
 
 
+def cmd_explain(args: argparse.Namespace) -> None:
+    """Show the evidence behind a task's memo key — and why it differs from a sibling.
+
+    Each record stores its fingerprint parts (code vs. input hash, plus a short
+    hash per tracked dependency). ``explain`` prints them and, when another record
+    ran the same fn under a different key, diffs the two — answering "why did this
+    re-run" / "why is that record superseded" down to the dependency that moved.
+    """
+    store = _store_for(args.name, args)
+    rec = store.record(args.key)
+    if not rec.get('state') and not rec.get('deps'):
+        raise SystemExit(f'no record for key {args.key!r} in experiment {args.name!r}')
+    requested = set(store.requested_keys() or [])
+    suffix = '' if not requested or args.key in requested else '  (superseded)'
+    print(f'{rec["key"]}  {rec.get("fn", "task")}  {_rec_state(rec)}{suffix}')
+    print(f'  code {rec.get("code_fp", "?")} · inputs {rec.get("input_fp", "?")} · version {rec.get("version", "-")}')
+    deps: dict[str, str] = rec.get('deps') or {}
+    for name, h in sorted(deps.items()):
+        print(f'    {name:40} {h}')
+    if not deps:
+        print('    (no dependency manifest — record predates `explain`)')
+        return
+    # Diff against the best sibling: another record of the same fn, preferring one
+    # the current DAG requests (the "replacement"), then the most recent.
+    siblings = [
+        r
+        for r in store.records()
+        if r.get('fn') == rec.get('fn') and r['key'] != rec['key'] and r.get('deps') and r.get('input_fp')
+    ]
+    if not siblings:
+        return
+    other = max(siblings, key=lambda r: (r['key'] in requested, r.get('created_at', 0)))
+    other_deps: dict[str, str] = other['deps']
+    print(f'  vs {other["key"]} ({_rec_state(other)}{"" if other["key"] in requested else ", superseded"}):')
+    print(f'    inputs: {"unchanged" if other.get("input_fp") == rec.get("input_fp") else "changed"}')
+    if other.get('version') != rec.get('version'):
+        print(f'    version: {rec.get("version", "-")} → {other.get("version", "-")}')
+    for name in sorted(deps.keys() | other_deps.keys()):
+        a, b = deps.get(name), other_deps.get(name)
+        if a == b:
+            continue
+        what = 'changed' if a and b else ('only here' if a else 'only there')
+        print(f'    {name}: {what}' + (f' ({a} → {b})' if a and b else ''))
+    if deps == other_deps:
+        print('    code: unchanged')
+
+
 def cmd_cancel(args: argparse.Namespace) -> None:
     apparatus = _build_apparatus(args.name, args)
     cancelled = apparatus.cancel(apparatus.memo_store())
@@ -383,6 +431,12 @@ def main() -> None:
     p.add_argument('key')
     _add_app_flag(p)
     p.set_defaults(func=cmd_logs)
+
+    p = sub.add_parser('explain', help="show a task's memo-key evidence and diff it against its sibling")
+    p.add_argument('name')
+    p.add_argument('key')
+    _add_app_flag(p)
+    p.set_defaults(func=cmd_explain)
 
     p = sub.add_parser('cancel', help='stop in-flight tasks and mark them cancelled')
     p.add_argument('name')

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -13,21 +13,27 @@ churn (site-packages and the mini framework itself are excluded).
 from __future__ import annotations
 
 import dataclasses
+import dis
+import enum
+import functools
 import hashlib
 import inspect
 import json
+import logging
 import time
 import types
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from pathlib import Path
-from typing import Any, Callable
+from pathlib import Path, PurePath
+from typing import Any, Callable, Iterator
 
 import cloudpickle
 
 from mini.runs import SETTLED, RunState, _atomic_write, _merge_json
 
-__all__ = ['fingerprint', 'RecordStore', 'LocalRecordStore', 'MemoStore', 'PollCache', 'META_KEY']
+__all__ = ['fingerprint', 'fingerprint_parts', 'RecordStore', 'LocalRecordStore', 'MemoStore', 'PollCache', 'META_KEY']
+
+log = logging.getLogger(__name__)
 
 # Source under these roots is treated as an opaque, stable dependency: the
 # stdlib, installed packages, and the mini framework itself (so editing mini
@@ -53,6 +59,104 @@ def _is_project_source(obj: Any) -> bool:
     return 'site-packages' not in rf and '/lib/python3' not in rf and not rf.startswith(_MINI_DIR)
 
 
+def _nested_codes(code: types.CodeType) -> Iterator[types.CodeType]:
+    """*code* plus every code object nested in it (inner defs, lambdas, genexprs).
+
+    A helper referenced only inside a nested function lives in the *inner* code
+    object's ``co_names``; walking just the outer one would miss it.
+    """
+    yield code
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            yield from _nested_codes(const)
+
+
+def _attr_chain_refs(fn: Callable) -> list[Any]:
+    """Objects reached through attribute chains rooted at a global (``utils.helper``).
+
+    Bare names are resolved via ``co_names`` ∩ globals, but a helper called as a
+    module attribute never appears in globals under its own name — so without this
+    walk, ``import utils; utils.helper()`` would be *invisible* to the fingerprint
+    and editing the helper would silently serve stale results. We scan the bytecode
+    for ``LOAD_GLOBAL`` → ``LOAD_ATTR``… chains and resolve each step with
+    ``getattr``, collecting any function/class the chain lands on (``pkg.mod.fn``
+    resolves through the intermediate modules).
+    """
+    code = getattr(fn, '__code__', None)
+    g = getattr(fn, '__globals__', {})
+    if code is None:
+        return []
+    refs: list[Any] = []
+    for c in _nested_codes(code):
+        chain: Any = None
+        for ins in dis.get_instructions(c):
+            if ins.opname == 'LOAD_GLOBAL' and ins.argval in g:
+                chain = g[ins.argval]
+            elif ins.opname == 'LOAD_ATTR' and chain is not None:
+                chain = getattr(chain, ins.argval, None)
+                if callable(chain) or isinstance(chain, type):
+                    refs.append(chain)
+            else:
+                chain = None  # any other instruction breaks the chain
+    return refs
+
+
+def _collect_class(cls: type, seen: dict[str, str]) -> None:
+    """Collect a class's source, then traverse its methods' *references*.
+
+    The class source already contains the method bodies textually (so editing a
+    method invalidates); traversing the methods is what picks up the helpers and
+    project bases they *call*, which the text alone doesn't reach.
+    """
+    if cls.__qualname__ in seen:
+        return
+    try:
+        seen[cls.__qualname__] = inspect.getsource(cls)
+    except TypeError, OSError:
+        return
+    for base in cls.__bases__:
+        if _is_project_source(base):
+            _collect_class(base, seen)
+    for member in vars(cls).values():
+        if isinstance(member, (staticmethod, classmethod)):
+            member = member.__func__
+        if isinstance(member, types.FunctionType):
+            _collect_sources(member, seen)
+
+
+def _value_json(obj: Any) -> str | None:
+    """A stable JSON encoding of a plain value, or ``None`` if it has none.
+
+    No ``default=`` fallback here: an exotic object's ``repr`` can embed a memory
+    address, which would make the fingerprint differ every process — worse than
+    not tracking the value at all. Stable-or-skip.
+    """
+    try:
+        return json.dumps(_canonical(obj), sort_keys=True)
+    except TypeError, ValueError:
+        return None
+
+
+def _named_refs(fn: Callable) -> list[tuple[str | None, Any]]:
+    """Everything *fn* references, as ``(name, object)`` pairs.
+
+    Bare globals (from every nested code object), closure cells (named via
+    ``co_freevars``), and attribute-chain targets (unnamed — they're never
+    treated as values, only as code).
+    """
+    code = getattr(fn, '__code__', None)
+    g = getattr(fn, '__globals__', {})
+    names = [n for c in _nested_codes(code) for n in c.co_names] if code is not None else []
+    refs: list[tuple[str | None, Any]] = [(n, g[n]) for n in names if n in g]
+    freevars = code.co_freevars if code is not None else ()
+    for name, cell in zip(freevars, getattr(fn, '__closure__', None) or (), strict=False):
+        try:
+            refs.append((name, cell.cell_contents))
+        except ValueError:
+            pass
+    return refs + [(None, obj) for obj in _attr_chain_refs(fn)]
+
+
 def _collect_sources(fn: Callable, seen: dict[str, str]) -> None:
     qualname = getattr(fn, '__qualname__', repr(fn))
     if qualname in seen:
@@ -61,28 +165,36 @@ def _collect_sources(fn: Callable, seen: dict[str, str]) -> None:
         seen[qualname] = inspect.getsource(fn)
     except TypeError, OSError:
         return
-    code = getattr(fn, '__code__', None)
-    g = getattr(fn, '__globals__', {})
-    refs: list[Any] = [g[n] for n in code.co_names if n in g] if code is not None else []
-    for cell in getattr(fn, '__closure__', None) or []:
-        try:
-            refs.append(cell.cell_contents)
-        except ValueError:
-            pass
-    for obj in refs:
+    for name, obj in _named_refs(fn):
+        if isinstance(obj, types.MethodType):
+            obj = obj.__func__
         if isinstance(obj, types.FunctionType) and _is_project_source(obj):
             _collect_sources(obj, seen)
         elif isinstance(obj, type) and _is_project_source(obj):
-            try:
-                seen.setdefault(obj.__qualname__, inspect.getsource(obj))
-            except TypeError, OSError:
-                pass
+            _collect_class(obj, seen)
+        elif name is not None and not isinstance(obj, types.ModuleType) and not callable(obj):
+            # A plain value referenced by name (a module-level LR, a config table):
+            # fold its canonical JSON in, so editing the *value* invalidates like
+            # editing code. Skipped when it has no stable encoding (see _value_json).
+            if (js := _value_json(obj)) is not None:
+                seen[f'{qualname}::{name}'] = js
+
+
+@functools.lru_cache(maxsize=256)
+def _sources_for(fn: Callable) -> tuple[tuple[str, str], ...]:
+    """The (cached) sorted dependency manifest for *fn*: ``(name, source-or-value)``.
+
+    Source never changes within one process (every wake is a fresh process), so
+    this caches per fn object — a ``ctx.map`` fingerprints its fn once per wake
+    instead of re-walking the reference graph for every cell.
+    """
+    seen: dict[str, str] = {}
+    _collect_sources(fn, seen)
+    return tuple(sorted(seen.items()))
 
 
 def _code_fingerprint(fn: Callable) -> str:
-    seen: dict[str, str] = {}
-    _collect_sources(fn, seen)
-    blob = '\n--\n'.join(f'{k}:{v}' for k, v in sorted(seen.items()))
+    blob = '\n--\n'.join(f'{k}:{v}' for k, v in _manifest(fn))
     return hashlib.sha256(blob.encode()).hexdigest()
 
 
@@ -105,13 +217,44 @@ def _canonical(o: Any) -> Any:
             return _canonical(dump())
     if dataclasses.is_dataclass(o) and not isinstance(o, type):
         return _canonical(dataclasses.asdict(o))
+    if isinstance(o, enum.Enum):
+        return [type(o).__qualname__, _canonical(o.value)]
     if isinstance(o, Mapping):
         return {str(k): _canonical(v) for k, v in o.items()}
     if isinstance(o, (set, frozenset)):
         return sorted((_canonical(x) for x in o), key=lambda v: json.dumps(v, sort_keys=True, default=repr))
     if isinstance(o, (list, tuple)):
         return [_canonical(x) for x in o]
+    if isinstance(o, PurePath):
+        return str(o)  # a path keys by *location* — prefer an Artifact, which keys by content
+    if (code := _canonical_code(o)) is not None:
+        return code
     return o
+
+
+def _canonical_code(o: Any) -> list | None:
+    """Canonical forms for *code passed as data* — keyed by source, not identity.
+
+    A callable's repr embeds a memory address, so without these a callable input
+    would produce a fresh key every process — relaunching the task on every wake.
+    Returns ``None`` for non-code values (handled by :func:`_canonical`).
+    """
+    if isinstance(o, types.MethodType):
+        return ['method', o.__func__.__qualname__, _code_fingerprint(o.__func__)[:12], _canonical(o.__self__)]
+    if isinstance(o, types.FunctionType):
+        return ['fn', o.__qualname__, _code_fingerprint(o)[:12]]
+    if isinstance(o, type):
+        return ['class', o.__qualname__, hashlib.sha256(_class_source(o).encode()).hexdigest()[:12]]
+    if isinstance(o, functools.partial):
+        return ['partial', _canonical(o.func), _canonical(o.args), _canonical(o.keywords)]
+    return None
+
+
+def _class_source(cls: type) -> str:
+    try:
+        return inspect.getsource(cls)
+    except TypeError, OSError:
+        return cls.__qualname__  # no source (builtin/C) — the name is the stable id
 
 
 def _input_fingerprint(args: tuple) -> str:
@@ -119,17 +262,67 @@ def _input_fingerprint(args: tuple) -> str:
         blob = json.dumps(_canonical(args), sort_keys=True, default=repr).encode()
     except Exception:
         blob = repr(args).encode()
+    if b' at 0x' in blob:  # an object address leaked into the key
+        log.warning(
+            'task inputs have no stable encoding (repr contains an object address), so the memo '
+            'key will differ every process and the task can never be a cache hit — it will relaunch '
+            'on every wake. Pass plain data, dataclasses, or Artifact handles instead: %.200r',
+            args,
+        )
     return hashlib.sha256(blob).hexdigest()
+
+
+# Guards fn-value cycles: a module-level container holding the fn that references
+# it would recurse (collect fn → canonicalize the container → fingerprint fn → …).
+# The marker is a constant per qualname, so the resulting manifest stays
+# deterministic across processes.
+_collecting: set[int] = set()
+
+
+def _manifest(fn: Callable) -> tuple[tuple[str, str], ...]:
+    if id(fn) in _collecting:
+        return ((f'<recursive:{getattr(fn, "__qualname__", "?")}>', ''),)
+    _collecting.add(id(fn))
+    try:
+        try:
+            return _sources_for(fn)
+        except TypeError:  # unhashable callable — compute uncached
+            seen: dict[str, str] = {}
+            _collect_sources(fn, seen)
+            return tuple(sorted(seen.items()))
+    finally:
+        _collecting.discard(id(fn))
 
 
 def fingerprint(fn: Callable, args: tuple, version: str | None = None) -> str:
     """A stable content key for calling *fn* with *args* (the memo key)."""
+    return fingerprint_parts(fn, args, version)[0]
+
+
+def fingerprint_parts(fn: Callable, args: tuple, version: str | None = None) -> tuple[str, dict[str, Any]]:
+    """The memo key plus the evidence behind it, for the record (``mini explain``).
+
+    Returns ``(key, parts)`` where *parts* carries the code and input fingerprints
+    separately (so "why did this re-run" splits into "code changed" vs "inputs
+    changed") and ``deps`` — a short hash per tracked dependency (the fn itself,
+    each project helper/class it references, each plain-value global) — so two
+    records can be diffed down to *which* dependency moved.
+    """
+    manifest = _manifest(fn)
+    blob = '\n--\n'.join(f'{k}:{v}' for k, v in manifest)
+    code_fp = hashlib.sha256(blob.encode()).hexdigest()
+    input_fp = _input_fingerprint(args)
     h = hashlib.sha256()
-    h.update(_code_fingerprint(fn).encode())
-    h.update(_input_fingerprint(args).encode())
+    h.update(code_fp.encode())
+    h.update(input_fp.encode())
     if version:
         h.update(version.encode())
-    return f'{getattr(fn, "__name__", "task")}-{h.hexdigest()[:12]}'
+    key = f'{getattr(fn, "__name__", "task")}-{h.hexdigest()[:12]}'
+    deps = {k: hashlib.sha256(v.encode()).hexdigest()[:8] for k, v in manifest}
+    parts = {'code_fp': code_fp[:12], 'input_fp': input_fp[:12], 'deps': deps}
+    if version:
+        parts['version'] = version
+    return key, parts
 
 
 class RecordStore(ABC):
@@ -281,15 +474,24 @@ class MemoStore:
         """
         self.records_backend.write(key, {'key': key, 'state': None})
 
-    def mark_running(self, fn: Callable, key: str) -> None:
+    def mark_running(self, fn: Callable, key: str, parts: dict[str, Any] | None = None) -> None:
         """Flip the record to RUNNING (wholesale, clearing any prior error).
 
         Called by ``Ctx`` before the apparatus spawns the worker, so a poll
         between stage and first heartbeat sees RUNNING rather than a stale state.
+        *parts* is the fingerprint evidence (``code_fp``/``input_fp``/``deps``
+        from :func:`fingerprint_parts`), stored so ``mini explain`` can answer
+        "why did this re-run" after the fact.
         """
         self.records_backend.write(
             key,
-            {'key': key, 'fn': getattr(fn, '__name__', 'task'), 'state': RunState.RUNNING, 'created_at': time.time()},
+            {
+                'key': key,
+                'fn': getattr(fn, '__name__', 'task'),
+                'state': RunState.RUNNING,
+                'created_at': time.time(),
+                **(parts or {}),
+            },
         )
 
     def write_call(self, key: str, fn: Callable, args: tuple, hooks: list[Callable] | None = None) -> None:

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, overload
 
-from mini.memo import MemoStore, fingerprint
+from mini.memo import MemoStore, fingerprint_parts
 from mini.runs import SETTLED, RunState
 
 if TYPE_CHECKING:
@@ -153,12 +153,12 @@ class Ctx:
         and return its batch entry — *without* spawning. The caller batches the
         spawn so a ``map`` fans out in one ``spawn_tasks`` call.
         """
-        key = fingerprint(fn, args, version)
+        key, parts = fingerprint_parts(fn, args, version)
         self.requested.append(key)
         state = self.store.state(key)
         to_launch: tuple[str, Callable, tuple, list] | None = None
         if state is None:  # never run; FAILED/CANCELLED are terminal (retry takes intent)
-            self.store.mark_running(fn, key)
+            self.store.mark_running(fn, key, parts)
             to_launch = (key, fn, args, getattr(app, '_before_hooks', []))
             self.launched.append(key)
             state = RunState.RUNNING

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -108,6 +108,50 @@ def test_status_and_ls_report_done_despite_superseded_failure(tmp_path: Path, mo
     assert 'done' in ls_out and '+1 superseded' in ls_out
 
 
+def test_explain_diffs_superseded_record_against_replacement(tmp_path: Path, monkeypatch, capsys):
+    """After a hotfix, ``explain <old-key>`` must answer "why was this re-keyed":
+    same inputs, code changed — naming the dependency that moved."""
+    monkeypatch.chdir(tmp_path)
+
+    def make(fixed: bool):
+        if fixed:
+
+            def work(x):
+                return x
+        else:
+
+            def work(x):
+                raise RuntimeError('bug')
+
+        return work
+
+    def sweep(fn):
+        return Experiment(name='explain', main=lambda ctx: ctx.map(fn, [(1,)]))
+
+    app = LocalApparatus('explain')
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            tick(sweep(make(fixed=False)), app)
+        except ExceptionGroup:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError('map never surfaced the failure')
+    _drive(sweep(make(fixed=True)), LocalApparatus('explain'))
+
+    store = app.memo_store()
+    (failed_key,) = [r['key'] for r in store.records() if r.get('state') == RunState.FAILED]
+
+    from mini.__main__ import cmd_explain
+
+    cmd_explain(argparse.Namespace(name='explain', key=failed_key, app='local'))
+    out = capsys.readouterr().out
+    assert '(superseded)' in out  # the old key is no longer requested
+    assert 'inputs: unchanged' in out  # same args — the hotfix changed code, not inputs
+    assert 'changed' in out  # the fn's own dep hash moved
+
+
 def test_cancel_stops_running_task(tmp_path: Path):
     def slow(x):
         import time

--- a/tests/mini/test_fingerprint.py
+++ b/tests/mini/test_fingerprint.py
@@ -1,0 +1,171 @@
+"""Fingerprint semantics: what invalidates a memo key, and what must not.
+
+The contract has two sides. *Honesty*: editing anything a task actually depends
+on — a helper (however it's referenced), a module-level constant, a method —
+must change the key, or a re-run silently serves stale results. *Stability*: the
+key must be identical across processes and across distinct-but-identical
+function objects, or a task relaunches on every wake.
+
+Module-level dependencies are exercised with real modules written to disk (the
+fingerprint reads *source*, so the functions must have files); "editing" is
+simulated by loading a variant of the module from a sibling directory with the
+same module name, keeping the task's own source byte-identical.
+"""
+
+from __future__ import annotations
+
+import enum
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from mini.memo import fingerprint, fingerprint_parts
+
+TASK_ATTR = 'import helpers\n\ndef task(x):\n    return helpers.helper(x)\n'
+TASK_NESTED = 'from helpers import helper\n\ndef task(xs):\n    inner = lambda v: helper(v)  # noqa: E731\n    return [inner(x) for x in xs]\n'
+TASK_METHOD = 'from helpers import helper\n\nclass Model:\n    def run(self, x):\n        return helper(x)\n\ndef task(x):\n    return Model().run(x)\n'
+TASK_VALUE = 'LR = 0.1\n\ndef task(x):\n    return x * LR\n'
+
+HELPER_V1 = 'def helper(x):\n    return x + 1\n'
+HELPER_V2 = 'def helper(x):\n    return x + 2\n'
+
+
+@pytest.fixture
+def load_module(tmp_path: Path):
+    """Write and import a module from a per-variant subdir; unimport on teardown."""
+    loaded: list[str] = []
+
+    def _load(name: str, source: str, variant: str):
+        d = tmp_path / variant
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f'{name}.py'
+        path.write_text(source)
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod  # so `import helpers` inside a task module resolves
+        loaded.append(name)
+        spec.loader.exec_module(mod)
+        return mod
+
+    yield _load
+    for name in loaded:
+        sys.modules.pop(name, None)
+
+
+def _fp_with_helper(load_module, task_src: str, helper_src: str, variant: str) -> str:
+    load_module('helpers', helper_src, variant)
+    tasks = load_module('tasks', task_src, variant)
+    return fingerprint(tasks.task, (1,))
+
+
+@pytest.mark.parametrize(
+    'task_src',
+    [TASK_ATTR, TASK_NESTED, TASK_METHOD],
+    ids=['module-attr call', 'nested-code reference', 'via a method'],
+)
+def test_helper_edits_invalidate_however_referenced(load_module, task_src: str):
+    """Editing a helper must re-key the task whether it's called by bare name,
+    as a module attribute (``helpers.helper``), from inside a nested lambda /
+    comprehension, or from a method of a class the task uses. The task's own
+    source is byte-identical across variants — only the helper differs — and an
+    identical copy must produce an identical key (no path or object identity in
+    the fingerprint)."""
+    fp_v1 = _fp_with_helper(load_module, task_src, HELPER_V1, 'a')
+    fp_v2 = _fp_with_helper(load_module, task_src, HELPER_V2, 'b')
+    fp_v1_copy = _fp_with_helper(load_module, task_src, HELPER_V1, 'c')
+    assert fp_v1 != fp_v2, 'editing the helper did not change the key — stale results would be served'
+    assert fp_v1 == fp_v1_copy, 'identical source produced different keys — the task could never cache'
+
+
+def test_module_level_value_edits_invalidate(load_module):
+    """A module-level constant a task reads (``LR``) is part of its behavior:
+    editing the value must re-key the task, exactly like editing code."""
+    fp_v1 = fingerprint(load_module('tasks', TASK_VALUE, 'a').task, (1,))
+    fp_v2 = fingerprint(load_module('tasks', TASK_VALUE.replace('0.1', '0.2'), 'b').task, (1,))
+    fp_v1_copy = fingerprint(load_module('tasks', TASK_VALUE, 'c').task, (1,))
+    assert fp_v1 != fp_v2
+    assert fp_v1 == fp_v1_copy
+
+
+def _make_callback(delta: int):
+    """A fresh function object per call — same source, different identity."""
+    if delta == 1:
+
+        def cb(x):
+            return x + 1
+    else:
+
+        def cb(x):
+            return x + 2
+
+    return cb
+
+
+def test_callable_inputs_key_by_source_not_identity():
+    """A function passed as *data* must fingerprint by its source: two fresh
+    objects of the same source coincide (a repr would embed a memory address and
+    relaunch the task every wake), while a different body diverges."""
+
+    def apply(f, x):
+        return f(x)
+
+    assert fingerprint(apply, (_make_callback(1), 5)) == fingerprint(apply, (_make_callback(1), 5))
+    assert fingerprint(apply, (_make_callback(1), 5)) != fingerprint(apply, (_make_callback(2), 5))
+
+
+class _Color(enum.Enum):
+    RED = 1
+    BLUE = 2
+
+
+def test_enum_and_path_inputs_are_stable_and_distinct():
+    def t(v):
+        return v
+
+    assert fingerprint(t, (_Color.RED,)) == fingerprint(t, (_Color.RED,))
+    assert fingerprint(t, (_Color.RED,)) != fingerprint(t, (_Color.BLUE,))
+    assert fingerprint(t, (Path('/a/b'),)) == fingerprint(t, (Path('/a/b'),))
+    assert fingerprint(t, (Path('/a/b'),)) != fingerprint(t, (Path('/a/c'),))
+
+
+def test_self_referential_global_does_not_recurse(load_module):
+    """A module-level container holding the task itself (a registry pattern) must
+    not send the collector into infinite recursion."""
+    src = 'CALLBACKS = []\n\ndef task(x):\n    return len(CALLBACKS) + x\n\nCALLBACKS.append(task)\n'
+    mod = load_module('tasks', src, 'a')
+    assert fingerprint(mod.task, (1,))  # completes; no RecursionError
+
+
+def test_fingerprint_parts_split_code_from_inputs(load_module):
+    """``explain`` relies on the parts: same code + different inputs moves only
+    ``input_fp``; an edited helper moves only ``code_fp`` (and names the dep)."""
+    load_module('helpers', HELPER_V1, 'a')
+    tasks = load_module('tasks', TASK_ATTR, 'a')
+    _, p1 = fingerprint_parts(tasks.task, (1,))
+    _, p2 = fingerprint_parts(tasks.task, (2,))
+    assert p1['code_fp'] == p2['code_fp'] and p1['input_fp'] != p2['input_fp']
+
+    load_module('helpers', HELPER_V2, 'b')
+    tasks_b = load_module('tasks', TASK_ATTR, 'b')
+    _, p3 = fingerprint_parts(tasks_b.task, (1,))
+    assert p3['input_fp'] == p1['input_fp'] and p3['code_fp'] != p1['code_fp']
+    changed = [k for k in p1['deps'] if p3['deps'].get(k) != p1['deps'][k]]
+    assert changed == ['helper']  # the diff names exactly the dependency that moved
+
+
+def test_repr_fallback_warns_about_unstable_inputs(caplog):
+    """Inputs with no stable encoding (an object whose repr embeds its address)
+    can never cache — that's a silent money-burner, so it must warn."""
+
+    class Opaque:
+        __slots__ = ()
+
+    def t(o):
+        return o
+
+    with caplog.at_level('WARNING', logger='mini.memo'):
+        fingerprint(t, (Opaque(),))
+    assert any('never be a cache hit' in r.message for r in caplog.records)

--- a/todo.md
+++ b/todo.md
@@ -11,4 +11,12 @@ The storage / artifacts / publishing backlog has moved out of here:
   #39 (wire the store through interactive `app.map`/`arun`), #15 (GC), #19 (queued vs.
   running visibility).
 
-_(Empty otherwise — add notes below.)_
+- **Late-orphan writes to mutable names.** A superseded worker (fn edited under a
+  live run, against the hotfix rules) runs to completion and can last-writer-win a
+  mutable name *after* its replacement already wrote it: `set_ref`, `publish`, and
+  shared volume paths (`get_data_dir()` filenames). Memo results (per-key dirs) and
+  CAS blobs (content-addressed) are immune. Auto-cancelling orphans at tick time is
+  wrong — mid-run the requested-set manifest is only a lower bound, so it would kill
+  in-flight downstream tasks and settle them CANCELLED (terminal). Options if it
+  bites: per-task scratch dirs on the volume, or a generation stamp on refs. For now
+  the guard is the existing rule: `cancel` before editing.


### PR DESCRIPTION
Close the fingerprint's silent coverage gaps and store the evidence behind each memo key, surfaced by a new `mini explain` verb.

**The honesty gaps** (each meant an edit that did *not* re-key a task, so a re-run served stale results with no warning — the exact dishonesty the source fingerprint exists to prevent):

- Helpers called as module attributes (`import utils; utils.helper()`) — only bare names in `co_names` ∩ globals were followed. Now a bytecode walk resolves `LOAD_GLOBAL → LOAD_ATTR…` chains through project modules.
- References made only inside nested code objects (inner defs, lambdas) — now traversed.
- Helpers called from methods of classes the task uses — the class source was captured textually, but its methods' *references* were never followed. Now they are (project bases too).
- Plain module-level values (`def train(): return LR * 2`) — editing `LR` changed nothing. Now folded in by canonical JSON, stable-or-skip (never `repr`, whose addresses would flip the key every process).

**The stability gap** (the opposite failure): a function passed as *data* canonicalized via `repr`, embedding a memory address — a fresh key every process, so the task could never cache and **relaunched on every wake**, silently burning compute. Functions/methods/classes/partials now key by source; Enum and Path get stable forms; anything that still falls back to an address-bearing repr logs a loud warning.

Plus: a reentrancy guard for fn-value cycles (a registry list holding the task itself), and an lru-cached per-fn manifest so a `map` fingerprints its fn once per wake instead of once per cell.

**Transparency.** `fingerprint_parts()` returns the evidence behind a key — `code_fp` and `input_fp` separately, plus a short hash per tracked dependency — stored on the record at launch. `mini explain <exp> <key>` prints it and diffs against the record's sibling:

```
work-4581cee0c3f8  work  failed  (superseded)
  code 52bf2edfc526 · inputs 038966de9f6b · version -
    work                                     1492a80f
    work::SCALE                              4a44dc15
  vs work-b4c3c9794896 (done):
    inputs: unchanged
    work: changed (1492a80f → d78b1e9b)
```

**Cache impact.** Tasks with no newly-tracked deps keep their keys — verified live: the pipeline example re-runs as pure memo hits. A task that *does* gain deps re-keys once, correctly (those deps were untracked before). Records written before this change show `(no dependency manifest)` in `explain` and are otherwise unaffected.

Docs updated (memoization.md: real coverage, what the fingerprint *cannot* see and the conventions for each, `explain`; running.md: recovery pointer). Also a todo note on the late-orphan mutable-name race discussed in review. Full suite green (210 passed), including new per-gap tests driven through real on-disk modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)