### PR TITLE
Small-fixes batch: attempt generations, locked records, Executor-style ctx.map

### DIFF
--- a/.agents/skills/mi-ni/references/authoring.md
+++ b/.agents/skills/mi-ni/references/authoring.md
@@ -12,8 +12,8 @@ from mini import Ctx, Experiment
 
 def main(ctx: Ctx) -> dict:
     meta = ctx.run(prepare_data)                        # one step; suspends until done
-    configs = [(lr, meta['vocab_size']) for lr in LRS]  # plain Python between steps
-    return ctx.map(train, configs)                      # fan-out that depends on prep
+    vocab = meta['vocab_size']                          # plain Python between steps
+    return ctx.map(train, LRS, [vocab] * len(LRS))      # fan-out that depends on prep
 
 experiment = Experiment(name='my-exp', main=main)
 ```
@@ -85,7 +85,7 @@ to a concrete apparatus:
 
 ```python
 meta = ctx.run(prepare_data, role='cpu')          # prep on CPU
-return ctx.map(train, configs, role='gpu')        # training on GPU
+return ctx.map(train, configs, role='gpu')        # training on GPU (fn(config) per item)
 ```
 
 Each step also picks up that apparatus's `before_each` hooks. The default role

--- a/.agents/skills/mi-ni/references/memoization.md
+++ b/.agents/skills/mi-ni/references/memoization.md
@@ -79,9 +79,13 @@ The single most effective habit. A task keyed on the entire experiment config
 re-runs whenever any unrelated field changes:
 
 ```python
