### PR TITLE
Add mini gc: reclaim memo storage no current read path can reach

### DIFF
--- a/.agents/skills/mi-ni/references/memoization.md
+++ b/.agents/skills/mi-ni/references/memoization.md
@@ -132,6 +132,14 @@ superseded records too (resetting one would plant a phantom that never runs);
 target one explicitly with `--key` if you really mean it. (Editing a fn's *body*
 no longer supersedes anything — the re-run lands on the same record.)
 
+Superseded records linger until reclaimed: `mini gc <name>` prints a sweep plan
+(superseded records with their result dirs, files from replaced attempts, stale
+staged calls) and `--apply` deletes it. It never touches a current record — a
+DONE result is a future memo hit, and deleting a FAILED one would silently turn
+a terminal failure into a relaunch — and it collects superseded records only
+once the last tick ran the DAG to completion with nothing left in flight.
+Local backend only for now (Modal Dict entries self-expire; see #15).
+
 ### Failure is terminal by design
 
 `FAILED` and `CANCELLED` are terminal *under the code that produced them*: a

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -16,6 +16,7 @@ agent (or you) can drive, poll, and gather without holding a session open:
     python -m mini logs   pipeline <key>                       # a failed task's traceback
     python -m mini explain pipeline <key>                      # why this re-ran: evidence + attempt timeline
     python -m mini cancel pipeline                             # stop in-flight tasks
+    python -m mini gc     pipeline                             # plan a storage sweep (--apply to delete)
 
 State is addressed by experiment NAME (one memo store per experiment). Read
 commands take ``--app modal`` to inspect a run on the Modal control plane.
@@ -367,6 +368,64 @@ def cmd_explain(args: argparse.Namespace) -> None:
         print(line)
 
 
+def _human_size(n: float) -> str:
+    for unit in ('B', 'KB', 'MB'):
+        if n < 1024:
+            return f'{n:.0f} {unit}' if unit == 'B' else f'{n:.1f} {unit}'
+        n /= 1024
+    return f'{n:.1f} GB'
+
+
+_GC_LABEL = {
+    'superseded': 'superseded record(s)',
+    'attempt-files': 'task(s) with stale attempt files',
+    'orphan-dir': 'orphaned result dir(s)',
+    'staged-call': 'staged call(s) for tasks no longer running',
+}
+
+
+def cmd_gc(args: argparse.Namespace) -> None:
+    """Reclaim memo storage no current read path can reach. Dry run unless ``--apply``.
+
+    Collects superseded records (with their result dirs), unreachable attempt
+    files from replaced generations, orphaned result dirs, and staged calls for
+    settled tasks. Never touches a current record — a DONE result is a future
+    memo hit, and deleting a FAILED record would silently turn a terminal
+    failure into a relaunch.
+    """
+    if getattr(args, 'app', 'local') != 'local':
+        raise SystemExit(
+            'gc only supports --app local for now (#15): Modal Dict entries self-expire '
+            'after 7 days of inactivity, but Volume result dirs need a Volume-side sweep'
+        )
+    from mini.gc import apply_gc, plan_gc
+
+    apparatus = _build_apparatus(args.name, args)
+    store = apparatus.memo_store()
+    recs = store.records()
+    if not recs and not (store.data_dir / '_memo').is_dir():
+        raise SystemExit(f'no tasks found for experiment {args.name!r}')
+    apparatus.reap_dead(store, recs)  # a vanished worker's RUNNING record must not read as alive
+    plan = plan_gc(store, recs)
+
+    print(f'{args.name} — gc plan:')
+    for kind, label in _GC_LABEL.items():
+        if not (items := plan.by_kind(kind)):
+            continue
+        keys = ', '.join(i.key for i in items[:6]) + (f', +{len(items) - 6} more' if len(items) > 6 else '')
+        print(f'  {label}: {len(items)}  ({_human_size(sum(i.size for i in items))})  — {keys}')
+    for reason in plan.kept:
+        print(f'  kept: {reason}')
+    if not plan.items:
+        print('  nothing to collect')
+        return
+    if args.apply:
+        apply_gc(store, plan)
+        print(f'reclaimed {_human_size(plan.size)}')
+    else:
+        print(f'dry run — pass --apply to reclaim {_human_size(plan.size)}')
+
+
 def cmd_cancel(args: argparse.Namespace) -> None:
     apparatus = _build_apparatus(args.name, args)
     cancelled = apparatus.cancel(apparatus.memo_store())
@@ -456,6 +515,14 @@ def main() -> None:
     p.add_argument('name')
     _add_app_flag(p)
     p.set_defaults(func=cmd_cancel)
+
+    p = sub.add_parser(
+        'gc', help='reclaim stale memo storage (superseded records, replaced attempts) — dry run by default'
+    )
+    p.add_argument('name')
+    p.add_argument('--apply', action='store_true', help='actually delete (default: print the plan only)')
+    _add_app_flag(p)
+    p.set_defaults(func=cmd_gc)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/mini/gc.py
+++ b/src/mini/gc.py
@@ -1,0 +1,172 @@
+"""Reclaim memo-store state that no current read path can reach (``mini gc``).
+
+Collectibility is judged against the store's own invariants, not age or size:
+
+- A **superseded record** (its key absent from the requested-keys manifest) is
+  collectible once the manifest is trustworthy: the last tick ran the DAG to
+  completion (``complete`` in the run meta) and nothing is still unsettled.
+  A *current* record is never collectible — a DONE one is a future memo hit,
+  and even a FAILED one is live state (deleting it would silently convert a
+  terminal failure into a relaunch on the next wake).
+- A **stale attempt file** (a ``result-<gen>.pkl``/``error-<gen>.txt`` under a
+  generation the record no longer owns) is unreachable: readers resolve through
+  the record's current ``gen``, and a fenced zombie writer can't make anything
+  read it again. The one exception is the legacy ``error.txt``, which
+  ``MemoStore.error`` still falls back to when the current attempt left no
+  traceback — that stays live until the current generation writes its own.
+- An **orphaned result dir** has no record at all. Records are claimed before
+  the worker creates its dir, so this is debris, not a race.
+- A **staged call** (``.control/memo/<key>.pkl``) is worker spawn input; it is
+  dead once its task is off RUNNING (a relaunch rewrites it).
+
+Local backend only for now. On Modal the control plane self-expires (Dict
+entries lapse after 7 days idle) but Volume result dirs persist; that sweep,
+and the artifact CAS (which has no reference index yet), are tracked in #15.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from mini.memo import MemoStore
+from mini.runs import SETTLED, RunState
+
+__all__ = ['GcItem', 'GcPlan', 'plan_gc', 'apply_gc']
+
+# The worker-written files an attempt owns; anything else in a result dir is
+# unknown, and unknown is not garbage.
+_ATTEMPT_FILE = re.compile(r'result(-\w+)?\.pkl|error(-\w+)?\.txt')
+
+
+@dataclass
+class GcItem:
+    kind: str  # 'superseded' | 'attempt-files' | 'orphan-dir' | 'staged-call'
+    key: str
+    paths: list[Path]
+    size: int
+
+
+@dataclass
+class GcPlan:
+    items: list[GcItem] = field(default_factory=list)
+    kept: list[str] = field(default_factory=list)  # reasons collectible-looking state was left alone
+
+    @property
+    def size(self) -> int:
+        return sum(i.size for i in self.items)
+
+    def by_kind(self, kind: str) -> list[GcItem]:
+        return [i for i in self.items if i.kind == kind]
+
+
+def _size(paths: list[Path]) -> int:
+    total = 0
+    for p in paths:
+        if p.is_dir():
+            total += sum(f.stat().st_size for f in p.rglob('*') if f.is_file())
+        elif p.is_file():
+            total += p.stat().st_size
+    return total
+
+
+def plan_gc(store: MemoStore, records: list[dict] | None = None) -> GcPlan:
+    """What ``apply_gc`` would delete, and why the rest stays.
+
+    Call ``reap_dead`` first so a vanished worker's RUNNING record doesn't read
+    as alive. Pass *records* to reuse a snapshot already in hand.
+    """
+    records = store.records() if records is None else records
+    plan = GcPlan()
+    collected = _plan_superseded(store, records, plan)
+    _plan_attempt_files(store, records, collected, plan)
+    _plan_orphan_dirs(store, records, plan)
+    _plan_staged_calls(store, records, collected, plan)
+    return plan
+
+
+def _plan_superseded(store: MemoStore, records: list[dict], plan: GcPlan) -> set[str]:
+    """Whole superseded records — JSON, result dir, and staged call — gate permitting."""
+    current, superseded = store.split_current(records)
+    if not superseded:
+        return set()
+    unsettled = [r for r in current if r.get('state') not in SETTLED]
+    if not store.meta().get('complete'):
+        plan.kept.append(
+            f'{len(superseded)} superseded record(s): the last tick did not run the DAG to '
+            'completion, so the manifest may be missing keys a later stage still wants'
+        )
+        return set()
+    if unsettled:
+        plan.kept.append(f'{len(superseded)} superseded record(s): {len(unsettled)} task(s) still unsettled')
+        return set()
+    collected: set[str] = set()
+    for rec in superseded:
+        key = rec['key']
+        if rec.get('state') == RunState.RUNNING:  # reap_dead left it: the worker is provably alive
+            plan.kept.append(f'{key}: superseded, but its worker is still alive — cancel it first')
+            continue
+        paths = [p for p in (store.result_dir(key), store._call(key)) if p.exists()]
+        plan.items.append(GcItem('superseded', key, paths, _size(paths)))
+        collected.add(key)
+    return collected
+
+
+def _plan_attempt_files(store: MemoStore, records: list[dict], collected: set[str], plan: GcPlan) -> None:
+    """Attempt files no read through the record's current gen can reach."""
+    for rec in records:
+        key = rec['key']
+        d = store.result_dir(key)
+        if key in collected or not d.is_dir():
+            continue
+        gen = rec.get('gen')
+        live = {store.result_path(key, gen).name, store.error_path(key, gen).name}
+        if gen and not store.error_path(key, gen).exists():
+            live.add(store.error_path(key, None).name)  # error() falls back to the legacy name
+        stale = [
+            p for p in sorted(d.iterdir()) if p.is_file() and _ATTEMPT_FILE.fullmatch(p.name) and p.name not in live
+        ]
+        if stale:
+            plan.items.append(GcItem('attempt-files', key, stale, _size(stale)))
+
+
+def _plan_orphan_dirs(store: MemoStore, records: list[dict], plan: GcPlan) -> None:
+    """Result dirs with no record at all (e.g. a control plane that expired out from under the volume)."""
+    known = {r['key'] for r in records}
+    memo_root = store.data_dir / '_memo'
+    if not memo_root.is_dir():
+        return
+    for d in sorted(memo_root.iterdir()):
+        if d.is_dir() and d.name not in known:
+            plan.items.append(GcItem('orphan-dir', d.name, [d], _size([d])))
+
+
+def _plan_staged_calls(store: MemoStore, records: list[dict], collected: set[str], plan: GcPlan) -> None:
+    """Cloudpickled spawn inputs for tasks that are no longer running."""
+    recs = {r['key']: r for r in records}
+    if not store.root.is_dir():
+        return
+    for p in sorted(store.root.glob('*.pkl')):
+        if p.stem in collected:
+            continue
+        if (recs.get(p.stem) or {}).get('state') != RunState.RUNNING:
+            plan.items.append(GcItem('staged-call', p.stem, [p], _size([p])))
+
+
+def apply_gc(store: MemoStore, plan: GcPlan) -> None:
+    """Delete everything in *plan*.
+
+    Record first, files second: a crash between the two leaves an orphaned dir,
+    which the next gc collects — never the reverse (a record whose result dir
+    is gone).
+    """
+    for item in plan.items:
+        if item.kind == 'superseded':
+            store.records_backend.delete(item.key)
+        for p in item.paths:
+            if p.is_dir():
+                shutil.rmtree(p, ignore_errors=True)
+            else:
+                p.unlink(missing_ok=True)

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -373,6 +373,10 @@ class RecordStore(ABC):
     @abstractmethod
     def keys(self) -> list[str]: ...
 
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Remove a record entirely (the GC verb) — a no-op if *key* is absent."""
+
     # Conditional writes, fenced on the record's attempt generation (``gen``).
     # These defaults are read-check-write — atomic only if the backend makes them
     # so (``LocalRecordStore`` overrides under a file lock; ``modal.Dict`` has no
@@ -444,6 +448,10 @@ class LocalRecordStore(RecordStore):
 
     def keys(self) -> list[str]:
         return sorted(p.stem for p in self.root.glob('*.json')) if self.root.exists() else []
+
+    def delete(self, key: str) -> None:
+        with self._locked():
+            (self.root / f'{key}.json').unlink(missing_ok=True)
 
 
 class MemoStore:

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -125,6 +125,12 @@ class ModalRecordStore(RecordStore):
     def keys(self) -> list[str]:
         return list(self._d.keys())
 
+    def delete(self, key: str) -> None:
+        try:
+            self._d.pop(key)
+        except KeyError:
+            pass
+
 
 class ModalMemoStore(MemoStore):
     """A ``MemoStore`` whose records live in a ``modal.Dict`` and whose results

--- a/src/mini/orchestration.py
+++ b/src/mini/orchestration.py
@@ -328,8 +328,10 @@ def tick(experiment: Experiment, apparatus: Apparatus, keep_stale: bool = False)
     """
     store = apparatus.memo_store()
     ctx = Ctx(store, apparatus, experiment.resolve_roles(apparatus), keep_stale=keep_stale)
+    complete = False
     try:
         result = experiment.main(ctx)
+        complete = True
     except Pending as p:
         return False, str(p)
     finally:
@@ -340,10 +342,14 @@ def tick(experiment: Experiment, apparatus: Apparatus, keep_stale: bool = False)
         # wake requests them again — honest, since an upstream edit may have changed
         # what they'll ask for. ``kept_stale`` rides along so read-only views can
         # badge results served under old code (they can't fingerprint code
-        # themselves — reads never import or tick).
+        # themselves — reads never import or tick). ``complete`` records whether
+        # this manifest covers the *whole* DAG (``main`` ran to the end) — the
+        # gate ``mini gc`` needs before trusting "not requested" to mean
+        # "never requested again".
         store.set_meta(
             requested=list(dict.fromkeys(ctx.requested)),
             kept_stale=list(dict.fromkeys(ctx.stale_kept)),
+            complete=complete,
         )
     return True, result
 

--- a/tests/mini/test_gc.py
+++ b/tests/mini/test_gc.py
@@ -1,0 +1,237 @@
+"""``mini gc``: reclaim memo storage no current read path can reach.
+
+The invariants under test, in order of how much damage violating them does:
+
+- **Current records are untouchable** — a DONE record is a future memo hit and
+  a FAILED one is terminal state; gc must not convert either into a relaunch.
+- **Superseded records are collectible only when the manifest is trustworthy**:
+  the last tick ran the DAG to completion (``complete``) and nothing is
+  unsettled. A suspended tick's manifest is complete only up to the suspension
+  point, so "not requested" doesn't yet mean "never requested again".
+- **Attempt files are judged by reachability**: readers resolve through the
+  record's current ``gen``, so files under a replaced generation are garbage,
+  while the legacy ``error.txt`` stays live as ``MemoStore.error``'s fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+from mini.experiment import Experiment
+from mini.gc import apply_gc, plan_gc
+from mini.local_apparatus import LocalApparatus
+from mini.orchestration import tick
+from mini.runs import RunState
+
+
+def _sweep(name: str, fn, xs: list) -> Experiment:
+    return Experiment(name=name, main=lambda ctx: ctx.map(fn, xs))
+
+
+def _drive(exp: Experiment, app: LocalApparatus, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        done, _ = tick(exp, app)
+        if done:
+            return
+        time.sleep(0.1)
+    raise AssertionError('orchestration did not complete')
+
+
+def _with_superseded(name: str, monkeypatch, tmp_path: Path) -> LocalApparatus:
+    """A completed run with one superseded record: sweep [1,2,3], then drop 3."""
+    monkeypatch.chdir(tmp_path)
+
+    def train(x):
+        return x * 2
+
+    app = LocalApparatus(name)
+    _drive(_sweep(name, train, [1, 2, 3]), app)
+    _drive(_sweep(name, train, [1, 2]), app)  # config 3 removed → its record superseded
+    return app
+
+
+def test_tick_stamps_manifest_completeness(tmp_path: Path, monkeypatch):
+    """A suspended tick's manifest is incomplete; a completing tick's covers the DAG."""
+    monkeypatch.chdir(tmp_path)
+
+    def slow(x):
+        time.sleep(0.3)
+        return x
+
+    exp = _sweep('stamp', slow, [1])
+    app = LocalApparatus('stamp')
+    done, _ = tick(exp, app)  # spawns, then suspends on the in-flight task
+    assert not done
+    assert app.memo_store().meta().get('complete') is False
+    _drive(exp, app)
+    assert app.memo_store().meta().get('complete') is True
+
+
+def test_superseded_record_collected_with_its_dir_and_call(tmp_path: Path, monkeypatch):
+    app = _with_superseded('gcx', monkeypatch, tmp_path)
+    store = app.memo_store()
+    recs = store.records()
+    current, superseded = store.split_current(recs)
+    [dead] = superseded
+    dead_dir = store.result_dir(dead['key'])
+    assert dead_dir.is_dir()
+
+    plan = plan_gc(store, recs)
+    assert {i.key for i in plan.by_kind('superseded')} == {dead['key']}
+    assert plan.size > 0
+    apply_gc(store, plan)
+
+    assert {r['key'] for r in store.records()} == {r['key'] for r in current}
+    assert not dead_dir.exists()
+    assert not store._call(dead['key']).exists()
+    assert sorted(store.result(r['key']) for r in current) == [2, 4]  # kept hits still resolve
+
+
+def test_superseded_kept_unless_manifest_trustworthy(tmp_path: Path, monkeypatch):
+    app = _with_superseded('gates', monkeypatch, tmp_path)
+    store = app.memo_store()
+    current, superseded = store.split_current(store.records())
+    [dead] = superseded
+
+    # An incomplete manifest (a suspended tick) closes the gate entirely.
+    store.set_meta(complete=False)
+    plan = plan_gc(store)
+    assert not plan.by_kind('superseded')
+    assert any('completion' in reason for reason in plan.kept)
+
+    # So does any unsettled current task.
+    store.set_meta(complete=True)
+    live = current[0]
+    orig = store.record(live['key'])
+    store.update(live['key'], state=RunState.RUNNING)
+    plan = plan_gc(store)
+    assert not plan.by_kind('superseded')
+    assert any('unsettled' in reason for reason in plan.kept)
+    store.update(live['key'], state=orig['state'])
+
+    # A superseded record whose worker is still alive is skipped individually.
+    store.update(dead['key'], state=RunState.RUNNING)
+    plan = plan_gc(store)
+    assert not plan.by_kind('superseded')
+    assert any('cancel' in reason for reason in plan.kept)
+
+
+def test_current_records_are_never_collected(tmp_path: Path, monkeypatch):
+    """Even a FAILED current record is live state, not garbage."""
+    monkeypatch.chdir(tmp_path)
+
+    def bad(x):
+        raise RuntimeError('bug')
+
+    app = LocalApparatus('keepfail')
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            tick(_sweep('keepfail', bad, [1]), app)
+        except ExceptionGroup:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError('map never surfaced the failure')
+
+    store = app.memo_store()
+    [rec] = store.records()
+    assert rec['state'] == RunState.FAILED
+    plan = plan_gc(store)
+    assert not plan.by_kind('superseded') and not plan.by_kind('attempt-files')
+    apply_gc(store, plan)  # collects at most the staged call
+    [rec] = store.records()
+    assert rec['state'] == RunState.FAILED  # still terminal, still visible
+    assert 'bug' in store.error(rec['key'])  # traceback intact
+
+
+def test_stale_attempt_files_swept_current_and_unknown_kept(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def train(x):
+        return x * 2
+
+    app = LocalApparatus('attempts')
+    _drive(_sweep('attempts', train, [1]), app)
+    store = app.memo_store()
+    [rec] = store.records()
+    key, d = rec['key'], store.result_dir(rec['key'])
+    assert rec['gen']
+
+    (d / 'result-deadbeef.pkl').write_bytes(b'old attempt')  # replaced generation
+    (d / 'error-deadbeef.txt').write_text('old traceback')
+    (d / 'result.pkl').write_bytes(b'legacy result')  # unreachable: result() has no legacy fallback
+    (d / 'error.txt').write_text('legacy traceback')  # live: error() falls back to it
+    (d / 'notes.txt').write_text('unknown is not garbage')
+
+    plan = plan_gc(store)
+    [item] = plan.by_kind('attempt-files')
+    assert {p.name for p in item.paths} == {'result-deadbeef.pkl', 'error-deadbeef.txt', 'result.pkl'}
+    apply_gc(store, plan)
+
+    assert store.result(key) == 2  # current attempt intact
+    assert (d / 'error.txt').exists() and (d / 'notes.txt').exists()
+
+
+def test_orphan_dirs_and_settled_calls_collected(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def train(x):
+        return x
+
+    app = LocalApparatus('orphans')
+    _drive(_sweep('orphans', train, [1]), app)
+    store = app.memo_store()
+    [rec] = store.records()
+
+    ghost = store.data_dir / '_memo' / 'ghost-000000000000'
+    ghost.mkdir(parents=True)
+    (ghost / 'result-cafecafe.pkl').write_bytes(b'x' * 64)
+
+    plan = plan_gc(store)
+    assert [i.key for i in plan.by_kind('orphan-dir')] == ['ghost-000000000000']
+    assert [i.key for i in plan.by_kind('staged-call')] == [rec['key']]  # spawn input, task settled
+
+    # A RUNNING task's staged call stays: its worker may still need respawn input.
+    store.update(rec['key'], state=RunState.RUNNING)
+    assert not plan_gc(store).by_kind('staged-call')
+    store.update(rec['key'], state=RunState.DONE)
+
+    apply_gc(store, plan)
+    assert not ghost.exists()
+    assert not store._call(rec['key']).exists()
+    assert store.result(rec['key']) == 1
+
+
+def test_cmd_gc_dry_run_then_apply(tmp_path: Path, monkeypatch, capsys):
+    app = _with_superseded('gccli', monkeypatch, tmp_path)
+    store = app.memo_store()
+
+    from mini.__main__ import cmd_gc, cmd_status
+
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False))
+    out = capsys.readouterr().out
+    assert 'dry run' in out and 'superseded' in out
+    assert len(store.records()) == 3  # nothing deleted
+
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=True))
+    assert 'reclaimed' in capsys.readouterr().out
+    assert len(store.records()) == 2
+
+    cmd_status(argparse.Namespace(name='gccli', app='local'))  # the cleaned store still reads done
+    assert '—  done  (2 tasks)' in capsys.readouterr().out
+
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False))  # idempotent: nothing left
+    assert 'nothing to collect' in capsys.readouterr().out
+
+
+def test_modal_record_store_delete(tmp_path: Path):
+    from mini.modal_apparatus import ModalRecordStore
+
+    store = ModalRecordStore({'k': {'key': 'k', 'state': 'done'}})
+    store.delete('k')
+    store.delete('missing')  # absent key is a no-op, not an error
+    assert store.keys() == []

