### PR TITLE
Key memo records by task identity; code moves to attempt evidence

### DIFF
--- a/.agents/skills/mi-ni/references/authoring.md
+++ b/.agents/skills/mi-ni/references/authoring.md
@@ -37,9 +37,12 @@ runnable example.
 
 ## Write cache-friendly experiments
 
-The memo key is `fingerprint(source of fn + the project fns it calls) + inputs`
-(full semantics in [memoization.md](./memoization.md)). To keep the "fix a bug,
-re-run" loop fast and honest:
+The memo key is the task's *identity* — `fn name + fingerprint(inputs)` — and
+each attempt carries *evidence* (`fingerprint(source of fn + the project fns it
+calls)`) that decides whether its cached result is still current; stale evidence
+re-runs the task in place, under the same key (full semantics in
+[memoization.md](./memoization.md)). To keep the "fix a bug, re-run" loop fast
+and honest:
 
 - **Pass each task the narrow subset of config it actually uses.** `train(lr,
   vocab_size)` re-runs only when `lr` or `vocab_size` change; `train(whole_config)`
@@ -48,9 +51,9 @@ re-run" loop fast and honest:
   there; do heavy or random work _inside_ a task.
 - **Fold RNG seeds into the inputs**, so the memo is honest (same inputs ⇒ same
   result). A task seeded from wall-clock can never be a cache hit.
-- **Force a re-run** by editing the function (its source fingerprint changes) or
-  passing `version='v2'`. Editing a project helper a task calls also invalidates
-  it; library/framework churn does not.
+- **Force a re-run** by editing the function (its evidence goes stale) or passing
+  `version='v2'` — either way a new attempt on the same record. Editing a project
+  helper a task calls also invalidates it; library/framework churn does not.
 
 ## Returning large outputs
 

--- a/.agents/skills/mi-ni/references/memoization.md
+++ b/.agents/skills/mi-ni/references/memoization.md
@@ -1,33 +1,44 @@
-# Memoization: keys, caching, and the recovery loop
+# Memoization: identity, evidence, and the recovery loop
 
-Every `ctx.run`/`ctx.map` call is content-addressed. The key decides whether a
-call is a cache hit, so understanding how it's computed is how you keep the
-"fix a bug, re-run" loop fast and honest.
+Every `ctx.run`/`ctx.map` call resolves to a durable record that answers two
+separate questions:
 
-## How the key is computed
+- **Identity — which task is this?** The *key*: the fn's qualified name plus a
+  fingerprint of its inputs. Stable across code edits, so a task's record, logs,
+  and results keep one address for the task's whole life.
+- **Validity — is the cached result current?** The *evidence* stamped on each
+  attempt: a fingerprint of the code the task actually depends on, plus
+  `version=`. Stale evidence re-runs the task **in place** — a new attempt on
+  the same record, with the old attempt kept in the record's history.
+
+Understanding both is how you keep the "fix a bug, re-run" loop fast and honest.
+
+## How the key and evidence are computed
 
 ```
-key = fingerprint(source(fn) + source(project fns/classes fn calls, transitively)) + fingerprint(inputs)
+key      = {fn name}-hash(fn's module-qualified name + fingerprint(inputs))
+evidence = fingerprint(source(fn) + source(project fns/classes fn calls, transitively)) + version
 ```
 
+- **Inputs are the identity.** Plain data (dict/list/tuple/str/num, dataclasses,
+  pydantic models, enums, `Artifact`s) fingerprints deterministically; a *function*
+  passed as data keys by its source, not its object identity. An input with no
+  stable encoding (an object whose repr embeds its address) logs a loud warning —
+  it can never cache, so the task would relaunch every wake. Renaming a fn is a
+  new identity (the old records read `(superseded)`); editing its body is not.
 - **Source, not bytes.** Hashing `cloudpickle.dumps(fn)` is tempting (it captures
   by-value dependencies) but its bytes differ across processes — and every agent
-  wake is a fresh process, so it would miss the cache _every wake_. The source
-  fingerprint is deterministic across processes.
-- **Transitive over your own code.** It includes the source of the project
-  functions and classes `fn` references — by bare name, as a module attribute
-  (`utils.helper()`), from inside a nested lambda/comprehension, or from a method
-  of a class the task uses — plus **plain module-level values** the code reads (a
-  module-level `LR`, a config table), so editing any of them invalidates the task.
-  **Site-packages and the mini framework are excluded**, so library churn (or
-  editing mini itself) doesn't bust your cache.
-- **Inputs are part of the key.** Plain data (dict/list/tuple/str/num, dataclasses,
-  pydantic models, enums, `Artifact`s) fingerprints deterministically; a *function*
-  passed as data keys by its source, not its identity. An input with no stable
-  encoding (an object whose repr embeds its address) logs a loud warning — it can
-  never cache, so the task would relaunch every wake.
-- **`version=` is an explicit override** added to the hash — bump it to force a
-  re-run without editing code.
+  wake is a fresh process, so nothing would ever look current. Both fingerprints
+  are deterministic across processes.
+- **Evidence is transitive over your own code.** It covers the source of the
+  project functions and classes `fn` references — by bare name, as a module
+  attribute (`utils.helper()`), from inside a nested lambda/comprehension, or from
+  a method of a class the task uses — plus **plain module-level values** the code
+  reads (a module-level `LR`, a config table), so editing any of them re-runs the
+  task. **Site-packages and the mini framework are excluded**, so library churn
+  (or editing mini itself) doesn't bust your cache.
+- **`version=` is explicit evidence** — bump it to force a re-run without editing
+  code. Like a code edit, the bump lands as a new attempt on the same record.
 
 ### What the fingerprint cannot see
 
@@ -44,15 +55,23 @@ invisible by nature — fold them into the *inputs* instead:
 
 ### `mini explain`: why did this re-run?
 
-Each launched record stores its fingerprint evidence — code hash, input hash, and
-a short hash per tracked dependency. `mini explain <name> <key>` prints them and
-diffs the record against its sibling (the same fn under another key), naming
-exactly what moved: `inputs: unchanged · helper: changed`. Use it whenever a memo
-hit or miss surprises you.
+Each attempt stamps its evidence on the record — code hash, input hash, and a
+short hash per tracked dependency — and a replaced attempt stays compacted in
+the record's history. `mini explain <name> <key>` prints the current evidence
+and walks the timeline, naming exactly what moved between attempts:
 
-Why not key on inputs alone? Because after you fix a bug, pure input-keying
-returns the _stale, buggy_ result — the opposite of what the loop needs. Source
-fingerprinting re-runs exactly the code that changed.
+```
+#1 failed     code a1b2c3  !! RuntimeError: divide by zero
+#2 done       code d4e5f6  ⇐ helper: changed
+```
+
+Use it whenever a memo hit or re-run surprises you.
+
+Why isn't the result keyed on inputs *alone*, with no code tracking? Because
+after you fix a bug, pure input-keying would return the _stale, buggy_ result —
+the opposite of what the loop needs. Tracking code as validity evidence re-runs
+exactly the code that changed, while keeping the task's address (record, logs,
+history) stable through the fix.
 
 ### Maximise cache hits: pass narrow inputs
 
@@ -72,34 +91,58 @@ into a task's inputs so the same inputs really do produce the same result.
 <!-- prettier-ignore -->
 | You want to… | Do this | What re-runs |
 | --- | --- | --- |
-| Fix a bug in a step | Edit the fn, `mini run` | Every call of that fn — one step, or a whole `map` (all cells share its source); *other* steps stay hits |
+| Fix a bug in a step | Edit the fn, `mini run` | Every stale cell of that fn — in place, same keys (FAILED cells relaunch automatically); *other* steps stay hits |
+| Fix a bug without redoing finished cells | Edit the fn, `mini run --keep-stale-done` | Only cells that never finished; DONE results are kept and badged `(stale code — kept)` |
 | Add a config to a sweep | Append to `configs`, `mini run` | Only the new key |
 | Remove a config | Delete it from `configs` | Nothing — its old record shows `(superseded)` |