-ctx.map(train, [(whole_config,) for ...])   # re-runs on ANY config change
-ctx.map(train, [(lr, vocab_size) for ...])  # re-runs only when lr / vocab_size change
+ctx.map(train, whole_configs)      # re-runs on ANY config change
+ctx.map(train, lrs, vocab_sizes)   # re-runs only when lr / vocab_size change
 ```
+
+(`ctx.map` zips its iterables Executor-style — `train(lr, vocab_size)` per pair,
+mismatched lengths raise. A single iterable passes each element as one argument,
+tuples included.)
 
 Keep `main` cheap and deterministic (it re-runs every wake), and fold RNG seeds
 into a task's inputs so the same inputs really do produce the same result.

--- a/.agents/skills/mi-ni/references/running.md
+++ b/.agents/skills/mi-ni/references/running.md
@@ -72,9 +72,12 @@ rules keep the blast radius bounded:
    computed, run with `--keep-stale-done`: DONE results are served as-is (badged
    `(stale code — kept)` in `status`) and only the unfinished cells re-run.
 2. **If anything is in-flight, `cancel` first, then fix.** Never edit under a
-   live worker — a stale worker that settles later writes onto the *same* record
-   its replacement would use. (`cancel` is store-scoped — it also stops stale
-   old-code workers, which keep showing as `RUNNING` in `status`.)
+   live worker — you'd pay for compute nobody wants. (`cancel` is store-scoped —
+   it also stops stale old-code workers, which keep showing as `RUNNING` in
+   `status`.) The *records* are safe either way: every attempt runs under a
+   generation stamp, so a stale worker that survives `cancel` can't overwrite
+   its replacement's state or result — but it can still race mutable *names* it
+   writes (`set_ref`, `publish`, shared volume paths).
 3. **Only ever edit the single failing task fn.** Never a shared helper, `main`,
    or the DAG shape — those re-run an unbounded set of tasks. That's an
    **escalation**, not a hotfix.

--- a/docs/gpt-sweep/experiment.py
+++ b/docs/gpt-sweep/experiment.py
@@ -148,7 +148,8 @@ def publish_curves(results: list[tuple]) -> str:
 
 def main(ctx: Ctx) -> list[tuple]:
     meta = ctx.run(prepare_data, role='prep')  # CPU prep; suspends until done
-    results = ctx.map(train_one, build_sweep(meta), role='train')  # GPU sweep that depends on prep
+    configs, archs, lrs = zip(*build_sweep(meta), strict=True)
+    results = ctx.map(train_one, configs, archs, lrs, role='train')  # GPU sweep that depends on prep
     ctx.run(publish_curves, results, role='prep')  # share the curves by name for the report
     return results
 

--- a/docs/pipeline/experiment.py
+++ b/docs/pipeline/experiment.py
@@ -61,7 +61,8 @@ def main(ctx: Ctx) -> dict:
     # inside tasks (with any seed folded into their inputs).
     meta = ctx.run(prepare_data)  # single prep step; suspends until done
     vocab = meta['vocab_size']  # the dependency a single-map experiment can't express
-    results = ctx.map(train, [(lr, vocab) for lr in (1e-3, 1e-2, 1e-1)])
+    lrs = [1e-3, 1e-2, 1e-1]
+    results = ctx.map(train, lrs, [vocab] * len(lrs))  # zipped, Executor-style: train(lr, vocab)
     best = min(results, key=lambda r: r['val_loss'])
     return {'meta': meta, 'best': best, 'results': results}
 

--- a/src/mini/_taskworker.py
+++ b/src/mini/_taskworker.py
@@ -28,24 +28,34 @@ from mini.volume import data_dir_context
 
 
 class _MemoSink:
-    """Writes the latest progress/metrics for a task straight to its memo record."""
+    """Writes the latest progress/metrics for a task straight to its memo record.
 
-    def __init__(self, store: MemoStore, key: str):
+    Writes are fenced on the attempt's *gen*: once a successor attempt (or a
+    ``cancel``) takes the record, this worker's progress stops landing — and stops
+    trying (``_fenced``), since a superseded attempt can never own it again.
+    """
+
+    def __init__(self, store: MemoStore, key: str, gen: str | None = None):
         self._store = store
         self._key = key
+        self._gen = gen
+        self._fenced = False
 
     def put(self, item: Any, /, block: bool = True, timeout: float | None = None) -> None:
         del block, timeout
-        if isinstance(item, EndOfQueue):
+        if isinstance(item, EndOfQueue) or self._fenced:
             return
-        self._store.update(
-            self._key,
+        fields = dict(
             step=item.step,
             total=item.total,
             message=item.message,
             metrics=item.metrics,
             heartbeat_at=time.time(),
         )
+        if self._gen is None:
+            self._store.update(self._key, **fields)
+        elif not self._store.update_if(self._key, self._gen, **fields):
+            self._fenced = True
 
     def get(self, /, block: bool = True, timeout: float | None = None) -> Any:
         del block, timeout
@@ -63,12 +73,19 @@ def execute_task(
     hooks: list,
     commit: Callable[[], None] | None = None,
     artifacts: Store | None = None,
+    gen: str | None = None,
 ) -> None:
     """Run one memoized call and persist its result/state — backend-agnostic.
 
     Shared by the local subprocess worker and the Modal remote worker: only how
     the call *arrives* (staged on disk vs passed to ``spawn``) and where state
     lands (``RecordStore``) differ; the run/persist core is identical.
+
+    *gen* is the attempt generation this worker runs under. Every record write is
+    fenced on it, and the result/error land in gen-qualified files — so a stale
+    worker (superseded by a relaunch, or cancelled but surviving SIGTERM) can
+    neither merge DONE over its successor's RUNNING nor overwrite its result. A
+    worker that finds itself already superseded at startup exits without running.
 
     *commit* is called after the result/error is written to the I/O plane and
     *before* the record flips to DONE/FAILED — so a poller never sees a settled
@@ -80,11 +97,19 @@ def execute_task(
     so the existing write → commit → DONE order extends from "the volume flushed"
     to "the referenced blobs are durable" for free.
     """
+
+    def record(**fields: Any) -> bool:
+        if gen is None:
+            store.update(key, **fields)
+            return True
+        return store.update_if(key, gen, **fields)
+
     result_dir = store.result_dir(key)
     result_dir.mkdir(parents=True, exist_ok=True)
-    sink = _MemoSink(store, key)
+    sink = _MemoSink(store, key, gen)
     # Record what we actually ran on (host/GPU/…), captured here in the worker.
-    store.update(key, state=RunState.RUNNING, heartbeat_at=time.time(), env=compute_env())
+    if not record(state=RunState.RUNNING, heartbeat_at=time.time(), env=compute_env()):
+        return  # superseded before we even started — nothing here is wanted anymore
     try:
         with (
             data_dir_context(store.data_dir),
@@ -94,17 +119,16 @@ def execute_task(
             for hook in reversed(hooks):
                 hook()
             result = fn(*args)
-        (result_dir / 'result.pkl').write_bytes(cloudpickle.dumps(result))
+        store.result_path(key, gen).write_bytes(cloudpickle.dumps(result))
         if commit is not None:
             commit()
-        store.update(key, state=RunState.DONE, heartbeat_at=time.time())
+        record(state=RunState.DONE, heartbeat_at=time.time())
     except Exception as exc:
         tb = traceback.format_exc()
-        (result_dir / 'error.txt').write_text(tb)
+        store.error_path(key, gen).write_text(tb)
         if commit is not None:
             commit()
-        store.update(
-            key,
+        record(
             state=RunState.FAILED,
             error=tb.strip().splitlines()[-1],
             exc_type=f'{type(exc).__module__}.{type(exc).__qualname__}',
@@ -115,12 +139,12 @@ def execute_task(
 def run_task(data_dir: Path, key: str) -> None:
     """Local subprocess entry: read the staged call from disk and run it."""
     store = MemoStore(data_dir)
-    fn, args, hooks = store.read_call(key)
+    fn, args, hooks, gen = store.read_call(key)
     # Project-scoped artifact store sits beside the experiment's data dir (or the
     # shared HF bucket, if MINI_STORE_BUCKET is set), so a blob put here resolves
     # from any experiment in the project (and from reports).
     artifacts = store_for(store_root_for(data_dir))
-    execute_task(store, key, fn, args, hooks, artifacts=artifacts)
+    execute_task(store, key, fn, args, hooks, artifacts=artifacts, gen=gen)
 
 
 def main() -> None:

--- a/src/mini/apparatus.py
+++ b/src/mini/apparatus.py
@@ -195,14 +195,15 @@ class Apparatus(ABC, Generic[V]):
         ...
 
     @abstractmethod
-    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, Callable, tuple, list]]) -> None:
+    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, str, Callable, tuple, list]]) -> None:
         """Spawn detached workers for a batch of memoized tasks.
 
-        ``Ctx`` marks each record RUNNING, then passes the batch — each entry
-        ``(key, fn, args, hooks)`` — here to launch workers that persist
-        results under each key, surviving the tick that launched them. Batching
-        lets ``ctx.map`` fan out efficiently (one ``spawn_map`` on Modal rather
-        than one detached call per task).
+        ``Ctx`` claims each record RUNNING under a fresh generation, then passes
+        the batch — each entry ``(key, gen, fn, args, hooks)`` — here to launch
+        workers that persist results under each key, surviving the tick that
+        launched them. *gen* travels with the call: the worker fences all its
+        writes on it. Batching lets ``ctx.map`` fan out efficiently (one
+        ``spawn_map`` on Modal rather than one detached call per task).
         """
         ...
 
@@ -211,7 +212,10 @@ class Apparatus(ABC, Generic[V]):
 
         Delegates per-task stops to ``_stop_task`` (local SIGTERMs the worker
         process group; Modal cancels the ``FunctionCall``). Settled tasks are
-        left alone.
+        left alone. Releasing ``gen`` fences the worker even if it survives the
+        stop (an ignored SIGTERM): its writes no longer own the record, so it
+        can't flip CANCELLED back to DONE and pass a half-cancelled attempt off
+        as a current result.
         """
         from mini.runs import RunState
 
@@ -220,7 +224,7 @@ class Apparatus(ABC, Generic[V]):
             state = RunState(rec['state']) if rec.get('state') else RunState.PENDING
             if state in (RunState.RUNNING, RunState.PENDING):
                 self._stop_task(rec)
-                store.update(rec['key'], state=RunState.CANCELLED)
+                store.update(rec['key'], state=RunState.CANCELLED, gen=None)
                 cancelled.append(rec['key'])
         return cancelled
 
@@ -266,7 +270,9 @@ class Apparatus(ABC, Generic[V]):
             if store.state(rec['key']) != RunState.RUNNING:
                 continue
             error = 'worker vanished (killed/crashed, no result written)'
-            store.update(rec['key'], state=RunState.FAILED, error=error)
+            # gen=None releases the attempt: if the liveness probe was wrong and the
+            # worker still breathes somewhere, its fenced writes can't undo the reap.
+            store.update(rec['key'], state=RunState.FAILED, error=error, gen=None)
             rec['state'], rec['error'] = RunState.FAILED, error  # keep the caller's snapshot current
             reaped.append(rec['key'])
         return reaped

--- a/src/mini/experiment.py
+++ b/src/mini/experiment.py
@@ -58,10 +58,6 @@ class Experiment:
             return {label: base.w(**kwargs) for label, kwargs in table.items()}
         return dict(self.roles(base))
 
-    def orchestration(self) -> Callable[[Ctx], Any]:
-        """Return the ``main(ctx)`` orchestration DAG."""
-        return self.main
-
 
 def load_experiment(path: str | Path) -> Experiment:
     """Import a file and return its module-level ``experiment = Experiment(...)``."""

--- a/src/mini/local_apparatus.py
+++ b/src/mini/local_apparatus.py
@@ -75,10 +75,10 @@ class LocalApparatus(Apparatus[LocalVolume]):
         return MemoStore(self.volume.path)
 
     @override
-    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, Callable, tuple, list]]) -> None:
-        for key, fn, args, hooks in batch:
-            store.write_call(key, fn, args, hooks)  # stage to disk for the subprocess worker
-            store.update(key, pid=spawn_taskworker(store.data_dir, key))  # pid == pgid, for cancel
+    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, str, Callable, tuple, list]]) -> None:
+        for key, gen, fn, args, hooks in batch:
+            store.write_call(key, fn, args, hooks, gen)  # stage to disk for the subprocess worker
+            store.update_if(key, gen, pid=spawn_taskworker(store.data_dir, key))  # pid == pgid, for cancel
 
     @override
     def _stop_task(self, rec: dict[str, Any]) -> None:

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -23,15 +23,18 @@ from __future__ import annotations
 import dataclasses
 import dis
 import enum
+import fcntl
 import functools
 import hashlib
 import inspect
 import json
 import logging
+import secrets
 import time
 import types
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from contextlib import contextmanager
 from pathlib import Path, PurePath
 from typing import Any, Callable, Iterator
 
@@ -341,7 +344,7 @@ def task_key_parts(fn: Callable, args: tuple, version: str | None = None) -> tup
 # What a finished attempt is worth keeping once a new one replaces it: the
 # evidence and the outcome. Live/bulky fields (metrics, env, heartbeats, pids)
 # describe a worker, not the attempt's identity in the run's story.
-_ATTEMPT_KEEP = ('state', 'code_fp', 'input_fp', 'version', 'deps', 'created_at', 'error', 'exc_type')
+_ATTEMPT_KEEP = ('state', 'gen', 'code_fp', 'input_fp', 'version', 'deps', 'created_at', 'error', 'exc_type')
 
 
 def _compact_attempt(rec: dict[str, Any]) -> dict[str, Any]:
@@ -370,24 +373,74 @@ class RecordStore(ABC):
     @abstractmethod
     def keys(self) -> list[str]: ...
 
+    # Conditional writes, fenced on the record's attempt generation (``gen``).
+    # These defaults are read-check-write — atomic only if the backend makes them
+    # so (``LocalRecordStore`` overrides under a file lock; ``modal.Dict`` has no
+    # compare-and-swap, so on Modal the fence is best-effort with a tiny window —
+    # still a vast improvement over unconditional last-writer-wins).
+
+    def write_if(self, key: str, record: dict[str, Any], gen: str | None) -> bool:
+        """Replace the record iff its current ``gen`` equals *gen* (``None`` = unclaimed)."""
+        if (self.read(key) or {}).get('gen') != gen:
+            return False
+        self.write(key, record)
+        return True
+
+    def merge_if(self, key: str, fields: dict[str, Any], gen: str | None) -> bool:
+        """Merge *fields* iff the record's current ``gen`` equals *gen*."""
+        if (self.read(key) or {}).get('gen') != gen:
+            return False
+        self.merge(key, fields)
+        return True
+
 
 class LocalRecordStore(RecordStore):
-    """``RecordStore`` backed by JSON files under a directory."""
+    """``RecordStore`` backed by JSON files under a directory.
+
+    All mutations serialize on one store-wide ``flock``: ``merge`` is
+    read-modify-write, so without the lock two concurrent mergers (a worker's
+    final DONE vs the reaper's FAILED, a heartbeat vs the tick's pid stamp)
+    could each read the same base record and silently drop the other's fields.
+    Reads stay lock-free — ``_atomic_write`` renames, so a reader never sees a
+    half-written file. The lock also makes ``write_if``/``merge_if`` genuinely
+    atomic (check and write under one critical section).
+    """
 
     def __init__(self, root: Path):
         self.root = Path(root)
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        with open(self.root / '.lock', 'w') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            yield  # released when the file closes
 
     def read(self, key: str) -> dict[str, Any] | None:
         p = self.root / f'{key}.json'
         return json.loads(p.read_text()) if p.exists() else None
 
     def write(self, key: str, record: dict[str, Any]) -> None:
-        self.root.mkdir(parents=True, exist_ok=True)
-        _atomic_write(self.root / f'{key}.json', json.dumps(record))
+        with self._locked():
+            _atomic_write(self.root / f'{key}.json', json.dumps(record))
 
     def merge(self, key: str, fields: dict[str, Any]) -> None:
-        self.root.mkdir(parents=True, exist_ok=True)
-        _merge_json(self.root / f'{key}.json', fields)
+        with self._locked():
+            _merge_json(self.root / f'{key}.json', fields)
+
+    def write_if(self, key: str, record: dict[str, Any], gen: str | None) -> bool:
+        with self._locked():
+            if (self.read(key) or {}).get('gen') != gen:
+                return False
+            _atomic_write(self.root / f'{key}.json', json.dumps(record))
+            return True
+
+    def merge_if(self, key: str, fields: dict[str, Any], gen: str | None) -> bool:
+        with self._locked():
+            if (self.read(key) or {}).get('gen') != gen:
+                return False
+            _merge_json(self.root / f'{key}.json', fields)
+            return True
 
     def keys(self) -> list[str]:
         return sorted(p.stem for p in self.root.glob('*.json')) if self.root.exists() else []
@@ -425,15 +478,43 @@ class MemoStore:
     def record(self, key: str) -> dict[str, Any]:
         return self.records_backend.read(key) or {'key': key, 'state': None}
 
+    def result_path(self, key: str, gen: str | None) -> Path:
+        """Where attempt *gen* of *key* writes its result.
+
+        Generation-qualified so a superseded worker that survives ``cancel``
+        physically *cannot* overwrite its successor's result — each attempt owns
+        its own file, and readers resolve through the record's current ``gen``.
+        (``None`` — a record from before generations — reads the legacy name.)
+        """
+        return self.result_dir(key) / (f'result-{gen}.pkl' if gen else 'result.pkl')
+
+    def error_path(self, key: str, gen: str | None) -> Path:
+        return self.result_dir(key) / (f'error-{gen}.txt' if gen else 'error.txt')
+
+    def _gen(self, key: str) -> str | None:
+        return (self.records_backend.read(key) or {}).get('gen')
+
     def result(self, key: str) -> Any:
-        return cloudpickle.loads((self.result_dir(key) / 'result.pkl').read_bytes())
+        return cloudpickle.loads(self.result_path(key, self._gen(key)).read_bytes())
 
     def error(self, key: str) -> str:
-        e = self.result_dir(key) / 'error.txt'
-        return e.read_text() if e.exists() else '(no logs)'
+        for p in (self.error_path(key, self._gen(key)), self.error_path(key, None)):
+            if p.exists():
+                return p.read_text()
+        return '(no logs)'
 
     def update(self, key: str, **fields: Any) -> None:
         self.records_backend.merge(key, fields)
+
+    def update_if(self, key: str, gen: str, **fields: Any) -> bool:
+        """Merge *fields* only while attempt *gen* still owns the record.
+
+        The worker-side fence: every write a worker makes passes through here, so
+        once its record is claimed by a successor attempt (or released by
+        ``cancel``/``reap_dead``), a lingering worker can no longer heartbeat, merge
+        DONE over the new attempt's RUNNING, or resurrect cleared fields.
+        """
+        return self.records_backend.merge_if(key, fields, gen)
 
     def records(self) -> list[dict[str, Any]]:
         return [
@@ -513,8 +594,11 @@ class MemoStore:
         """
         self.records_backend.write(key, self._with_history(key, {'key': key, 'state': None}))
 
-    def mark_running(self, fn: Callable, key: str, parts: dict[str, Any] | None = None) -> None:
-        """Flip the record to RUNNING (wholesale, clearing any prior error).
+    def mark_running(
+        self, fn: Callable, key: str, parts: dict[str, Any] | None = None, expect_gen: str | None = None
+    ) -> str | None:
+        """Claim the record for a fresh attempt: flip it to RUNNING (wholesale,
+        clearing any prior error) under a new generation stamp.
 
         Called by ``Ctx`` before the apparatus spawns the worker, so a poll
         between stage and first heartbeat sees RUNNING rather than a stale state.
@@ -522,27 +606,35 @@ class MemoStore:
         :func:`task_key_parts`) this attempt runs under; any prior attempt is
         compacted into ``history``, so ``mini explain`` can answer "why did this
         re-run" after the fact.
-        """
-        self.records_backend.write(
-            key,
-            self._with_history(
-                key,
-                {
-                    'key': key,
-                    'fn': getattr(fn, '__name__', 'task'),
-                    'state': RunState.RUNNING,
-                    'created_at': time.time(),
-                    **(parts or {}),
-                },
-            ),
-        )
 
-    def write_call(self, key: str, fn: Callable, args: tuple, hooks: list[Callable] | None = None) -> None:
+        The claim is conditional on *expect_gen* — the ``gen`` the caller read
+        when it classified the record (``None`` = unclaimed). If another ticker
+        claimed the key in between, nothing is written and ``None`` returns
+        (don't spawn — theirs is running). On success, returns the new attempt's
+        ``gen``: the fence every write from that worker must carry.
+        """
+        gen = secrets.token_hex(4)
+        rec = self._with_history(
+            key,
+            {
+                'key': key,
+                'fn': getattr(fn, '__name__', 'task'),
+                'state': RunState.RUNNING,
+                'gen': gen,
+                'created_at': time.time(),
+                **(parts or {}),
+            },
+        )
+        return gen if self.records_backend.write_if(key, rec, expect_gen) else None
+
+    def write_call(
+        self, key: str, fn: Callable, args: tuple, hooks: list[Callable] | None = None, gen: str | None = None
+    ) -> None:
         """Stage the cloudpickled call to disk for a local subprocess worker."""
         self.root.mkdir(parents=True, exist_ok=True)
-        self._call(key).write_bytes(cloudpickle.dumps((fn, args, hooks or [])))
+        self._call(key).write_bytes(cloudpickle.dumps((fn, args, hooks or [], gen)))
 
-    def read_call(self, key: str) -> tuple[Callable, tuple, list[Callable]]:
+    def read_call(self, key: str) -> tuple[Callable, tuple, list[Callable], str | None]:
         return cloudpickle.loads(self._call(key).read_bytes())
 
 

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -143,13 +143,18 @@ class ModalMemoStore(MemoStore):
         return b''.join(self._volume._modal_volume.read_file(rel))
 
     def result(self, key: str) -> Any:
-        return cloudpickle.loads(self._read_volume_bytes(f'_memo/{key}/result.pkl'))
+        gen = self._gen(key)
+        name = f'result-{gen}.pkl' if gen else 'result.pkl'
+        return cloudpickle.loads(self._read_volume_bytes(f'_memo/{key}/{name}'))
 
     def error(self, key: str) -> str:
-        try:
-            return self._read_volume_bytes(f'_memo/{key}/error.txt').decode()
-        except FileNotFoundError, modal.exception.NotFoundError:
-            return '(no logs)'
+        gen = self._gen(key)
+        for name in dict.fromkeys((f'error-{gen}.txt' if gen else 'error.txt', 'error.txt')):
+            try:
+                return self._read_volume_bytes(f'_memo/{key}/{name}').decode()
+            except FileNotFoundError, modal.exception.NotFoundError:
+                continue
+        return '(no logs)'
 
 
 class ModalVolumeStore(Store):
@@ -228,7 +233,7 @@ def _hf_store_secret() -> modal.Secret | None:
     return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
 
 
-def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, mount_point: str) -> None:
+def _modal_task_entry(blob: bytes, key: str, gen: str, dict_name: str, volume_name: str, mount_point: str) -> None:
     """Remote entry: run one memoized call on Modal and persist its result/state.
 
     Mirrors the local subprocess worker (``mini._taskworker``) but reads the call
@@ -251,7 +256,7 @@ def _modal_task_entry(blob: bytes, key: str, dict_name: str, volume_name: str, m
     # back with no shared Volume. Otherwise the CAS rides *under* the mounted
     # Volume (committed with the result), per-experiment until #22's project Volume.
     artifacts = store_for(Path(mount_point) / 'store')
-    execute_task(store, key, fn, args, hooks, commit=volume.commit, artifacts=artifacts)
+    execute_task(store, key, fn, args, hooks, commit=volume.commit, artifacts=artifacts, gen=gen)
 
 
 class ModalApparatus(Apparatus[ModalVolume]):
@@ -387,7 +392,7 @@ class ModalApparatus(Apparatus[ModalVolume]):
         return self._memo_fn
 
     @override
-    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, Callable, tuple, list]]) -> None:
+    def spawn_tasks(self, store: MemoStore, batch: list[tuple[str, str, Callable, tuple, list]]) -> None:
         worker = self._memo_worker()
         dict_name, volume_name, mount_point = self._dict_name, self.app.name, str(self.volume.path)
         # One detached app context for the whole batch (the cost we batch away is
@@ -397,15 +402,15 @@ class ModalApparatus(Apparatus[ModalVolume]):
         # failure is diagnosable (cross-check via FunctionCall.from_id, find logs
         # on the dashboard) even before the worker writes its first heartbeat.
         # max_containers is dropped in ``_memo_worker``, so the tasks parallelise.
-        fc_ids: dict[str, str] = {}
+        fc_ids: dict[str, tuple[str, str]] = {}
         with self.app.run(detach=True):
-            for key, fn, args, hooks in batch:
+            for key, gen, fn, args, hooks in batch:
                 blob = cloudpickle.dumps((fn, args, hooks))
-                fc = worker.spawn(blob, key, dict_name, volume_name, mount_point)
-                fc_ids[key] = fc.object_id
+                fc = worker.spawn(blob, key, gen, dict_name, volume_name, mount_point)
+                fc_ids[key] = (gen, fc.object_id)
         now = time.time()
-        for key, fc_id in fc_ids.items():
-            store.update(key, fc_id=fc_id, heartbeat_at=now)
+        for key, (gen, fc_id) in fc_ids.items():
+            store.update_if(key, gen, fc_id=fc_id, heartbeat_at=now)
 
     @override
     def _stop_task(self, rec: dict[str, Any]) -> None:

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -17,7 +17,7 @@ told ``keep_stale`` (the bounded sweep-hotfix lever).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, overload
 
 from mini.memo import MemoStore, task_key_parts
 from mini.runs import SETTLED, RunState
@@ -164,8 +164,8 @@ class Ctx:
 
     def _classify(
         self, fn: Callable, args: tuple, version: str | None, app: Apparatus
-    ) -> tuple[str, RunState | None, tuple[str, Callable, tuple, list] | None]:
-        """Resolve a call's key/state and, if it needs launching, mark it RUNNING
+    ) -> tuple[str, RunState | None, tuple[str, str, Callable, tuple, list] | None]:
+        """Resolve a call's key/state and, if it needs launching, claim it RUNNING
         and return its batch entry — *without* spawning. The caller batches the
         spawn so a ``map`` fans out in one ``spawn_tasks`` call.
 
@@ -177,6 +177,12 @@ class Ctx:
         Same-evidence FAILED/CANCELLED stays terminal (retry takes intent), and a
         RUNNING task is never relaunched out from under its worker — staleness
         waits for it to settle.
+
+        Launching is a *claim*, not a blind write: ``mark_running`` replaces the
+        record only if its generation still matches what we read, so two
+        concurrent tickers (a cron routine and a human both waking the run)
+        can't both spawn a worker for one key — the loser sees RUNNING and
+        suspends like any other in-flight task.
         """
         key, parts = task_key_parts(fn, args, version)
         self.requested.append(key)
@@ -189,11 +195,12 @@ class Ctx:
         keep = stale and state == RunState.DONE and self.keep_stale
         if keep:
             self.stale_kept.append(key)
-        to_launch: tuple[str, Callable, tuple, list] | None = None
+        to_launch: tuple[str, str, Callable, tuple, list] | None = None
         if state is None or (stale and state != RunState.RUNNING and not keep):
-            self.store.mark_running(fn, key, parts)
-            to_launch = (key, fn, args, getattr(app, '_before_hooks', []))
-            self.launched.append(key)
+            gen = self.store.mark_running(fn, key, parts, expect_gen=rec.get('gen'))
+            if gen is not None:
+                to_launch = (key, gen, fn, args, getattr(app, '_before_hooks', []))
+                self.launched.append(key)
             state = RunState.RUNNING
         return key, state, to_launch
 
@@ -224,7 +231,7 @@ class Ctx:
     def map[R](
         self,
         fn: Callable[..., R],
-        items: Sequence[Any],
+        *iterables: Iterable[Any],
         version: str | None = None,
         on: Apparatus | None = None,
         role: str | None = None,
@@ -234,25 +241,32 @@ class Ctx:
     def map[R](
         self,
         fn: Callable[..., R],
-        items: Sequence[Any],
+        *iterables: Iterable[Any],
         version: str | None = None,
         on: Apparatus | None = None,
         role: str | None = None,
-        *,
         allow_partial: Literal[True],
     ) -> list[R | _Missing]: ...
     def map[R](
         self,
         fn: Callable[..., R],
-        items: Sequence[Any],
+        *iterables: Iterable[Any],
         version: str | None = None,
         on: Apparatus | None = None,
         role: str | None = None,
         allow_partial: bool = False,
     ) -> list[R] | list[R | _Missing]:
-        """Fan out *fn* over *items*, suspending until the results are ready.
+        """Fan out *fn* over the zipped *iterables*, suspending until the results
+        are ready.
 
-        Launches every missing item in one batch, then raises ``Pending`` while
+        Like ``Executor.map`` / ``Apparatus.map``: the iterables are zipped and
+        each row is passed as positional arguments — ``ctx.map(train, lrs, sizes)``
+        runs ``train(lr, size)`` per pair. With a single iterable each element is
+        passed as *one* argument, never unpacked (an element that happens to be a
+        tuple stays a tuple). Unlike ``Executor.map``, mismatched iterable lengths
+        raise rather than silently truncating the sweep.
+
+        Launches every missing cell in one batch, then raises ``Pending`` while
         any task is still in flight. By default the map is all-or-nothing: once the
         fan-out has *settled*, any cell that settled ``FAILED``/``CANCELLED`` raises
         — all of them together, as an ``ExceptionGroup`` of ``TaskFailed`` (so you
@@ -261,19 +275,19 @@ class Ctx:
 
         With ``allow_partial=True`` the map still waits for in-flight tasks, but
         once everything has settled it returns instead of raising: the result list
-        stays index-aligned with *items*, with ``MISSING`` in the position of each
-        failed/cancelled cell. This lets the pipeline's later steps run on the
+        stays index-aligned with the inputs, with ``MISSING`` in the position of
+        each failed/cancelled cell. This lets the pipeline's later steps run on the
         subset that succeeded.
         """
         app = self._route(on, role)
+        calls = list(zip(*iterables, strict=True))
         results: list[Any] = []
-        batch: list[tuple[str, Callable, tuple, list]] = []
+        batch: list[tuple[str, str, Callable, tuple, list]] = []
         failed: list[tuple[str, RunState]] = []
         # `self.pending` holds only truly in-flight keys; settled-but-failed cells go
         # to `failed`. Ctx is rebuilt each tick and the first incomplete step raises,
         # so this stays a clean per-tick view across steps.
-        for raw in items:
-            args = raw if isinstance(raw, tuple) else (raw,)
+        for args in calls:
             key, state, to_launch = self._classify(fn, args, version, app)
             if to_launch is not None:
                 batch.append(to_launch)
@@ -291,7 +305,7 @@ class Ctx:
             raise Pending(f'{len(self.pending)} task(s) in flight')
         if failed and not allow_partial:  # everything settled — surface the failures together
             raise ExceptionGroup(
-                f'{len(failed)} of {len(items)} task(s) failed',
+                f'{len(failed)} of {len(calls)} task(s) failed',
                 [self._task_failed(key, state) for key, state in failed],
             )
         return results
@@ -314,7 +328,7 @@ def tick(experiment: Experiment, apparatus: Apparatus, keep_stale: bool = False)
     store = apparatus.memo_store()
     ctx = Ctx(store, apparatus, experiment.resolve_roles(apparatus), keep_stale=keep_stale)
     try:
-        result = experiment.orchestration()(ctx)
+        result = experiment.main(ctx)
     except Pending as p:
         return False, str(p)
     finally:

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -261,10 +261,11 @@ class Ctx:
 
         Like ``Executor.map`` / ``Apparatus.map``: the iterables are zipped and
         each row is passed as positional arguments — ``ctx.map(train, lrs, sizes)``
-        runs ``train(lr, size)`` per pair. With a single iterable each element is
-        passed as *one* argument, never unpacked (an element that happens to be a
-        tuple stays a tuple). Unlike ``Executor.map``, mismatched iterable lengths
-        raise rather than silently truncating the sweep.
+        runs ``train(lr, size)`` per pair. With a single iterable each
+        element is passed as *one* argument, never unpacked (an element that
+        happens to be a tuple stays a tuple). The iterables are collected
+        immediately rather than lazily. Unlike ``Executor.map``, mismatched
+        iterable lengths raise rather than silently truncating the sweep.
 
         Launches every missing cell in one batch, then raises ``Pending`` while
         any task is still in flight. By default the map is all-or-nothing: once the

--- a/tests/mini/test_budget.py
+++ b/tests/mini/test_budget.py
@@ -30,7 +30,7 @@ def _slow_exp(name: str):
         time.sleep(30)  # only a cancel ends it within the test
         return x
 
-    return Experiment(name=name, main=lambda ctx: ctx.map(slow, [(1,)]))
+    return Experiment(name=name, main=lambda ctx: ctx.map(slow, [1]))
 
 
 def _reap(pid: int) -> None:

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -54,7 +54,7 @@ def test_ls_and_status_surface_memo_experiments(tmp_path: Path, monkeypatch, cap
     def train(x):
         return x * 2
 
-    exp = Experiment(name='cli', main=lambda ctx: ctx.map(train, [(1,), (2,)]))
+    exp = Experiment(name='cli', main=lambda ctx: ctx.map(train, [1, 2]))
     _drive(exp, LocalApparatus('cli'))  # default data_dir → .mini/cli
 
     from mini.__main__ import cmd_ls, cmd_status
@@ -83,7 +83,7 @@ def test_status_and_ls_report_done_despite_superseded_failure(tmp_path: Path, mo
         return x
 
     def sweep(fn):
-        return Experiment(name='super', main=lambda ctx: ctx.map(fn, [(1,)]))
+        return Experiment(name='super', main=lambda ctx: ctx.map(fn, [1]))
 
     app = LocalApparatus('super')  # default data_dir → .mini/super
     deadline = time.monotonic() + 30
@@ -129,7 +129,7 @@ def test_explain_walks_the_attempt_timeline_after_a_hotfix(tmp_path: Path, monke
         return work
 
     def sweep(fn):
-        return Experiment(name='explain', main=lambda ctx: ctx.map(fn, [(1,)]))
+        return Experiment(name='explain', main=lambda ctx: ctx.map(fn, [1]))
 
     app = LocalApparatus('explain')
     deadline = time.monotonic() + 30
@@ -165,7 +165,7 @@ def test_cancel_stops_running_task(tmp_path: Path):
         return x
 
     app = LocalApparatus('cancelexp', data_dir=tmp_path / 'cancelexp')
-    tick(Experiment(name='cancelexp', main=lambda ctx: ctx.map(slow, [(1,)])), app)  # launch + suspend
+    tick(Experiment(name='cancelexp', main=lambda ctx: ctx.map(slow, [1])), app)  # launch + suspend
 
     store = app.memo_store()
     (rec,) = store.records()
@@ -198,7 +198,7 @@ def test_retry_cli_heals_failed_task(tmp_path: Path, monkeypatch, capsys):
             if n == 0:  # fail on the first attempt only
                 raise RuntimeError('boom once')
             return x
-        experiment = Experiment(name='retrycli', main=lambda ctx: ctx.map(flaky, [(7,)]))
+        experiment = Experiment(name='retrycli', main=lambda ctx: ctx.map(flaky, [7]))
         """)
     )
     from mini.__main__ import cmd_retry, cmd_run

--- a/tests/mini/test_experiments_e2e.py
+++ b/tests/mini/test_experiments_e2e.py
@@ -60,7 +60,7 @@ def test_every_demo_experiment_loads(path: Path):
     ``experiment = Experiment(...)`` contract without running any training."""
     exp = load_experiment(path)
     assert exp.name == path.parent.name  # the dir is the experiment name by convention
-    assert callable(exp.orchestration())  # main(ctx), or a sweep lowered to one map
+    assert callable(exp.main)  # main(ctx), or a sweep lowered to one map
 
 
 def test_pipeline_demo_runs_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/mini/test_memo_races.py
+++ b/tests/mini/test_memo_races.py
@@ -1,0 +1,123 @@
+"""Concurrency safety of the memo control plane.
+
+Two writers can share a record: a second ticker racing the first to launch, a
+reaper racing a worker's final write, or a stale worker (superseded relaunch, or
+cancelled but surviving SIGTERM) racing its successor. The generation stamp on
+attempts plus the locked local record store keep every such race from corrupting
+the record or the result.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from mini._taskworker import execute_task
+from mini.local_apparatus import LocalApparatus
+from mini.memo import LocalRecordStore, MemoStore, task_key_parts
+from mini.runs import RunState
+
+
+def _claim(store: MemoStore, fn, args=(1,)) -> tuple[str, str]:
+    """Claim a fresh attempt as ``Ctx._classify`` would; return (key, gen)."""
+    key, parts = task_key_parts(fn, args)
+    gen = store.mark_running(fn, key, parts, expect_gen=store.record(key).get('gen'))
+    assert gen is not None
+    return key, gen
+
+
+def _work(x):
+    return x * 10
+
+
+def test_mark_running_claim_is_exclusive(tmp_path: Path):
+    """Two tickers that both read "un-run" cannot both claim the launch: the
+    second write-if fails and returns None, so only one worker is ever spawned
+    (the double-spawn race between the record read and mark_running)."""
+    store = MemoStore(tmp_path / 'claim')
+    key, parts = task_key_parts(_work, (1,))
+    # Both tickers read the record first (both see no attempt), *then* both claim.
+    assert store.mark_running(_work, key, parts, expect_gen=None) is not None
+    assert store.mark_running(_work, key, parts, expect_gen=None) is None  # lost the race — don't spawn
+
+
+def test_stale_worker_is_fenced_after_supersession(tmp_path: Path):
+    """Once a successor claims the record, the old attempt's writes stop landing:
+    no heartbeat resurrection, no DONE over the new attempt's RUNNING."""
+    store = MemoStore(tmp_path / 'fence')
+    key, old = _claim(store, _work)
+    _, new = _claim(store, _work)  # relaunch (e.g. after a cancel): new generation
+
+    assert store.update_if(key, old, state=RunState.DONE, heartbeat_at=1.0) is False
+    assert store.record(key)['state'] == RunState.RUNNING  # untouched
+    assert store.update_if(key, new, state=RunState.DONE) is True
+
+
+def test_superseded_worker_exits_at_startup_without_writing(tmp_path: Path):
+    """A worker whose attempt was superseded before it started runs nothing."""
+    ran = tmp_path / 'ran'
+    store = MemoStore(tmp_path / 'startup')
+
+    def task(x):
+        ran.touch()
+        return x
+
+    key, old = _claim(store, task)
+    _claim(store, task)  # successor claims before the old worker starts
+    execute_task(store, key, task, (1,), [], gen=old)
+    assert not ran.exists()
+    assert store.record(key)['state'] == RunState.RUNNING  # the successor's claim, untouched
+
+
+def test_zombie_finishing_mid_run_cannot_overwrite_successor(tmp_path: Path):
+    """The todo.md hazard: a worker superseded *mid-run* completes anyway. Its
+    final state is fenced out and its result lands in its own generation's file,
+    so the successor's record and result both survive."""
+    store = MemoStore(tmp_path / 'zombie')
+    taken: dict[str, str] = {}
+
+    def sneaky(x):
+        # While the first attempt runs, a successor claims the record.
+        _, taken['gen'] = _claim(store, sneaky)
+        return 'stale'
+
+    key, old = _claim(store, sneaky)
+    execute_task(store, key, sneaky, (1,), [], gen=old)  # zombie runs to completion
+    assert store.record(key)['state'] == RunState.RUNNING  # DONE was fenced out
+
+    # The successor completes normally and its result is the one served.
+    execute_task(store, key, lambda x: 'fresh', (1,), [], gen=taken['gen'])
+    assert store.record(key)['state'] == RunState.DONE
+    assert store.result(key) == 'fresh'
+
+
+def test_cancel_releases_the_generation(tmp_path: Path):
+    """``cancel`` releases the record's gen, so a worker that survives SIGTERM
+    can't flip CANCELLED back to DONE and pass its half-cancelled result off as
+    current."""
+    store = MemoStore(tmp_path / 'cancel')
+    key, gen = _claim(store, _work)
+    app = LocalApparatus('cancel', data_dir=tmp_path / 'cancel')
+    assert app.cancel(store) == [key]
+
+    assert store.update_if(key, gen, state=RunState.DONE) is False  # the survivor is fenced
+    assert store.record(key)['state'] == RunState.CANCELLED
+
+
+def test_concurrent_merges_do_not_drop_fields(tmp_path: Path):
+    """``merge`` is read-modify-write; unlocked, two mergers (heartbeat vs reaper)
+    each read the same base and silently drop the other's fields. The store-wide
+    lock serializes them: after a thrash of concurrent single-field merges, every
+    field is present with its final value."""
+    backend = LocalRecordStore(tmp_path / 'merge')
+    backend.write('k', {'key': 'k'})
+
+    def hammer(i: int) -> None:
+        for n in range(25):
+            backend.merge('k', {f'f{i}': n})
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(hammer, range(8)))
+
+    rec = backend.read('k')
+    assert rec == {'key': 'k', **{f'f{i}': 24 for i in range(8)}}

--- a/tests/mini/test_monitor.py
+++ b/tests/mini/test_monitor.py
@@ -49,7 +49,7 @@ def test_drives_multistep_to_completion(tmp_path: Path):
 
     def main(ctx):
         meta = ctx.run(prep)  # second stage depends on the first
-        return ctx.map(train, [(lr, meta['vocab']) for lr in (0.1, 0.2)])
+        return ctx.map(train, [0.1, 0.2], [meta['vocab']] * 2)
 
     app = LocalApparatus('watch_ok', max_workers=2, data_dir=tmp_path / 'watch_ok')
     payload = _watch(Experiment(name='watch_ok', main=main), app)
@@ -65,7 +65,7 @@ def test_watch_observes_a_run_it_did_not_launch(tmp_path: Path):
     ``watch`` only polls the durable records and returns once they settle. It takes
     no experiment, so it structurally *can't* relaunch — the read-only invariant."""
     app = LocalApparatus('watch_ro', max_workers=2, data_dir=tmp_path / 'watch_ro')
-    exp = Experiment(name='watch_ro', main=lambda ctx: ctx.map(_times_ten, [(1,), (2,)]))
+    exp = Experiment(name='watch_ro', main=lambda ctx: ctx.map(_times_ten, [1, 2]))
     tick(exp, app)  # launch the single stage detached, then suspend — like a separate process
 
     records = watch(app, poll=0.05, console=_quiet())
@@ -79,7 +79,7 @@ def test_raises_on_failure_without_relaunching(tmp_path: Path):
         raise ValueError(f'boom {x}')
 
     app = LocalApparatus('watch_fail', max_workers=2, data_dir=tmp_path / 'watch_fail')
-    exp = Experiment(name='watch_fail', main=lambda ctx: ctx.map(boom, [(1,), (2,)]))
+    exp = Experiment(name='watch_fail', main=lambda ctx: ctx.map(boom, [1, 2]))
     with pytest.raises(ExceptionGroup) as exc:
         _watch(exp, app)
     assert len(exc.value.exceptions) == 2  # both surfaced together, not busy-looped
@@ -90,7 +90,7 @@ def test_reap_dead_settles_a_killed_worker(tmp_path: Path):
     """A worker hard-killed mid-run (no FAILED written) is detected as dead and
     settled FAILED, so it can't masquerade as RUNNING forever."""
     app = LocalApparatus('reap', data_dir=tmp_path / 'reap')
-    tick(Experiment(name='reap', main=lambda ctx: ctx.map(_sleeper, [(1,)])), app)  # launch + suspend
+    tick(Experiment(name='reap', main=lambda ctx: ctx.map(_sleeper, [1])), app)  # launch + suspend
     store = app.memo_store()
     (rec,) = store.records()
     pid = rec['pid']
@@ -115,7 +115,7 @@ def test_drive_stops_on_cancelled_instead_of_spinning(tmp_path: Path):
     """A CANCELLED task is terminal: ``drive_and_watch`` must stop (raise), not
     busy-loop ticking a DAG that can never progress (nothing RUNNING, no FAILED)."""
     app = LocalApparatus('watch_cancel', data_dir=tmp_path / 'watch_cancel')
-    exp = Experiment(name='watch_cancel', main=lambda ctx: ctx.map(_sleeper, [(1,)]))
+    exp = Experiment(name='watch_cancel', main=lambda ctx: ctx.map(_sleeper, [1]))
     tick(exp, app)  # launch detached
     store = app.memo_store()
 
@@ -142,7 +142,7 @@ def test_watch_surfaces_a_killed_worker(tmp_path: Path):
     """The wedge fix end-to-end: a worker killed *while watching* settles FAILED
     via ``reap_dead``, so the drain raises instead of waiting on it forever."""
     app = LocalApparatus('watch_killed', data_dir=tmp_path / 'watch_killed')
-    exp = Experiment(name='watch_killed', main=lambda ctx: ctx.map(_sleeper, [(1,)]))
+    exp = Experiment(name='watch_killed', main=lambda ctx: ctx.map(_sleeper, [1]))
 
     captured: dict[str, BaseException] = {}
 

--- a/tests/mini/test_orchestration.py
+++ b/tests/mini/test_orchestration.py
@@ -57,7 +57,7 @@ def test_multistep_dependency(tmp_path: Path):
 
     def main(ctx):
         meta = ctx.run(prep)  # sweep configs depend on prep's output
-        return ctx.map(train, [(lr, meta['vocab']) for lr in (0.1, 0.2)])
+        return ctx.map(train, [0.1, 0.2], [meta['vocab']] * 2)
 
     assert _drive(*_setup('dep', main, tmp_path)) == [{'lr': 0.1, 'vocab': 7}, {'lr': 0.2, 'vocab': 7}]
 
@@ -76,7 +76,7 @@ def test_prep_runs_once_across_wakes(tmp_path: Path):
 
     def main(ctx):
         ctx.run(prep)
-        return ctx.map(train, [(1,), (2,)])
+        return ctx.map(train, [1, 2])
 
     exp, app = _setup('once', main, tmp_path)
     _drive(exp, app)
@@ -101,7 +101,7 @@ def test_failed_is_terminal_until_retry(tmp_path: Path):
         return x * 10
 
     def main(ctx):
-        return ctx.map(train, [(1,), (2,), (3,)])
+        return ctx.map(train, [1, 2, 3])
 
     exp, app = _setup('crash', main, tmp_path)
     store = app.memo_store()
@@ -137,7 +137,7 @@ def test_allow_partial_returns_sentinel_for_failed_cell(tmp_path: Path):
         return x * 10
 
     def main(ctx):
-        results = ctx.map(train, [(1,), (2,), (3,)], allow_partial=True)
+        results = ctx.map(train, [1, 2, 3], allow_partial=True)
         present = [r for r in results if r is not MISSING]
         return {'results': results, 'best': max(present)}
 
@@ -157,7 +157,7 @@ def test_allow_partial_still_waits_for_in_flight(tmp_path: Path):
         return x * 10
 
     def main(ctx):
-        return ctx.map(train, [(1,), (2,), (3,)], allow_partial=True)
+        return ctx.map(train, [1, 2, 3], allow_partial=True)
 
     from mini.orchestration import MISSING
 
@@ -174,7 +174,7 @@ def test_strict_map_surfaces_failures_as_group(tmp_path: Path):
             raise RuntimeError('boom')
         return x
 
-    exp, app = _setup('strict', lambda ctx: ctx.map(train, [(1,), (2,), (3,)]), tmp_path)
+    exp, app = _setup('strict', lambda ctx: ctx.map(train, [1, 2, 3]), tmp_path)
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         try:
@@ -211,9 +211,37 @@ def test_single_map(tmp_path: Path):
     def sq(x):
         return x * x
 
-    exp = Experiment(name='map', main=lambda ctx: ctx.map(sq, [(2,), (3,)]))
+    exp = Experiment(name='map', main=lambda ctx: ctx.map(sq, [2, 3]))
     app = LocalApparatus('map', data_dir=tmp_path / 'map')
     assert _drive(exp, app) == [4, 9]
+
+
+def test_map_does_not_unpack_tuple_items(tmp_path: Path):
+    """A single-iterable map passes each element as *one* argument — an element
+    that happens to be a tuple stays a tuple. (The old items-based map unpacked
+    tuples as positional args, silently breaking tasks that take a tuple.)"""
+
+    def span(pair):
+        lo, hi = pair
+        return hi - lo
+
+    exp, app = _setup('tup', lambda ctx: ctx.map(span, [(1, 4), (2, 8)]), tmp_path)
+    assert _drive(exp, app) == [3, 6]
+
+
+def test_map_zips_iterables_strictly(tmp_path: Path):
+    """Multiple iterables zip Executor-style into positional args — and
+    mismatched lengths raise rather than silently truncating the sweep."""
+
+    def add(a, b):
+        return a + b
+
+    exp, app = _setup('zipped', lambda ctx: ctx.map(add, [1, 2], [10, 20]), tmp_path)
+    assert _drive(exp, app) == [11, 22]
+
+    exp, app = _setup('lopsided', lambda ctx: ctx.map(add, [1, 2], [10]), tmp_path)
+    with pytest.raises(ValueError, match='shorter'):
+        tick(exp, app)
 
 
 def test_metrics_recorded_on_task(tmp_path: Path):
@@ -224,7 +252,7 @@ def test_metrics_recorded_on_task(tmp_path: Path):
         return x
 
     def main(ctx):
-        return ctx.map(t, [(5,)])
+        return ctx.map(t, [5])
 
     _drive(*_setup('met', main, tmp_path))
     recs = MemoStore(tmp_path / 'met').records()
@@ -233,7 +261,7 @@ def test_metrics_recorded_on_task(tmp_path: Path):
 
 def test_env_recorded_on_task(tmp_path: Path):
     """The worker stamps each record with *what it ran on* (host/OS/Python)."""
-    _drive(*_setup('env', lambda ctx: ctx.map(lambda x: x, [(5,)]), tmp_path))
+    _drive(*_setup('env', lambda ctx: ctx.map(lambda x: x, [5]), tmp_path))
     (rec,) = MemoStore(tmp_path / 'env').records()
     env = rec['env']
     assert env['host'] and env['platform'] and env['python']
@@ -283,10 +311,10 @@ def test_version_reruns_in_place(tmp_path: Path):
         return x
 
     def main_v1(ctx):
-        return ctx.map(t, [(1,)], version='v1')
+        return ctx.map(t, [1], version='v1')
 
     def main_v2(ctx):
-        return ctx.map(t, [(1,)], version='v2')
+        return ctx.map(t, [1], version='v2')
 
     _drive(*_setup('ver', main_v1, tmp_path))
     _drive(Experiment(name='ver', main=main_v2), LocalApparatus('ver', data_dir=tmp_path / 'ver'))
@@ -311,7 +339,7 @@ def test_prune_and_memo_hits_across_config_edits(tmp_path: Path):
         return x * 10
 
     def sweep(items):
-        return Experiment(name='prune', main=lambda ctx: ctx.map(work, [(i,) for i in items]))
+        return Experiment(name='prune', main=lambda ctx: ctx.map(work, items))
 
     data_dir = tmp_path / 'prune'  # one shared memo store across both drives
     assert _drive(sweep([1, 2]), LocalApparatus('prune', data_dir=data_dir, max_workers=3)) == [10, 20]
@@ -333,7 +361,7 @@ def test_tick_persists_requested_keys(tmp_path: Path):
         return x * 10
 
     def sweep(items):
-        return Experiment(name='req', main=lambda ctx: ctx.map(work, [(i,) for i in items]))
+        return Experiment(name='req', main=lambda ctx: ctx.map(work, items))
 
     data_dir = tmp_path / 'req'
     _drive(sweep([1, 2]), LocalApparatus('req', data_dir=data_dir))
@@ -364,7 +392,7 @@ def test_superseded_records_are_excluded_and_not_retried(tmp_path: Path):
         return x * 10
 
     def sweep(fn):
-        return Experiment(name='hotfix', main=lambda ctx: ctx.map(fn, [(1,), (2,)]))
+        return Experiment(name='hotfix', main=lambda ctx: ctx.map(fn, [1, 2]))
 
     data_dir = tmp_path / 'hotfix'
     _drive_to_failure(sweep(bad), LocalApparatus('hotfix', data_dir=data_dir))
@@ -411,7 +439,7 @@ def _make_train(fixed: bool):
 
 
 def _hotfix_sweep(fixed: bool) -> Experiment:
-    return Experiment(name='hot', main=lambda ctx: ctx.map(_make_train(fixed), [(1,), (2,)]))
+    return Experiment(name='hot', main=lambda ctx: ctx.map(_make_train(fixed), [1, 2]))
 
 
 def test_hotfix_edit_relaunches_failed_cells_in_place(tmp_path: Path):
@@ -470,7 +498,7 @@ def test_per_step_apparatus_uses_its_hooks(tmp_path: Path):
     gpu = LocalApparatus('perstep', data_dir=data_dir).before_each(mark_gpu)
 
     def main(ctx):
-        return ctx.map(task, [(1,)], on=gpu)
+        return ctx.map(task, [1], on=gpu)
 
     assert _drive(Experiment(name='perstep', main=main), default) == [1]
     assert (data_dir / 'gpu_hook').exists()  # the on= apparatus's hook ran
@@ -504,7 +532,7 @@ def test_role_routes_to_its_apparatus(tmp_path: Path):
 
     def main(ctx):
         ctx.run(task, 0, role='prep')
-        return ctx.map(task, [(1,)], role='train')
+        return ctx.map(task, [1], role='train')
 
     exp = Experiment(name='roles', main=main, roles=roles)
     assert _drive(exp, LocalApparatus('roles', data_dir=data_dir)) == [1]
@@ -524,7 +552,7 @@ def test_role_kwargs_table_applies_w(tmp_path: Path):
     def task(x):
         return x
 
-    exp = Experiment(name='wtab', main=lambda ctx: ctx.map(task, [(1,)], role='train'), roles={'train': dict(gpu='L4')})
+    exp = Experiment(name='wtab', main=lambda ctx: ctx.map(task, [1], role='train'), roles={'train': dict(gpu='L4')})
     assert _drive(exp, RecordingLocal('wtab', data_dir=tmp_path / 'wtab')) == [1]
     assert captured == {'gpu': 'L4'}
 
@@ -556,15 +584,15 @@ def test_ctx_spawns_via_the_apparatus(tmp_path: Path):
     class InlineApparatus(LocalApparatus):
         def spawn_tasks(self, store, batch):
             batches.append(len(batch))  # record fan-out width
-            for key, fn, args, hooks in batch:
-                store.write_call(key, fn, args, hooks)
+            for key, gen, fn, args, hooks in batch:
+                store.write_call(key, fn, args, hooks, gen)
                 run_task(store.data_dir, key)  # run now, in-process — no subprocess
 
     def task(x):
         return x * 3
 
     app = InlineApparatus('inline', data_dir=tmp_path / 'inline')
-    exp = Experiment(name='inline', main=lambda ctx: ctx.map(task, [(2,), (5,)]))
+    exp = Experiment(name='inline', main=lambda ctx: ctx.map(task, [2, 5]))
     assert _drive(exp, app) == [6, 15]
     assert batches == [2]  # both tasks launched in a single batched spawn
 

--- a/todo.md
+++ b/todo.md
@@ -17,11 +17,16 @@ The storage / artifacts / publishing backlog has moved out of here:
   (superseded relaunch, or surviving `cancel`) can no longer overwrite its
   successor's state or result, and the double-spawn race in `Ctx._classify` is
   closed by the conditional claim in `mark_running`. What remains: a stale
-  worker can still last-writer-win a mutable *name* — `set_ref`, `publish`, and
+  worker can still last-writer-win a mutable _name_ — `set_ref`, `publish`, and
   shared volume paths (`get_data_dir()` filenames). CAS blobs are immune.
   Possible fixes if it bites: per-task scratch dirs, generation-stamped refs.
   Auto-cancelling stale workers at tick time is still wrong — mid-run the
-  requested-set manifest is only a lower bound. The guard remains: `cancel`
-  (and confirm dead) before editing. Note the fence is airtight locally (flock)
-  but best-effort on Modal (`modal.Dict` has no compare-and-swap) — see the
+  requested-set manifest is only a lower bound. The guard remains: `cancel` (and
+  confirm dead) before editing. Note the fence is airtight locally (flock) but
+  best-effort on Modal (`modal.Dict` has no compare-and-swap) — see the
   backend-consolidation discussion if this needs to be exact.
+
+  z0u: `modal.Dict` does have a synchronization primitive:
+  `put(...,skip_if_exists=True)`. "Returns `True` if the key-value pair was
+  added and `False` if it wasn’t because the key already existed and
+  `skip_if_exists` was set." See https://modal.com/blog/cache-dict-launch

--- a/todo.md
+++ b/todo.md
@@ -11,16 +11,17 @@ The storage / artifacts / publishing backlog has moved out of here:
   #39 (wire the store through interactive `app.map`/`arun`), #15 (GC), #19 (queued vs.
   running visibility).
 
-- **Late writes from stale workers.** A worker launched under old code (fn edited
-  under a live run, against the hotfix rules) runs to completion and can
-  last-writer-win a mutable name *after* its replacement already wrote it:
-  `set_ref`, `publish`, and shared volume paths (`get_data_dir()` filenames). CAS
-  blobs (content-addressed) are immune. Under identity keys the hazard extends to
-  the *record and result themselves*: the stale worker shares its successor's key,
-  so if it survives `cancel` (ignored SIGTERM) it can overwrite `result.pkl` and
-  merge DONE over the new attempt's RUNNING. A generation stamp on attempts (also
-  wanted to close the double-spawn race between the `state` read and
-  `mark_running` in `Ctx._classify`) would fence both; per-task scratch dirs
-  cover the volume paths. Auto-cancelling stale workers at tick time is still
-  wrong — mid-run the requested-set manifest is only a lower bound. For now the
-  guard is the existing rule: `cancel` (and confirm dead) before editing.
+- **Late writes from stale workers — mutable names only.** The record/result
+  half of this is fixed: attempts carry a generation stamp, workers fence every
+  record write on it, and results land in gen-qualified files — a stale worker
+  (superseded relaunch, or surviving `cancel`) can no longer overwrite its
+  successor's state or result, and the double-spawn race in `Ctx._classify` is
+  closed by the conditional claim in `mark_running`. What remains: a stale
+  worker can still last-writer-win a mutable *name* — `set_ref`, `publish`, and
+  shared volume paths (`get_data_dir()` filenames). CAS blobs are immune.
+  Possible fixes if it bites: per-task scratch dirs, generation-stamped refs.
+  Auto-cancelling stale workers at tick time is still wrong — mid-run the
+  requested-set manifest is only a lower bound. The guard remains: `cancel`
+  (and confirm dead) before editing. Note the fence is airtight locally (flock)
+  but best-effort on Modal (`modal.Dict` has no compare-and-swap) — see the
+  backend-consolidation discussion if this needs to be exact.


### PR DESCRIPTION
## Summary

The ④ small-fixes batch from the memoization design review — four independent fixes to the memo control plane.

### (a) Generation stamp on attempts

Every claim of a record now stamps a random per-attempt `gen`, and the claim itself is conditional:

- **Double-spawn race closed.** `mark_running` is a write-if-gen-matches claim. Two tickers (a cron routine and a human both waking the run) that both read "un-run" can't both spawn — the loser's claim fails and it treats the task as in-flight.
- **Stale workers are fenced.** The worker carries its `gen` and fences every record write on it (`update_if`), so a superseded or cancel-surviving worker can't heartbeat, merge DONE over its successor's RUNNING, or resurrect cleared fields. A worker superseded before it starts exits without running.
- **Results are per-attempt files.** `result-{gen}.pkl` / `error-{gen}.txt`, resolved through the record's current gen — a zombie physically cannot overwrite its successor's result. Legacy un-genned records fall back to the old names.
- **`cancel` / `reap_dead` release the gen**, fencing survivors the moment the record is settled externally.

This closes the record/result half of the todo.md "late writes from stale workers" hazard; the note now covers only mutable names (`set_ref`/`publish`/volume paths).

### (b) `ctx.map` matches `Executor.map` / `Apparatus.map`

`ctx.map(fn, *iterables)` zips iterables into positional args — `ctx.map(train, lrs, vocabs)` runs `train(lr, vocab)` per pair. A single iterable passes each element as **one** argument: a tuple element stays a tuple, killing the silent-unpack footgun. Unlike `Executor.map`, mismatched lengths raise instead of truncating the sweep. One mental model across the interactive and memoized paths.

### (c) Local record mutations serialize under a store-wide flock

`merge` was read-modify-write; two concurrent mergers (worker heartbeat vs reaper, final DONE vs pid stamp) could drop each other's fields. All local mutations now hold one flock, which also makes the (a) fence genuinely atomic locally. On Modal the fence is best-effort read-check-write — `modal.Dict` has no compare-and-swap (see PR discussion).

### (d) Vestigial `Experiment.orchestration()` removed

`tick` calls `experiment.main(ctx)` directly.

## Verification

- Suite: 221 passed, 4 skipped (8 new tests: claim exclusivity, mid-run zombie fencing, startup fencing, cancel release, concurrent-merge integrity, tuple/zip semantics).
- Real CLI flow: fresh run (`--watch`) with both map forms → hotfix edit → in-place re-run with `explain` timeline and coexisting per-gen result files → `cancel` (gen released, worker killed) → stale-CANCELLED auto-relaunch on the fixed code → DONE with the cancelled attempt in history. Mismatched map iterables fail the run with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)