--- a/todo.md
+++ b/todo.md
@@ -51,11 +51,11 @@ are explicitly conditional (do them when the pain is real, not preemptively):
 **Sequence after the above:**
 
 - #15 — GC across the control plane, I/O-plane volume dirs, and the CAS. The
-  CAS-refcounting shape depends on how #37 (shared store?) and #38 (bucket
-  split?) land, though the local per-experiment control-plane + I/O-plane sweep
-  could start independently now. Modal Dicts auto-expire after 7 days of
-  inactivity, which may take pressure off the control-plane leg specifically —
-  confirm Volume behavior isn't the same before assuming it needs GC too.
+  local per-experiment control-plane + I/O-plane sweep shipped as `mini gc`
+  (PR #49); Volumes confirmed to persist indefinitely (no Dict-style expiry;
+  per-path `rm` exists), so the remaining legs are the Modal Volume sweep and
+  CAS refcounting — the latter's shape still depends on how #37 (shared
+  store?) and #38 (bucket split?) land.
 
 **Orthogonal, no code overlap with the above:**
 


### PR DESCRIPTION
First cut of #15, scoped to what the issue's grounding comment said could start now: the **local per-experiment control-plane + I/O-plane sweep**. The CAS leg (no reference index yet; shape depends on #37/#38) and the Modal Volume leg stay on the issue.