-| Re-run a finished step | Edit the fn, or pass `version=` | That step |
-| Recover a failed step | `mini logs`, fix, `mini retry` | The reset (FAILED/CANCELLED) tasks |
+| Re-run a finished step | Edit the fn, or pass `version=` | That step — a new attempt on the same record |
+| Recover a failed step | `mini logs`, fix, `mini run` — or `mini retry` if the failure was flaky (no code change) | The stale (or reset) FAILED/CANCELLED tasks |
+
+### Hotfix a sweep in bounded time
+
+Mid-sweep, a bug fails 20 of 100 cells while 80 finish fine. Because keys are
+identity, fixing the fn doesn't orphan anything — every cell keeps its key, and
+the tick judges each record against the new evidence:
+
+- **Default** (`mini run`): all 100 cells are stale, so all 100 re-run. Honest,
+  but it re-pays for the 80 good results.
+- **Bounded** (`mini run --keep-stale-done`): the 80 DONE cells are served as-is
+  (their results predate the fix — `status` badges them `(stale code — kept)`,
+  and the tick records them in the run's meta), and only the 20 failed cells
+  re-run with the fixed code. No `retry` needed: a FAILED record whose code has
+  since changed relaunches automatically — the fix is what it was waiting for.
+
+Keeping stale DONE results is a *judgment call* — it asserts the edit didn't
+change what the finished cells computed. The default deliberately re-runs them
+(bias to over-invalidate); reach for the flag when you know the fix only matters
+to the cells that failed.
 
 ### Superseded records
 
-Records are keyed by content, so an edited fn or a removed config leaves its old
-record behind under a key no wake will request again. Each tick persists the set
-of keys the DAG requested; the read commands aggregate over that set, showing
+Renaming a task fn or removing a config changes what the DAG *requests*, leaving
+old records behind under keys no wake will ask for again. Each tick persists the
+set of keys the DAG requested; the read commands aggregate over that set, showing
 the orphans as `(superseded)` without letting them poison the run's state — a
 completed run reads DONE even if an old key once settled FAILED. `retry` skips
 superseded records too (resetting one would plant a phantom that never runs);
-target one explicitly with `--key` if you really mean it.
+target one explicitly with `--key` if you really mean it. (Editing a fn's *body*
+no longer supersedes anything — the re-run lands on the same record.)
 
 ### Failure is terminal by design
 
-`FAILED` and `CANCELLED` are terminal: a plain `mini run` will **not** relaunch
-them. This is deliberate — a deterministic failure shouldn't busy-loop, and a
-fix should be intentional. Recovery takes one of:
+`FAILED` and `CANCELLED` are terminal *under the code that produced them*: a
+plain `mini run` will **not** relaunch them. This is deliberate — a
+deterministic failure shouldn't busy-loop, and a fix should be intentional.
+Recovery takes one of:
 
-- `mini retry <name>` — resets all FAILED/CANCELLED tasks (`--key <key>` for one),
-  then advances the DAG;
-- bump `version=` or edit the fn — a new key, so `run` launches it fresh.
+- fix the code and `mini run` — the record's evidence is stale, so it relaunches;
+- bump `version=` — same effect, without an edit;
+- `mini retry <name>` — for a *flaky* failure (nothing changed): resets all
+  FAILED/CANCELLED tasks (`--key <key>` for one), then advances the DAG.
 
 The traceback lives on the I/O plane (`mini logs <name> <key>`); the record
-carries the last error line for a quick scan in `status`.
+carries the last error line for a quick scan in `status`, and each healed
+record keeps its failed attempts in history (`mini explain`).
 
 ### A failed item fails its `map` — unless you allow partials
 

--- a/.agents/skills/mi-ni/references/running.md
+++ b/.agents/skills/mi-ni/references/running.md
@@ -57,20 +57,24 @@ diffs it against its sibling record (code vs. inputs, per-dependency).
 
 ### Hotfix safety (avoid double-spending)
 
-Editing a task fn changes its memo key, so it re-runs. But a re-run does **not**
-kill workers already detached under the *old* key — they keep burning (real
-money on Modal). And editing a **shared helper** invalidates *every* task that
-calls it. Three rules keep the blast radius bounded:
+Editing a task fn makes every cell of it *stale*, so it re-runs (in place — keys
+are identity, so nothing is orphaned). But a re-run does **not** kill workers
+already detached under the old code — they keep burning (real money on Modal).
+And editing a **shared helper** invalidates *every* task that calls it. Three
+rules keep the blast radius bounded:
 
 1. **Only hotfix terminal (FAILED/CANCELLED) tasks** — their worker is already
-   dead. For a transient failure, don't edit: `retry --key <key>` re-runs just
-   that task (blast radius is one task). Editing the fn re-keys **every call of
-   it** — for a `map`, the *whole fan-out* re-runs, not just the failed cell
-   (the old records then show `(superseded)`). That's fine for a single-step fn;
-   for a big sweep it's a real recompute cost — weigh it, or escalate.
+   dead, and a stale terminal task relaunches on the next `run` (no `retry`
+   needed; the fix is what it was waiting for). For a transient failure, don't
+   edit: `retry --key <key>` re-runs just that task (blast radius is one task).
+   By default an edit also re-runs the fn's **DONE** cells — for a `map`, the
+   whole fan-out. If the fix demonstrably doesn't change what the finished cells
+   computed, run with `--keep-stale-done`: DONE results are served as-is (badged
+   `(stale code — kept)` in `status`) and only the unfinished cells re-run.
 2. **If anything is in-flight, `cancel` first, then fix.** Never edit under a
-   live worker. (`cancel` is store-scoped — it also stops orphaned old-version
-   workers, which keep showing as `RUNNING` in `status`.)
+   live worker — a stale worker that settles later writes onto the *same* record
+   its replacement would use. (`cancel` is store-scoped — it also stops stale
+   old-code workers, which keep showing as `RUNNING` in `status`.)
 3. **Only ever edit the single failing task fn.** Never a shared helper, `main`,
    or the DAG shape — those re-run an unbounded set of tasks. That's an
    **escalation**, not a hotfix.

--- a/docs/role-demo/experiment.py
+++ b/docs/role-demo/experiment.py
@@ -7,9 +7,10 @@ asks for an L4, so on Modal the records show one step saw no GPU and the other a
     bin/mini run docs/role-demo/experiment.py --app modal
     bin/mini results role-demo --app modal
 
-Note the ``label`` argument: the memo key is ``fingerprint(fn, args)`` and excludes
-the hardware, so calling the same fn with the same args twice would be a memo *hit*
-(both steps returning the first's result). The label keeps the two keys distinct.
+Note the ``label`` argument: the memo key is the task's identity — ``(fn, args)``
+— and excludes the hardware, so calling the same fn with the same args twice would
+be a memo *hit* (both steps returning the first's result). The label keeps the two
+identities distinct.
 """
 
 from __future__ import annotations

--- a/research/design.md
+++ b/research/design.md
@@ -23,10 +23,10 @@ whole design:
 
 - **Durable results.** A handle carries no location, so the result pickles durably and
   resolves from anywhere that can reach the store.
-- **Stable downstream memo keys.** The memo key is `fingerprint(fn, args, version)`.
-  Passing a `Path` into the next step fingerprints it *by location*; passing an
-  `Artifact` fingerprints it *by content*, so a consumer's key only moves when the
-  bytes actually change.
+- **Stable downstream memo keys.** The memo key is the task's identity,
+  `fn + fingerprint(args)`. Passing a `Path` into the next step fingerprints it
+  *by location*; passing an `Artifact` fingerprints it *by content*, so a
+  consumer's key only moves when the bytes actually change.
 - **Dedup, and idempotent `put`.** Identical bytes coincide; `put` hashes first and
   skips the upload if the blob is already present, so re-runs and cross-step duplicates
   are free.

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -14,7 +14,7 @@ agent (or you) can drive, poll, and gather without holding a session open:
     python -m mini status pipeline                             # per-task state + metrics, by NAME
     python -m mini results pipeline                            # per-task results
     python -m mini logs   pipeline <key>                       # a failed task's traceback
-    python -m mini explain pipeline <key>                      # why this key: code/input hashes, dep diff
+    python -m mini explain pipeline <key>                      # why this re-ran: evidence + attempt timeline
     python -m mini cancel pipeline                             # stop in-flight tasks
 
 State is addressed by experiment NAME (one memo store per experiment). Read
@@ -135,8 +135,9 @@ def _print_records(store: MemoStore, records: list[dict] | None = None) -> tuple
     so a completed run reads DONE even when an old key settled FAILED.
     """
     current, stale = store.split_current(store.records() if records is None else records)
+    kept = set(store.meta().get('kept_stale') or ())  # DONE served under old code (--keep-stale-done)
     for rec in current:
-        print(_memo_line(rec))
+        print(_memo_line(rec) + ('  (stale code — kept)' if rec['key'] in kept else ''))
     for rec in stale:
         print(f'{_memo_line(rec)}  (superseded)')
     return current, stale
@@ -175,9 +176,11 @@ def cmd_run(args: argparse.Namespace) -> None:
 def cmd_retry(args: argparse.Namespace) -> None:
     """Reset FAILED/CANCELLED tasks (or one ``--key``) then advance the DAG.
 
-    FAILED/CANCELLED are terminal, so a plain ``run`` won't re-launch them; this is
-    the explicit lever. DONE tasks stay memo hits — to re-run one, edit its fn or
-    bump ``version=``.
+    FAILED/CANCELLED are terminal under unchanged code, so a plain ``run`` won't
+    re-launch them; this is the explicit lever for a *flaky* failure. (After a
+    code fix, plain ``run`` relaunches them by itself — the record's evidence is
+    stale.) Fresh DONE tasks stay memo hits — to re-run one, edit its fn or bump
+    ``version=``.
     """
     exp = load_experiment(args.path)
     apparatus = _build_apparatus(exp.name, args)
@@ -190,8 +193,9 @@ def _run(exp, apparatus: Apparatus, args: argparse.Namespace) -> None:
     """Drive one wake (or to completion with ``--watch``) and report."""
     store = apparatus.memo_store()
     _arm_budget(store, args)
+    keep_stale = getattr(args, 'keep_stale', False)
     if args.watch:
-        _watch(exp, apparatus, poll=args.poll)
+        _watch(exp, apparatus, poll=args.poll, keep_stale=keep_stale)
         return
     if store.budget_expired():  # over budget — settle in-flight work, don't launch a new stage
         cancelled = apparatus.enforce_budget(store)
@@ -200,7 +204,7 @@ def _run(exp, apparatus: Apparatus, args: argparse.Namespace) -> None:
         print(f'⊘ wall-clock budget elapsed — cancelled {len(cancelled)} in-flight task(s); run settled CANCELLED')
         return
     try:
-        done, payload = tick(exp, apparatus)
+        done, payload = tick(exp, apparatus, keep_stale=keep_stale)
     except ExceptionGroup, TaskFailed:  # a depended-on task settled terminally
         done, payload = False, None
     print(f'{exp.name}:')
@@ -214,12 +218,12 @@ def _run(exp, apparatus: Apparatus, args: argparse.Namespace) -> None:
         print(f'… suspended — {payload} (re-run to advance)')
 
 
-def _watch(exp, apparatus: Apparatus, poll: float) -> None:
+def _watch(exp, apparatus: Apparatus, poll: float, keep_stale: bool = False) -> None:
     """Drive an orchestration to completion with a live bar (the ``--watch`` path)."""
     from mini.monitor import drive_and_watch
 
     try:
-        payload = drive_and_watch(exp, apparatus, poll=poll)
+        payload = drive_and_watch(exp, apparatus, poll=poll, keep_stale=keep_stale)
     except KeyboardInterrupt:
         print('\n… stopped watching; tasks keep running. Re-run the same command to resume.')
         return
@@ -313,13 +317,27 @@ def cmd_logs(args: argparse.Namespace) -> None:
     print(_store_for(args.name, args).error(args.key))
 
 
-def cmd_explain(args: argparse.Namespace) -> None:
-    """Show the evidence behind a task's memo key — and why it differs from a sibling.
+def _attempt_delta(prev: dict, cur: dict) -> str:
+    """Name what moved between two attempts' evidence — why *cur* re-ran."""
+    bits: list[str] = []
+    if prev.get('version') != cur.get('version'):
+        bits.append(f'version: {prev.get("version", "-")} → {cur.get("version", "-")}')
+    a, b = prev.get('deps') or {}, cur.get('deps') or {}
+    for name in sorted(a.keys() | b.keys()):
+        if a.get(name) == b.get(name):
+            continue
+        bits.append(f'{name}: {"changed" if name in a and name in b else ("added" if name in b else "removed")}')
+    return ', '.join(bits) or 'retried (evidence unchanged)'
 
-    Each record stores its fingerprint parts (code vs. input hash, plus a short
-    hash per tracked dependency). ``explain`` prints them and, when another record
-    ran the same fn under a different key, diffs the two — answering "why did this
-    re-run" / "why is that record superseded" down to the dependency that moved.
+
+def cmd_explain(args: argparse.Namespace) -> None:
+    """Show a task's identity evidence and its attempt timeline.
+
+    A record's key is *identity* (fn + inputs); each launch stamps the evidence it
+    ran under (code hash, ``version=``, a short hash per tracked dependency), and
+    prior attempts stay compacted on the record. ``explain`` prints the current
+    evidence and walks the timeline, answering "why did this re-run" down to the
+    dependency that moved between attempts.
     """
     store = _store_for(args.name, args)
     rec = store.record(args.key)
@@ -335,29 +353,18 @@ def cmd_explain(args: argparse.Namespace) -> None:
     if not deps:
         print('    (no dependency manifest — record predates `explain`)')
         return
-    # Diff against the best sibling: another record of the same fn, preferring one
-    # the current DAG requests (the "replacement"), then the most recent.
-    siblings = [
-        r
-        for r in store.records()
-        if r.get('fn') == rec.get('fn') and r['key'] != rec['key'] and r.get('deps') and r.get('input_fp')
-    ]
-    if not siblings:
+    attempts = [*(rec.get('history') or ()), rec]
+    if len(attempts) < 2:
         return
-    other = max(siblings, key=lambda r: (r['key'] in requested, r.get('created_at', 0)))
-    other_deps: dict[str, str] = other['deps']
-    print(f'  vs {other["key"]} ({_rec_state(other)}{"" if other["key"] in requested else ", superseded"}):')
-    print(f'    inputs: {"unchanged" if other.get("input_fp") == rec.get("input_fp") else "changed"}')
-    if other.get('version') != rec.get('version'):
-        print(f'    version: {rec.get("version", "-")} → {other.get("version", "-")}')
-    for name in sorted(deps.keys() | other_deps.keys()):
-        a, b = deps.get(name), other_deps.get(name)
-        if a == b:
-            continue
-        what = 'changed' if a and b else ('only here' if a else 'only there')
-        print(f'    {name}: {what}' + (f' ({a} → {b})' if a and b else ''))
-    if deps == other_deps:
-        print('    code: unchanged')
+    print(f'  attempts ({len(attempts)}):')
+    for i, att in enumerate(attempts, 1):
+        state = att.get('state') or '?'
+        line = f'    #{i} {state:9}  code {att.get("code_fp", "?")}'
+        if att.get('error'):
+            line += f'  !! {att["error"]}'
+        if i > 1:
+            line += f'  ⇐ {_attempt_delta(attempts[i - 2], att)}'
+        print(line)
 
 
 def cmd_cancel(args: argparse.Namespace) -> None:
@@ -384,6 +391,13 @@ def main() -> None:
         p.add_argument('--workers', type=int, default=1, help='local worker threads / task concurrency')
         p.add_argument('--gpu', default=None, help='Modal GPU type, e.g. L4, A100 (--app modal)')
         p.add_argument('--timeout', type=int, default=None, help='per-task timeout in seconds (--app modal)')
+        p.add_argument(
+            '--keep-stale-done',
+            action='store_true',
+            dest='keep_stale',
+            help='bounded hotfix: serve DONE results even where the code has since changed, '
+            're-running only cells that never finished (default: a stale DONE re-runs too)',
+        )
         p.add_argument(
             '--budget',
             default=None,
@@ -432,7 +446,7 @@ def main() -> None:
     _add_app_flag(p)
     p.set_defaults(func=cmd_logs)
 
-    p = sub.add_parser('explain', help="show a task's memo-key evidence and diff it against its sibling")
+    p = sub.add_parser('explain', help="show a task's identity evidence and attempt timeline (why did this re-run)")
     p.add_argument('name')
     p.add_argument('key')
     _add_app_flag(p)

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -1,13 +1,21 @@
 """
-Content-addressed memoization for multi-step orchestration.
+Identity-keyed memoization for multi-step orchestration.
 
-The cache key must be **deterministic across processes** (every agent wake is a
-fresh process) and should **invalidate when the relevant code changes** so the
-"fix a bug, re-run" loop works. Hashing ``cloudpickle.dumps(fn)`` fails the first
-test — its bytes vary run to run. So we fingerprint the function's *source*, plus
-the source of the project functions/classes it references (transitively), which
-is stable and captures dependencies in your own code while ignoring library
-churn (site-packages and the mini framework itself are excluded).
+A task record answers two different questions, and the store keeps them apart:
+
+- **Identity — which task is this?** The key: the fn's qualified name plus a
+  fingerprint of its inputs. Stable across code edits, so a record (and its
+  logs, results, history) keeps one address for the task's whole life.
+- **Validity — is the cached result current?** The *evidence* stored on each
+  attempt: a fingerprint of the fn's source plus the source of the project
+  functions/classes it references (transitively), and the explicit ``version=``.
+  Stale evidence re-runs the task **in place** — a new attempt under the same
+  key, with the prior attempt compacted into the record's ``history``.
+
+Both fingerprints must be **deterministic across processes** (every agent wake
+is a fresh process) — hashing ``cloudpickle.dumps(fn)`` fails that (its bytes
+vary run to run), so we fingerprint *source*, which also ignores library churn
+(site-packages and the mini framework itself are excluded).
 """
 
 from __future__ import annotations
@@ -31,7 +39,7 @@ import cloudpickle
 
 from mini.runs import SETTLED, RunState, _atomic_write, _merge_json
 
-__all__ = ['fingerprint', 'fingerprint_parts', 'RecordStore', 'LocalRecordStore', 'MemoStore', 'PollCache', 'META_KEY']
+__all__ = ['task_key', 'task_key_parts', 'RecordStore', 'LocalRecordStore', 'MemoStore', 'PollCache', 'META_KEY']
 
 log = logging.getLogger(__name__)
 
@@ -294,35 +302,50 @@ def _manifest(fn: Callable) -> tuple[tuple[str, str], ...]:
         _collecting.discard(id(fn))
 
 
-def fingerprint(fn: Callable, args: tuple, version: str | None = None) -> str:
-    """A stable content key for calling *fn* with *args* (the memo key)."""
-    return fingerprint_parts(fn, args, version)[0]
+def task_key(fn: Callable, args: tuple) -> str:
+    """The stable *identity* key for calling *fn* with *args*.
+
+    Identity is which task this is — the fn's qualified name plus its inputs —
+    deliberately excluding code: an edited fn re-runs under the **same** key (a
+    new attempt on the same record) instead of orphaning it. Whether the cached
+    result is still *valid* is judged against the evidence from
+    :func:`task_key_parts`, stored per attempt.
+    """
+    return task_key_parts(fn, args)[0]
 
 
-def fingerprint_parts(fn: Callable, args: tuple, version: str | None = None) -> tuple[str, dict[str, Any]]:
-    """The memo key plus the evidence behind it, for the record (``mini explain``).
+def task_key_parts(fn: Callable, args: tuple, version: str | None = None) -> tuple[str, dict[str, Any]]:
+    """The identity key plus the validity evidence to stamp on its next attempt.
 
-    Returns ``(key, parts)`` where *parts* carries the code and input fingerprints
-    separately (so "why did this re-run" splits into "code changed" vs "inputs
-    changed") and ``deps`` — a short hash per tracked dependency (the fn itself,
-    each project helper/class it references, each plain-value global) — so two
-    records can be diffed down to *which* dependency moved.
+    Returns ``(key, parts)``. The key hashes only the fn's module-qualified name
+    and the input fingerprint. *parts* carries what decides staleness — the code
+    fingerprint, ``version=``, and ``deps``: a short hash per tracked dependency
+    (the fn itself, each project helper/class it references, each plain-value
+    global) — so ``mini explain`` can diff two attempts down to *which*
+    dependency moved.
     """
     manifest = _manifest(fn)
     blob = '\n--\n'.join(f'{k}:{v}' for k, v in manifest)
     code_fp = hashlib.sha256(blob.encode()).hexdigest()
     input_fp = _input_fingerprint(args)
-    h = hashlib.sha256()
-    h.update(code_fp.encode())
-    h.update(input_fp.encode())
-    if version:
-        h.update(version.encode())
+    ident = f'{getattr(fn, "__module__", "?")}.{getattr(fn, "__qualname__", "task")}'
+    h = hashlib.sha256(f'{ident}\n{input_fp}'.encode())
     key = f'{getattr(fn, "__name__", "task")}-{h.hexdigest()[:12]}'
     deps = {k: hashlib.sha256(v.encode()).hexdigest()[:8] for k, v in manifest}
     parts = {'code_fp': code_fp[:12], 'input_fp': input_fp[:12], 'deps': deps}
     if version:
         parts['version'] = version
     return key, parts
+
+
+# What a finished attempt is worth keeping once a new one replaces it: the
+# evidence and the outcome. Live/bulky fields (metrics, env, heartbeats, pids)
+# describe a worker, not the attempt's identity in the run's story.
+_ATTEMPT_KEEP = ('state', 'code_fp', 'input_fp', 'version', 'deps', 'created_at', 'error', 'exc_type')
+
+
+def _compact_attempt(rec: dict[str, Any]) -> dict[str, Any]:
+    return {k: rec[k] for k in _ATTEMPT_KEEP if k in rec}
 
 
 class RecordStore(ABC):
@@ -466,32 +489,52 @@ class MemoStore:
         d = self.deadline()
         return d is not None and time.time() >= d
 
+    def _with_history(self, key: str, rec: dict[str, Any]) -> dict[str, Any]:
+        """Fold the record's prior attempt (if any ran) into *rec*'s ``history``.
+
+        Keys are identity, so a re-run replaces the record in place; compacting
+        the outgoing attempt first is what keeps the task's story — every attempt,
+        its evidence, its outcome — on the one record (``mini explain``).
+        """
+        prior = self.records_backend.read(key) or {}
+        history: list[dict[str, Any]] = list(prior.get('history') or ())
+        if prior.get('state'):  # a reset placeholder (state None) is not an attempt
+            history.append(_compact_attempt(prior))
+        if history:
+            rec['history'] = history
+        return rec
+
     def reset(self, key: str) -> None:
         """Clear a record back to un-run (state → None) so the next tick reruns it.
 
         The retry primitive: a settled-but-not-DONE task is terminal, so re-running
-        takes intent. Stale result/error artifacts are overwritten on the rerun.
+        takes intent. The cleared attempt is kept in the record's history; stale
+        result/error artifacts are overwritten on the rerun.
         """
-        self.records_backend.write(key, {'key': key, 'state': None})
+        self.records_backend.write(key, self._with_history(key, {'key': key, 'state': None}))
 
     def mark_running(self, fn: Callable, key: str, parts: dict[str, Any] | None = None) -> None:
         """Flip the record to RUNNING (wholesale, clearing any prior error).
 
         Called by ``Ctx`` before the apparatus spawns the worker, so a poll
         between stage and first heartbeat sees RUNNING rather than a stale state.
-        *parts* is the fingerprint evidence (``code_fp``/``input_fp``/``deps``
-        from :func:`fingerprint_parts`), stored so ``mini explain`` can answer
-        "why did this re-run" after the fact.
+        *parts* is the validity evidence (``code_fp``/``version``/``deps`` from
+        :func:`task_key_parts`) this attempt runs under; any prior attempt is
+        compacted into ``history``, so ``mini explain`` can answer "why did this
+        re-run" after the fact.
         """
         self.records_backend.write(
             key,
-            {
-                'key': key,
-                'fn': getattr(fn, '__name__', 'task'),
-                'state': RunState.RUNNING,
-                'created_at': time.time(),
-                **(parts or {}),
-            },
+            self._with_history(
+                key,
+                {
+                    'key': key,
+                    'fn': getattr(fn, '__name__', 'task'),
+                    'state': RunState.RUNNING,
+                    'created_at': time.time(),
+                    **(parts or {}),
+                },
+            ),
         )
 
     def write_call(self, key: str, fn: Callable, args: tuple, hooks: list[Callable] | None = None) -> None:
@@ -517,6 +560,11 @@ class PollCache:
     unsettled (so not cached), and the reaper writes it through ``MemoStore``, so
     the next ``records`` re-reads it once and caches the now-terminal record —
     nothing stale lingers.
+
+    A *tick* can relaunch a settled record in place (keys are identity; an edit
+    makes a new attempt, it doesn't re-key), so a cache must not outlive a tick —
+    ``drive_and_watch`` rebuilds its cache per stage. Between ticks, settled is
+    settled.
     """
 
     def __init__(self) -> None:

--- a/src/mini/monitor.py
+++ b/src/mini/monitor.py
@@ -127,6 +127,7 @@ def drive_and_watch(
     *,
     poll: float = 0.5,
     console: Console | None = None,
+    keep_stale: bool = False,
 ) -> Any:
     """Drive *experiment* to completion on *apparatus*, rendering a live bar.
 
@@ -134,7 +135,8 @@ def drive_and_watch(
     (or an ``ExceptionGroup`` of them) raised by ``tick`` when a depended-on task
     has settled terminally — ``tick`` won't relaunch it, so re-ticking surfaces the
     failure rather than spinning. Lets ``KeyboardInterrupt`` propagate too (the
-    caller reports; detached workers live on).
+    caller reports; detached workers live on). *keep_stale* is passed through to
+    each ``tick`` (serve DONE results whose code has since changed).
     """
     store = apparatus.memo_store()
     with _progress(console) as progress:
@@ -144,7 +146,7 @@ def drive_and_watch(
                 cancelled = apparatus.enforce_budget(store)
                 _refresh(progress, bars, store.records())
                 raise BudgetExpired(cancelled)
-            done, payload = tick(experiment, apparatus)  # advance DAG, launch missing work
+            done, payload = tick(experiment, apparatus, keep_stale=keep_stale)  # advance DAG, launch missing work
             # A tick can launch new keys and reset retried ones, so the cache for
             # this stage starts fresh — only the settled tail *within* a poll loop
             # is immutable, which is where the cheap re-reads pay off.

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -2,18 +2,24 @@
 Memoized orchestration for multi-step experiments.
 
 An experiment is a plain function ``main(ctx)`` that expresses the DAG in
-ordinary Python. Each ``ctx.run`` / ``ctx.map`` is content-addressed: cached ->
-return the stored result; otherwise launch a detached task and *suspend* the
-wake by raising ``Pending``. A driver re-runs ``main`` each wake; completed steps
-are memo hits, so only the un-run / failed pieces execute — crash-recovery by
-re-run.
+ordinary Python. Each ``ctx.run`` / ``ctx.map`` resolves to an identity key
+(fn + inputs): a record with a *current* result -> return it; otherwise launch
+a detached task and *suspend* the wake by raising ``Pending``. A driver re-runs
+``main`` each wake; completed steps are memo hits, so only the un-run / stale /
+failed pieces execute — crash-recovery by re-run.
+
+"Current" is judged per record against the attempt's stored evidence (code
+fingerprint + ``version=``): an edit re-runs the task **in place** under the
+same key. A FAILED task whose code has since changed relaunches automatically —
+the fix is what it was waiting for; a DONE one re-runs too unless the tick is
+told ``keep_stale`` (the bounded sweep-hotfix lever).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, overload
 
-from mini.memo import MemoStore, fingerprint_parts
+from mini.memo import MemoStore, task_key_parts
 from mini.runs import SETTLED, RunState
 
 if TYPE_CHECKING:
@@ -122,18 +128,28 @@ class Ctx:
     per-step ``before_each`` hooks.
     """
 
-    def __init__(self, store: MemoStore, apparatus: Apparatus, roles: dict[str, Apparatus] | None = None):
+    def __init__(
+        self,
+        store: MemoStore,
+        apparatus: Apparatus,
+        roles: dict[str, Apparatus] | None = None,
+        keep_stale: bool = False,
+    ):
         self.store = store
         self.apparatus = apparatus
         self.roles = roles or {}
+        self.keep_stale = keep_stale
         self.launched: list[str] = []
         self.pending: list[str] = []
         # Every key this wake resolved (hit, in-flight, or launched) — the DAG's
-        # *requested set*. A record whose key a wake no longer requests (its fn was
-        # edited, its config removed) is superseded: still on disk, but not part of
+        # *requested set*. A record whose key a wake no longer requests (its fn
+        # renamed, its config removed) is superseded: still on disk, but not part of
         # the run's state. ``tick`` persists this so read-only views can tell the two
         # apart without re-running ``main``.
         self.requested: list[str] = []
+        # DONE results served despite stale evidence (keep_stale) — persisted so
+        # read-only views can badge them (they can't fingerprint code themselves).
+        self.stale_kept: list[str] = []
 
     def _route(self, on: Apparatus | None, role: str | None) -> Apparatus:
         """Resolve which apparatus a step runs on: ``role`` label, ``on=``, or default."""
@@ -152,12 +168,29 @@ class Ctx:
         """Resolve a call's key/state and, if it needs launching, mark it RUNNING
         and return its batch entry — *without* spawning. The caller batches the
         spawn so a ``map`` fans out in one ``spawn_tasks`` call.
+
+        The key is identity; whether a settled record still *counts* is judged
+        against its attempt's evidence. Stale FAILED/CANCELLED relaunches — the
+        edit is the fix a terminal task was waiting for, so no ``retry`` needed.
+        Stale DONE re-runs too (bias to over-invalidate) unless ``keep_stale``,
+        which bounds a sweep hotfix to the cells that actually need the new code.
+        Same-evidence FAILED/CANCELLED stays terminal (retry takes intent), and a
+        RUNNING task is never relaunched out from under its worker — staleness
+        waits for it to settle.
         """
-        key, parts = fingerprint_parts(fn, args, version)
+        key, parts = task_key_parts(fn, args, version)
         self.requested.append(key)
-        state = self.store.state(key)
+        rec = self.store.record(key)
+        state = RunState(rec['state']) if rec.get('state') else None
+        stale = state is not None and (rec.get('code_fp'), rec.get('version')) != (
+            parts['code_fp'],
+            parts.get('version'),
+        )
+        keep = stale and state == RunState.DONE and self.keep_stale
+        if keep:
+            self.stale_kept.append(key)
         to_launch: tuple[str, Callable, tuple, list] | None = None
-        if state is None:  # never run; FAILED/CANCELLED are terminal (retry takes intent)
+        if state is None or (stale and state != RunState.RUNNING and not keep):
             self.store.mark_running(fn, key, parts)
             to_launch = (key, fn, args, getattr(app, '_before_hooks', []))
             self.launched.append(key)
@@ -264,7 +297,7 @@ class Ctx:
         return results
 
 
-def tick(experiment: Experiment, apparatus: Apparatus) -> tuple[bool, Any]:
+def tick(experiment: Experiment, apparatus: Apparatus, keep_stale: bool = False) -> tuple[bool, Any]:
     """Run one wake of an experiment's orchestration on *apparatus*.
 
     Returns ``(done, payload)``: ``(True, result)`` if the DAG completed, or
@@ -273,9 +306,13 @@ def tick(experiment: Experiment, apparatus: Apparatus) -> tuple[bool, Any]:
     step the DAG depends on has settled terminally — the run can't progress without
     a ``retry``. Steps can override the apparatus per call via ``ctx.run(...,
     on=)`` / ``ctx.map(..., on=)``.
+
+    *keep_stale* is the bounded-hotfix lever (``--keep-stale-done``): serve DONE
+    results even when their code has since changed, so an edit re-runs only the
+    cells that never finished. Stale FAILED/CANCELLED always relaunches.
     """
     store = apparatus.memo_store()
-    ctx = Ctx(store, apparatus, experiment.resolve_roles(apparatus))
+    ctx = Ctx(store, apparatus, experiment.resolve_roles(apparatus), keep_stale=keep_stale)
     try:
         result = experiment.orchestration()(ctx)
     except Pending as p:
@@ -285,22 +322,30 @@ def tick(experiment: Experiment, apparatus: Apparatus) -> tuple[bool, Any]:
         # can split current records from superseded ones. ``main`` replays from the
         # top each wake, so the set is complete up to the suspension point; keys past
         # it aren't known yet and their old records read as superseded until a later
-        # wake requests them again — honest, since an upstream edit may re-key them.
-        store.set_meta(requested=list(dict.fromkeys(ctx.requested)))
+        # wake requests them again — honest, since an upstream edit may have changed
+        # what they'll ask for. ``kept_stale`` rides along so read-only views can
+        # badge results served under old code (they can't fingerprint code
+        # themselves — reads never import or tick).
+        store.set_meta(
+            requested=list(dict.fromkeys(ctx.requested)),
+            kept_stale=list(dict.fromkeys(ctx.stale_kept)),
+        )
     return True, result
 
 
 def retry(store: MemoStore, key: str | None = None) -> list[str]:
     """Reset settled-but-not-DONE tasks so the next ``tick`` reruns them.
 
-    ``FAILED``/``CANCELLED`` are terminal — ``tick`` won't auto-relaunch them — so
-    re-running takes intent. This clears their records (state → un-run); the next
-    ``tick`` then relaunches. Pass *key* to retry one task; otherwise all
-    failed/cancelled tasks. Returns the keys reset (a `DONE` task is never reset —
-    edit the fn or bump ``version=`` to force that). DONE results stay memo hits.
+    ``FAILED``/``CANCELLED`` are terminal *under the code that produced them* —
+    ``tick`` won't auto-relaunch them — so re-running takes intent: this, or
+    editing the fn (stale evidence relaunches on the next tick), or bumping
+    ``version=``. This clears their records (state → un-run, prior attempt kept
+    in history); the next ``tick`` then relaunches. Pass *key* to retry one task;
+    otherwise all failed/cancelled tasks. Returns the keys reset (a `DONE` task
+    is never reset — edit the fn or bump ``version=`` to force that).
 
     Superseded records — keys the last tick no longer requested (their fn was
-    edited, their config removed) — are skipped: no tick will ever relaunch them,
+    renamed, their config removed) — are skipped: no tick will ever relaunch them,
     so resetting one just plants a phantom forever-pending record. An explicit
     *key* overrides (deliberate intent beats the manifest).
     """

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -69,10 +69,11 @@ def test_ls_and_status_surface_memo_experiments(tmp_path: Path, monkeypatch, cap
 
 
 def test_status_and_ls_report_done_despite_superseded_failure(tmp_path: Path, monkeypatch, capsys):
-    """The scenario a monitor agent hits: a task fails, the fn is edited (re-keying
-    every cell), and the run completes under the new keys. ``status``/``ls`` must
-    report the *run* as done — aggregating over the requested set — with the
-    orphaned old records shown but marked, not poisoning the state a poller acts on."""
+    """The scenario a monitor agent hits: a task fails, the fn is *replaced* by
+    one with a new name (a new identity — re-keying every cell), and the run
+    completes under the new keys. ``status``/``ls`` must report the *run* as done
+    — aggregating over the requested set — with the orphaned old records shown
+    but marked, not poisoning the state a poller acts on."""
     monkeypatch.chdir(tmp_path)
 
     def bad(x):
@@ -108,9 +109,11 @@ def test_status_and_ls_report_done_despite_superseded_failure(tmp_path: Path, mo
     assert 'done' in ls_out and '+1 superseded' in ls_out
 
 
-def test_explain_diffs_superseded_record_against_replacement(tmp_path: Path, monkeypatch, capsys):
-    """After a hotfix, ``explain <old-key>`` must answer "why was this re-keyed":
-    same inputs, code changed — naming the dependency that moved."""
+def test_explain_walks_the_attempt_timeline_after_a_hotfix(tmp_path: Path, monkeypatch, capsys):
+    """After a hotfix, ``explain <key>`` must answer "why did this re-run": the
+    record healed *in place* (same identity), so the story is its attempt
+    timeline — the failed attempt under the old code, then the current one,
+    naming the dependency that moved."""
     monkeypatch.chdir(tmp_path)
 
     def make(fixed: bool):
@@ -141,15 +144,17 @@ def test_explain_diffs_superseded_record_against_replacement(tmp_path: Path, mon
     _drive(sweep(make(fixed=True)), LocalApparatus('explain'))
 
     store = app.memo_store()
-    (failed_key,) = [r['key'] for r in store.records() if r.get('state') == RunState.FAILED]
+    (rec,) = store.records()  # same qualname + inputs — one identity across the fix
+    assert RunState(rec['state']) == RunState.DONE
 
     from mini.__main__ import cmd_explain
 
-    cmd_explain(argparse.Namespace(name='explain', key=failed_key, app='local'))
+    cmd_explain(argparse.Namespace(name='explain', key=rec['key'], app='local'))
     out = capsys.readouterr().out
-    assert '(superseded)' in out  # the old key is no longer requested
-    assert 'inputs: unchanged' in out  # same args — the hotfix changed code, not inputs
-    assert 'changed' in out  # the fn's own dep hash moved
+    assert '(superseded)' not in out  # healed in place — nothing orphaned
+    assert 'attempts (2):' in out
+    assert 'failed' in out and '!! RuntimeError: bug' in out  # the old attempt and its error
+    assert 'changed' in out  # …and the dependency that moved to heal it
 
 
 def test_cancel_stops_running_task(tmp_path: Path):

--- a/tests/mini/test_fingerprint.py
+++ b/tests/mini/test_fingerprint.py
@@ -1,10 +1,12 @@
-"""Fingerprint semantics: what invalidates a memo key, and what must not.
+"""Key semantics: identity must hold still while evidence tracks the code.
 
 The contract has two sides. *Honesty*: editing anything a task actually depends
 on — a helper (however it's referenced), a module-level constant, a method —
-must change the key, or a re-run silently serves stale results. *Stability*: the
-key must be identical across processes and across distinct-but-identical
-function objects, or a task relaunches on every wake.
+must change the attempt evidence (``code_fp``), or a re-run silently serves
+stale results. *Stability*: the identity key must be identical across processes,
+across distinct-but-identical function objects, **and across code edits** — the
+key is where the task's record, logs, and history live, so an edit must re-run
+it in place, not orphan it.
 
 Module-level dependencies are exercised with real modules written to disk (the
 fingerprint reads *source*, so the functions must have files); "editing" is
@@ -21,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from mini.memo import fingerprint, fingerprint_parts
+from mini.memo import task_key, task_key_parts
 
 TASK_ATTR = 'import helpers\n\ndef task(x):\n    return helpers.helper(x)\n'
 TASK_NESTED = 'from helpers import helper\n\ndef task(xs):\n    inner = lambda v: helper(v)  # noqa: E731\n    return [inner(x) for x in xs]\n'
@@ -55,10 +57,10 @@ def load_module(tmp_path: Path):
         sys.modules.pop(name, None)
 
 
-def _fp_with_helper(load_module, task_src: str, helper_src: str, variant: str) -> str:
+def _key_and_parts(load_module, task_src: str, helper_src: str, variant: str) -> tuple[str, dict]:
     load_module('helpers', helper_src, variant)
     tasks = load_module('tasks', task_src, variant)
-    return fingerprint(tasks.task, (1,))
+    return task_key_parts(tasks.task, (1,))
 
 
 @pytest.mark.parametrize(
@@ -66,28 +68,29 @@ def _fp_with_helper(load_module, task_src: str, helper_src: str, variant: str) -
     [TASK_ATTR, TASK_NESTED, TASK_METHOD],
     ids=['module-attr call', 'nested-code reference', 'via a method'],
 )
-def test_helper_edits_invalidate_however_referenced(load_module, task_src: str):
-    """Editing a helper must re-key the task whether it's called by bare name,
-    as a module attribute (``helpers.helper``), from inside a nested lambda /
-    comprehension, or from a method of a class the task uses. The task's own
-    source is byte-identical across variants — only the helper differs — and an
-    identical copy must produce an identical key (no path or object identity in
-    the fingerprint)."""
-    fp_v1 = _fp_with_helper(load_module, task_src, HELPER_V1, 'a')
-    fp_v2 = _fp_with_helper(load_module, task_src, HELPER_V2, 'b')
-    fp_v1_copy = _fp_with_helper(load_module, task_src, HELPER_V1, 'c')
-    assert fp_v1 != fp_v2, 'editing the helper did not change the key — stale results would be served'
-    assert fp_v1 == fp_v1_copy, 'identical source produced different keys — the task could never cache'
+def test_helper_edits_move_evidence_not_identity(load_module, task_src: str):
+    """Editing a helper must change the task's evidence (so it re-runs) whether
+    it's called by bare name, as a module attribute (``helpers.helper``), from
+    inside a nested lambda / comprehension, or from a method of a class the task
+    uses — while the *key* stays put, so the re-run lands on the same record.
+    An identical copy must produce identical evidence (no path or object
+    identity in the fingerprint)."""
+    key_v1, p_v1 = _key_and_parts(load_module, task_src, HELPER_V1, 'a')
+    key_v2, p_v2 = _key_and_parts(load_module, task_src, HELPER_V2, 'b')
+    key_copy, p_copy = _key_and_parts(load_module, task_src, HELPER_V1, 'c')
+    assert p_v1['code_fp'] != p_v2['code_fp'], 'helper edit invisible to evidence — stale results would be served'
+    assert key_v1 == key_v2, 'helper edit re-keyed the task — record/logs/history would be orphaned'
+    assert (key_copy, p_copy['code_fp']) == (key_v1, p_v1['code_fp']), 'identical source must fingerprint identically'
 
 
 def test_module_level_value_edits_invalidate(load_module):
     """A module-level constant a task reads (``LR``) is part of its behavior:
-    editing the value must re-key the task, exactly like editing code."""
-    fp_v1 = fingerprint(load_module('tasks', TASK_VALUE, 'a').task, (1,))
-    fp_v2 = fingerprint(load_module('tasks', TASK_VALUE.replace('0.1', '0.2'), 'b').task, (1,))
-    fp_v1_copy = fingerprint(load_module('tasks', TASK_VALUE, 'c').task, (1,))
-    assert fp_v1 != fp_v2
-    assert fp_v1 == fp_v1_copy
+    editing the value must change the evidence, exactly like editing code."""
+    _, p_v1 = task_key_parts(load_module('tasks', TASK_VALUE, 'a').task, (1,))
+    _, p_v2 = task_key_parts(load_module('tasks', TASK_VALUE.replace('0.1', '0.2'), 'b').task, (1,))
+    _, p_copy = task_key_parts(load_module('tasks', TASK_VALUE, 'c').task, (1,))
+    assert p_v1['code_fp'] != p_v2['code_fp']
+    assert p_v1['code_fp'] == p_copy['code_fp']
 
 
 def _make_callback(delta: int):
@@ -105,15 +108,16 @@ def _make_callback(delta: int):
 
 
 def test_callable_inputs_key_by_source_not_identity():
-    """A function passed as *data* must fingerprint by its source: two fresh
-    objects of the same source coincide (a repr would embed a memory address and
-    relaunch the task every wake), while a different body diverges."""
+    """A function passed as *data* is an input, so it fingerprints into the key
+    by its source: two fresh objects of the same source coincide (a repr would
+    embed a memory address and relaunch the task every wake), while a different
+    body diverges — a new input, a new cell."""
 
     def apply(f, x):
         return f(x)
 
-    assert fingerprint(apply, (_make_callback(1), 5)) == fingerprint(apply, (_make_callback(1), 5))
-    assert fingerprint(apply, (_make_callback(1), 5)) != fingerprint(apply, (_make_callback(2), 5))
+    assert task_key(apply, (_make_callback(1), 5)) == task_key(apply, (_make_callback(1), 5))
+    assert task_key(apply, (_make_callback(1), 5)) != task_key(apply, (_make_callback(2), 5))
 
 
 class _Color(enum.Enum):
@@ -125,10 +129,10 @@ def test_enum_and_path_inputs_are_stable_and_distinct():
     def t(v):
         return v
 
-    assert fingerprint(t, (_Color.RED,)) == fingerprint(t, (_Color.RED,))
-    assert fingerprint(t, (_Color.RED,)) != fingerprint(t, (_Color.BLUE,))
-    assert fingerprint(t, (Path('/a/b'),)) == fingerprint(t, (Path('/a/b'),))
-    assert fingerprint(t, (Path('/a/b'),)) != fingerprint(t, (Path('/a/c'),))
+    assert task_key(t, (_Color.RED,)) == task_key(t, (_Color.RED,))
+    assert task_key(t, (_Color.RED,)) != task_key(t, (_Color.BLUE,))
+    assert task_key(t, (Path('/a/b'),)) == task_key(t, (Path('/a/b'),))
+    assert task_key(t, (Path('/a/b'),)) != task_key(t, (Path('/a/c'),))
 
 
 def test_self_referential_global_does_not_recurse(load_module):
@@ -136,24 +140,40 @@ def test_self_referential_global_does_not_recurse(load_module):
     not send the collector into infinite recursion."""
     src = 'CALLBACKS = []\n\ndef task(x):\n    return len(CALLBACKS) + x\n\nCALLBACKS.append(task)\n'
     mod = load_module('tasks', src, 'a')
-    assert fingerprint(mod.task, (1,))  # completes; no RecursionError
+    assert task_key_parts(mod.task, (1,))  # completes; no RecursionError
 
 
-def test_fingerprint_parts_split_code_from_inputs(load_module):
+def test_parts_split_code_from_inputs(load_module):
     """``explain`` relies on the parts: same code + different inputs moves only
-    ``input_fp``; an edited helper moves only ``code_fp`` (and names the dep)."""
+    ``input_fp`` (a different cell); an edited helper moves only ``code_fp``
+    (and names the dep)."""
     load_module('helpers', HELPER_V1, 'a')
     tasks = load_module('tasks', TASK_ATTR, 'a')
-    _, p1 = fingerprint_parts(tasks.task, (1,))
-    _, p2 = fingerprint_parts(tasks.task, (2,))
+    k1, p1 = task_key_parts(tasks.task, (1,))
+    k2, p2 = task_key_parts(tasks.task, (2,))
     assert p1['code_fp'] == p2['code_fp'] and p1['input_fp'] != p2['input_fp']
+    assert k1 != k2  # inputs are identity
 
     load_module('helpers', HELPER_V2, 'b')
     tasks_b = load_module('tasks', TASK_ATTR, 'b')
-    _, p3 = fingerprint_parts(tasks_b.task, (1,))
+    k3, p3 = task_key_parts(tasks_b.task, (1,))
     assert p3['input_fp'] == p1['input_fp'] and p3['code_fp'] != p1['code_fp']
+    assert k3 == k1  # code is evidence, not identity
     changed = [k for k in p1['deps'] if p3['deps'].get(k) != p1['deps'][k]]
     assert changed == ['helper']  # the diff names exactly the dependency that moved
+
+
+def test_version_is_evidence_not_identity():
+    """``version=`` forces a re-run *in place*: it moves the evidence while the
+    key stays put, so the bump lands as a new attempt on the same record."""
+
+    def t(x):
+        return x
+
+    k1, p1 = task_key_parts(t, (1,), version='v1')
+    k2, p2 = task_key_parts(t, (1,), version='v2')
+    assert k1 == k2
+    assert (p1.get('version'), p2.get('version')) == ('v1', 'v2')
 
 
 def test_repr_fallback_warns_about_unstable_inputs(caplog):
@@ -167,5 +187,5 @@ def test_repr_fallback_warns_about_unstable_inputs(caplog):
         return o
 
     with caplog.at_level('WARNING', logger='mini.memo'):
-        fingerprint(t, (Opaque(),))
+        task_key(t, (Opaque(),))
     assert any('never be a cache hit' in r.message for r in caplog.records)

--- a/tests/mini/test_orchestration.py
+++ b/tests/mini/test_orchestration.py
@@ -15,7 +15,7 @@ import pytest
 from mini.apparatus import Apparatus
 from mini.experiment import Experiment
 from mini.local_apparatus import LocalApparatus
-from mini.memo import LocalRecordStore, MemoStore, fingerprint
+from mini.memo import LocalRecordStore, MemoStore, task_key
 from mini.orchestration import TaskFailed, retry, tick
 from mini.runs import RunState
 
@@ -25,15 +25,27 @@ def _setup(name: str, main, tmp_path: Path) -> tuple[Experiment, LocalApparatus]
     return Experiment(name=name, main=main), LocalApparatus(name, data_dir=tmp_path / name)
 
 
-def _drive(exp: Experiment, app: LocalApparatus, timeout: float = 30.0):
+def _drive(exp: Experiment, app: LocalApparatus, timeout: float = 30.0, keep_stale: bool = False):
     """Re-run the orchestration each 'wake' until it completes (mirrors the agent loop)."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        done, payload = tick(exp, app)
+        done, payload = tick(exp, app, keep_stale=keep_stale)
         if done:
             return payload
         time.sleep(0.1)
     raise AssertionError(f'orchestration did not complete: {payload}')
+
+
+def _drive_to_failure(exp: Experiment, app: LocalApparatus, timeout: float = 30.0) -> ExceptionGroup:
+    """Tick until the strict map surfaces its failures; return the group."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            tick(exp, app)
+        except ExceptionGroup as eg:
+            return eg
+        time.sleep(0.1)
+    raise AssertionError('map never surfaced the failure')
 
 
 def test_multistep_dependency(tmp_path: Path):
@@ -95,16 +107,8 @@ def test_failed_is_terminal_until_retry(tmp_path: Path):
     store = app.memo_store()
 
     # Drive until the map surfaces the failure (task 2 throws; 1 & 3 succeed).
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
-        try:
-            tick(exp, app)
-        except ExceptionGroup:
-            break
-        time.sleep(0.1)
-    else:
-        raise AssertionError('map never surfaced the failure')
-    # FAILED is terminal: re-ticking keeps raising, never relaunches.
+    _drive_to_failure(exp, app)
+    # FAILED is terminal (the code hasn't changed): re-ticking keeps raising, never relaunches.
     for _ in range(3):
         with pytest.raises(ExceptionGroup) as exc:
             tick(exp, app)
@@ -271,7 +275,10 @@ def test_poll_cache_reads_settled_records_once(tmp_path: Path):
     assert backend.reads.count('a') == 1  # read once on settle, then cached — no re-read
 
 
-def test_version_busts_cache(tmp_path: Path):
+def test_version_reruns_in_place(tmp_path: Path):
+    """``version=`` is evidence, not identity: a bump re-runs the task as a new
+    attempt on the *same* record, with the old attempt kept in its history."""
+
     def t(x):
         return x
 
@@ -283,7 +290,9 @@ def test_version_busts_cache(tmp_path: Path):
 
     _drive(*_setup('ver', main_v1, tmp_path))
     _drive(Experiment(name='ver', main=main_v2), LocalApparatus('ver', data_dir=tmp_path / 'ver'))
-    assert len({r['key'] for r in MemoStore(tmp_path / 'ver').records()}) == 2  # distinct keys per version
+    (rec,) = MemoStore(tmp_path / 'ver').records()  # one identity across both versions
+    assert rec['version'] == 'v2' and rec['state'] == RunState.DONE
+    assert [a['version'] for a in rec['history']] == ['v1']  # the bump preserved the story
 
 
 def test_prune_and_memo_hits_across_config_edits(tmp_path: Path):
@@ -339,11 +348,12 @@ def test_tick_persists_requested_keys(tmp_path: Path):
 
 
 def test_superseded_records_are_excluded_and_not_retried(tmp_path: Path):
-    """Editing a task fn re-keys every cell that calls it, orphaning the old
-    records. The orphaned FAILED record must not poison the run: ``retry`` skips
-    it (resetting it would plant a phantom no tick ever relaunches), and the
-    manifest marks it superseded for read-only views. Explicit ``--key`` intent
-    still beats the manifest."""
+    """*Renaming* (replacing) a task fn changes its identity, orphaning the old
+    records — an in-place edit does not (see the hotfix tests). The orphaned
+    FAILED record must not poison the run: ``retry`` skips it (resetting it would
+    plant a phantom no tick ever relaunches), and the manifest marks it
+    superseded for read-only views. Explicit ``--key`` intent still beats the
+    manifest."""
 
     def bad(x):
         if x == 2:
@@ -357,21 +367,13 @@ def test_superseded_records_are_excluded_and_not_retried(tmp_path: Path):
         return Experiment(name='hotfix', main=lambda ctx: ctx.map(fn, [(1,), (2,)]))
 
     data_dir = tmp_path / 'hotfix'
-    exp, app = sweep(bad), LocalApparatus('hotfix', data_dir=data_dir)
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
-        try:
-            tick(exp, app)
-        except ExceptionGroup:
-            break
-        time.sleep(0.1)
-    else:
-        raise AssertionError('map never surfaced the failure')
-    store = app.memo_store()
+    _drive_to_failure(sweep(bad), LocalApparatus('hotfix', data_dir=data_dir))
+    store = LocalApparatus('hotfix', data_dir=data_dir).memo_store()
     (failed_key,) = [r['key'] for r in store.records() if r.get('state') == RunState.FAILED]
 
-    # The "hotfix": the fixed fn has new source, so every cell re-keys and the old
-    # records are superseded. The fixed sweep completes despite the old failure.
+    # The replacement fn is a new identity (different name), so every cell re-keys
+    # and the old records are superseded. The new sweep completes despite the old
+    # failure.
     assert _drive(sweep(good), LocalApparatus('hotfix', data_dir=data_dir)) == [10, 20]
     assert retry(store) == []  # the orphaned FAILED is skipped, not reset
     assert store.state(failed_key) == RunState.FAILED  # left as-is — no phantom pending
@@ -381,6 +383,70 @@ def test_superseded_records_are_excluded_and_not_retried(tmp_path: Path):
     assert all(r.get('state') == RunState.DONE for r in current)
 
     assert retry(store, key=failed_key) == [failed_key]  # explicit key overrides
+
+
+def _make_train(fixed: bool):
+    """Two variants of the *same* task fn — same module and qualname, different
+    source: an in-place edit, as far as identity is concerned."""
+    if fixed:
+
+        def train(x):
+            from mini import get_data_dir
+
+            f = get_data_dir() / f'ran_{x}'
+            f.write_text(str(int(f.read_text()) + 1 if f.exists() else 1))
+            return x * 10
+    else:
+
+        def train(x):
+            from mini import get_data_dir
+
+            f = get_data_dir() / f'ran_{x}'
+            f.write_text(str(int(f.read_text()) + 1 if f.exists() else 1))
+            if x == 2:
+                raise RuntimeError('bug')
+            return x * 10
+
+    return train
+
+
+def _hotfix_sweep(fixed: bool) -> Experiment:
+    return Experiment(name='hot', main=lambda ctx: ctx.map(_make_train(fixed), [(1,), (2,)]))
+
+
+def test_hotfix_edit_relaunches_failed_cells_in_place(tmp_path: Path):
+    """The sweep-hotfix story. Editing the fn moves its *evidence*, not its keys:
+    the FAILED cell relaunches automatically (the fix is what it was waiting for
+    — no ``retry``), nothing is orphaned, and by default the stale DONE cell
+    re-runs too (bias to over-invalidate). The healed record keeps the failed
+    attempt in its history."""
+    data_dir = tmp_path / 'hot'
+    _drive_to_failure(_hotfix_sweep(False), LocalApparatus('hot', data_dir=data_dir))
+    store = LocalApparatus('hot', data_dir=data_dir).memo_store()
+    keys_before = {r['key'] for r in store.records()}
+
+    assert _drive(_hotfix_sweep(True), LocalApparatus('hot', data_dir=data_dir)) == [10, 20]
+    assert {r['key'] for r in store.records()} == keys_before  # same identities — nothing orphaned
+    assert store.split_current(store.records())[1] == []  # no superseded records
+    assert {x: int((data_dir / f'ran_{x}').read_text()) for x in (1, 2)} == {1: 2, 2: 2}
+
+    healed = store.record(task_key(_make_train(True), (2,)))
+    assert healed['state'] == RunState.DONE  # healed in place, same address
+    (prior,) = healed['history']
+    assert prior['state'] == RunState.FAILED and prior['code_fp'] != healed['code_fp']  # the edit is why it re-ran
+
+
+def test_keep_stale_bounds_hotfix_to_unfinished_cells(tmp_path: Path):
+    """``--keep-stale-done``: after an edit, DONE cells are served as-is and only
+    the cells that never finished re-run with the new code — the bounded hotfix.
+    The kept key lands in run meta so read-only views can badge it."""
+    data_dir = tmp_path / 'hot'
+    _drive_to_failure(_hotfix_sweep(False), LocalApparatus('hot', data_dir=data_dir))
+    store = LocalApparatus('hot', data_dir=data_dir).memo_store()
+
+    assert _drive(_hotfix_sweep(True), LocalApparatus('hot', data_dir=data_dir), keep_stale=True) == [10, 20]
+    assert {x: int((data_dir / f'ran_{x}').read_text()) for x in (1, 2)} == {1: 1, 2: 2}  # DONE cell untouched
+    assert store.meta()['kept_stale'] == [task_key(_make_train(True), (1,))]
 
 
 def test_per_step_apparatus_uses_its_hooks(tmp_path: Path):
@@ -503,12 +569,12 @@ def test_ctx_spawns_via_the_apparatus(tmp_path: Path):
     assert batches == [2]  # both tasks launched in a single batched spawn
 
 
-def test_fingerprint_is_deterministic_and_input_sensitive():
+def test_task_key_is_deterministic_and_input_sensitive():
     def fn(x):
         return x
 
-    assert fingerprint(fn, (1,)) == fingerprint(fn, (1,))
-    assert fingerprint(fn, (1,)) != fingerprint(fn, (2,))
+    assert task_key(fn, (1,)) == task_key(fn, (1,))
+    assert task_key(fn, (1,)) != task_key(fn, (2,))
 
 
 def test_input_fingerprint_stable_across_processes():

--- a/todo.md
+++ b/todo.md
@@ -11,12 +11,16 @@ The storage / artifacts / publishing backlog has moved out of here:
   #39 (wire the store through interactive `app.map`/`arun`), #15 (GC), #19 (queued vs.
   running visibility).
 
-- **Late-orphan writes to mutable names.** A superseded worker (fn edited under a
-  live run, against the hotfix rules) runs to completion and can last-writer-win a
-  mutable name *after* its replacement already wrote it: `set_ref`, `publish`, and
-  shared volume paths (`get_data_dir()` filenames). Memo results (per-key dirs) and
-  CAS blobs (content-addressed) are immune. Auto-cancelling orphans at tick time is
-  wrong — mid-run the requested-set manifest is only a lower bound, so it would kill
-  in-flight downstream tasks and settle them CANCELLED (terminal). Options if it
-  bites: per-task scratch dirs on the volume, or a generation stamp on refs. For now
-  the guard is the existing rule: `cancel` before editing.
+- **Late writes from stale workers.** A worker launched under old code (fn edited
+  under a live run, against the hotfix rules) runs to completion and can
+  last-writer-win a mutable name *after* its replacement already wrote it:
+  `set_ref`, `publish`, and shared volume paths (`get_data_dir()` filenames). CAS
+  blobs (content-addressed) are immune. Under identity keys the hazard extends to
+  the *record and result themselves*: the stale worker shares its successor's key,
+  so if it survives `cancel` (ignored SIGTERM) it can overwrite `result.pkl` and
+  merge DONE over the new attempt's RUNNING. A generation stamp on attempts (also
+  wanted to close the double-spawn race between the `state` read and
+  `mark_running` in `Ctx._classify`) would fence both; per-task scratch dirs
+  cover the volume paths. Auto-cancelling stale workers at tick time is still
+  wrong — mid-run the requested-set manifest is only a lower bound. For now the
+  guard is the existing rule: `cancel` (and confirm dead) before editing.


### PR DESCRIPTION
Editing a `map` fn mid-sweep re-ran the whole fan-out: every cell shared the fn's source hash, so a one-line hotfix orphaned 100 records to re-run 20 failed cells. This PR removes the cause instead of patching around it.

## The split

The old key conflated two questions — *which task is this?* and *is its cached result still valid?* Now they're separate:

- **Identity (the key):** `fn-` + hash of the fn's module-qualified name and the input fingerprint. Stable across code edits, so a task's record, logs, and results keep one address for its whole life.
- **Validity (the evidence):** the transitive source fingerprint and `version=`, stamped on each attempt. The tick judges each record against the current evidence; stale evidence re-runs the task **in place**, and the replaced attempt compacts into the record's `history`.

## What this changes in practice

- **Stale FAILED/CANCELLED relaunches automatically** on the next `run` — the edit is the fix it was waiting for. `retry` remains the lever for flaky failures (nothing changed).
- **Stale DONE re-runs by default** (bias to over-invalidate holds). `mini run --keep-stale-done` is the bounded hotfix: finished cells are served as-is and badged `(stale code — kept)` in `status` (recorded in run meta — read paths can't fingerprint code themselves), and only unfinished cells re-run with the new code.
- **`version=` is evidence too:** a bump re-runs in place as a new attempt rather than minting a parallel key.
- **`mini explain` walks the attempt timeline** (`#1 failed code a1b2c3 !! RuntimeError: bug` → `#2 done ⇐ helper: changed`) instead of diffing sibling records.
- **Superseded shrinks to what it really means:** renamed fns and removed configs. Editing a body orphans nothing, so the manifest machinery from #41 stays but sees far less traffic.
- Old stores effectively re-key once (identity format changed); nothing to preserve at this stage.

`fingerprint`/`fingerprint_parts` are renamed `task_key`/`task_key_parts` — the old names promised content addressing the key no longer does.

## Verified end-to-end

Drove the real CLI on a scratch 3-cell sweep with per-cell execution counters: buggy run settles 2 DONE + 1 FAILED → edit fn in place → `run --keep-stale-done` completes `[10, 20, 30]` with counters `1/2/1` (only the failed cell re-ran), `status` badges the two kept cells, `explain` shows the failed attempt and names the dep that moved. Probes: a later default `run` re-runs the kept-stale cells (counters `2/2/2`, badges clear); a plain re-run is all memo hits; `explain` on a bogus key errors cleanly. Suite: 213 passed, 4 skipped; ruff + ty clean.

## Noted for later (todo.md)

A stale worker that survives `cancel` now shares its successor's key, so an ignored SIGTERM could overwrite the new attempt's record/result — same fence (generation stamp on attempts) as the known double-spawn race, so they should be fixed together. The `cancel`-before-editing rule remains the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)