## What `mini gc <name>` collects

Collectibility is judged by the store's own invariants, not by age or size:

- **Superseded records** — key absent from the requested-keys manifest — go whole: record JSON, result dir, staged call. Deleting a *current* record is never safe (a DONE one is a future memo hit; deleting a FAILED one would silently convert a terminal failure into a relaunch), so gc refuses to touch them.
- **Files from replaced attempt generations** (`result-<gen>.pkl` under a gen the record no longer owns). Unreachable by construction: readers resolve through the record's current `gen`, and #44's fencing means a zombie writer can't make anything read them again. The legacy `error.txt` stays while it's still `error()`'s fallback.
- **Orphaned result dirs** (no record at all — the common case on Modal, where Dict entries self-expire out from under the Volume; local debris otherwise).
- **Staged calls** for tasks no longer RUNNING (a relaunch rewrites them).

Dry run by default; `--apply` deletes. `reap_dead` runs first so a vanished worker's RUNNING record doesn't read as alive.

## The manifest-trust gate

"Not requested" only means "never requested again" if the manifest covers the whole DAG — a suspended tick records keys only up to the suspension point, so a later stage's records read as superseded until a wake requests them again. Nothing persisted that distinction, so **`tick` now stamps `complete` into the run meta**. gc collects superseded records only when the last tick completed the DAG *and* nothing is unsettled; otherwise it prints why it kept them. A superseded record whose worker is provably alive is skipped individually (`cancel` it first).

`RecordStore` grows a `delete` verb (local: unlink under the store lock; Modal: `Dict.pop`), so the Modal control-plane sweep has its primitive when that leg lands.

## Testing

- 8 new tests in `tests/mini/test_gc.py` covering the gates (incomplete manifest, unsettled tasks, live superseded worker), attempt-file reachability (current gen and `error.txt` fallback kept, unknown files untouched), orphan dirs, staged calls, the never-touch-current invariant for FAILED, dry-run/apply/idempotence through `cmd_gc`, and the `complete` stamp.
- Full suite passes (237 tests).
- Verified end-to-end from the real CLI: drove a demo experiment through run → config removal → `gc` (dry run) → mid-flight `gc` while a stale sweep was suspended (gate held, printed its reason) → completion → `--apply` → `status`/`results` still read done and the next `run` was a pure memo hit → second `gc` reports nothing to collect. `--app modal` exits with a clear not-yet message; an unknown name errors cleanly.

Closes nothing yet — #15 stays open for the CAS and Modal legs; I'll note the scoping there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)