### PR TITLE
Surface queued-but-unstarted tasks distinctly from running (#19)

### DIFF
--- a/.agents/skills/mi-ni/references/running.md
+++ b/.agents/skills/mi-ni/references/running.md
@@ -45,6 +45,15 @@ tail (on Modal each record read is a `Dict` round-trip). Each task also records
 `status` shows `on <GPU>` for remote tasks, and the full snapshot is on the
 record under `env`.
 
+**Queued ≠ running.** A record reads RUNNING from launch, but the worker writes
+`env` as its first action — so until `env` appears, the task is *launched but
+not started*. `status` shows it as `◌ queued` with its time in queue (`⧖`)
+instead of a heartbeat, and `watch` tags its bar `— queued`. Locally this is a
+momentary blip; on Modal a capacity-starved task can sit queued indefinitely,
+and only the wall-clock budget (below) will reap it. A task stuck on `queued`
+with an old `⧖` is a scheduling problem (capacity, container boot), not slow
+code.
+
 ## Recovery
 
 `FAILED` and `CANCELLED` are **terminal by design** — a plain `run` will **not**

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -32,7 +32,7 @@ from mini.experiment import load_experiment
 from mini.local_apparatus import LocalApparatus
 from mini.memo import MemoStore
 from mini.orchestration import BudgetExpired, TaskFailed, retry, tick
-from mini.runs import SETTLED, RunState, data_root
+from mini.runs import SETTLED, RunState, data_root, is_queued
 from utils.time import duration
 
 _GLYPH = {
@@ -145,15 +145,22 @@ def _print_records(store: MemoStore, records: list[dict] | None = None) -> tuple
 
 
 def _memo_line(rec: dict) -> str:
-    """One status line for a memoized task record (shared by `run`/`status`)."""
+    """One status line for a memoized task record (shared by `run`/`status`).
+
+    A RUNNING record with no ``env`` yet reads ``queued`` — launched, but no
+    worker has started (see :func:`mini.runs.is_queued`). Its ``heartbeat_at``
+    is still the launch stamp, so it's shown as time-in-queue, not liveness.
+    """
     state = _rec_state(rec)
-    line = f'  {_GLYPH.get(state, "?")} {rec.get("fn", "task"):14} {rec["key"]:26} {state:9}'
+    queued = is_queued(rec)
+    glyph, label = ('◌', 'queued') if queued else (_GLYPH.get(state, '?'), str(state))
+    line = f'  {glyph} {rec.get("fn", "task"):14} {rec["key"]:26} {label:9}'
     if rec.get('total'):
         line += f'  {rec.get("step", 0)}/{rec["total"]}'
     if rec.get('metrics'):
         line += f'  {_fmt_metrics(rec["metrics"])}'
     if state == RunState.RUNNING and rec.get('heartbeat_at'):
-        line += f'  ♥ {_age(rec["heartbeat_at"])}'
+        line += f'  ⧖ queued {_age(rec["heartbeat_at"])}' if queued else f'  ♥ {_age(rec["heartbeat_at"])}'
     if gpu := rec.get('env', {}).get('gpu'):
         line += f'  on {gpu}'  # what it actually ran on, when not the local CPU
     if rec.get('fc_id'):

--- a/src/mini/monitor.py
+++ b/src/mini/monitor.py
@@ -31,7 +31,7 @@ from mini.apparatus import Apparatus
 from mini.experiment import Experiment
 from mini.memo import PollCache
 from mini.orchestration import BudgetExpired, tick
-from mini.runs import SETTLED, RunState
+from mini.runs import SETTLED, RunState, is_queued
 
 __all__ = ['drive_and_watch', 'watch']
 
@@ -41,6 +41,7 @@ _COLOR = {
     RunState.FAILED: 'red',
     RunState.CANCELLED: 'yellow',
 }
+_QUEUED_COLOR = 'blue'  # launched but no worker yet (RUNNING record, no env)
 
 
 def _fmt_metrics(metrics: dict[str, float]) -> str:
@@ -58,14 +59,18 @@ def _refresh(progress: Progress, bars: dict[str, TaskID], records: list[dict[str
             step = total
         elif state in (RunState.FAILED, RunState.CANCELLED):
             total = total or 1
+        queued = is_queued(rec)  # RUNNING claimed, but no worker has started yet
         desc = key
+        if queued:
+            desc += ' — queued'
         if rec.get('message'):
             desc += f' — {rec["message"]}'
         if rec.get('metrics'):
             desc += f'  {_fmt_metrics(rec["metrics"])}'
         if rec.get('error'):
             desc += f'  !! {rec["error"]}'
-        desc = f'[{_COLOR.get(state, "white")}]{escape(desc)}[/]'  # escape: errors/messages may hold [...]
+        color = _QUEUED_COLOR if queued else _COLOR.get(state, 'white')
+        desc = f'[{color}]{escape(desc)}[/]'  # escape: errors/messages may hold [...]
         if key not in bars:
             bars[key] = progress.add_task(desc, total=total or None)
         progress.update(bars[key], completed=step, total=total or None, description=desc)

--- a/src/mini/runs.py
+++ b/src/mini/runs.py
@@ -18,7 +18,7 @@ import sys
 from enum import StrEnum
 from pathlib import Path
 
-__all__ = ['RunState', 'SETTLED', 'compute_env', 'data_root', 'spawn_taskworker']
+__all__ = ['RunState', 'SETTLED', 'compute_env', 'data_root', 'is_queued', 'spawn_taskworker']
 
 # Markers that identify a project root, in priority order.
 _ROOT_MARKERS = ('pyproject.toml', '.git')
@@ -83,6 +83,19 @@ class RunState(StrEnum):
 
 
 SETTLED = {RunState.DONE, RunState.FAILED, RunState.CANCELLED}
+
+
+def is_queued(rec: dict) -> bool:
+    """Launched but no worker has started yet — queued, not actually running.
+
+    The client claims RUNNING *before* the apparatus spawns the worker, and
+    ``env`` is the worker's first write once it truly starts. So RUNNING with no
+    ``env`` means the task is still waiting to be scheduled: a momentary blip
+    locally, but on Modal a capacity-starved task can sit here indefinitely
+    (only the wall-clock budget reaps it). Display-only — settling stays with
+    ``reap_dead``/``enforce_budget``.
+    """
+    return rec.get('state') == RunState.RUNNING and not rec.get('env')
 
 
 def _atomic_write(path: Path, text: str) -> None:

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -157,6 +157,31 @@ def test_explain_walks_the_attempt_timeline_after_a_hotfix(tmp_path: Path, monke
     assert 'changed' in out  # …and the dependency that moved to heal it
 
 
+def test_status_shows_queued_distinct_from_running(tmp_path: Path, monkeypatch, capsys):
+    """A RUNNING record with no ``env`` is launched-but-unstarted (the worker
+    writes ``env`` as its first action): ``status`` must read it as *queued*,
+    not silently lump it in with tasks actually running on a worker."""
+    monkeypatch.chdir(tmp_path)
+    from mini.memo import MemoStore
+    from mini.runs import data_root
+
+    store = MemoStore(data_root() / 'queuedexp')
+    now = time.time()
+    pid = os.getpid()  # a live pid, so reap_dead doesn't settle the records
+    common = {'state': 'running', 'fn': 'train', 'pid': pid, 'heartbeat_at': now}
+    store.records_backend.merge('train-queued', {'key': 'train-queued', **common})
+    store.records_backend.merge('train-live', {'key': 'train-live', 'env': {'host': 'worker.test'}, **common})
+
+    from mini.__main__ import cmd_status
+
+    cmd_status(argparse.Namespace(name='queuedexp', app='local'))
+    out = capsys.readouterr().out
+    lines = {line.split()[2]: line for line in out.splitlines() if 'train-' in line}
+    assert '◌' in lines['train-queued'] and 'queued' in lines['train-queued']
+    assert '♥' not in lines['train-queued']  # its heartbeat is just the launch stamp, not liveness
+    assert '▸' in lines['train-live'] and 'running' in lines['train-live'] and '♥' in lines['train-live']
+
+
 def test_cancel_stops_running_task(tmp_path: Path):
     def slow(x):
         import time


### PR DESCRIPTION
A record reads RUNNING from launch, but the worker writes env as its
first action — so RUNNING with no env means the task is still waiting
to be scheduled (momentary locally; indefinite on Modal when capacity-
starved). Surface that in both read paths:

- status: ◌ queued glyph/label, with time-in-queue (⧖) instead of a
  heartbeat — a queued record's heartbeat_at is just the launch stamp
- watch: blue bar with a '— queued' tag

Display-only: settling stays with reap_dead/enforce_budget (#14's
budget remains the backstop for a task queued forever).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HZCKcx6VSqCyM4aiGjJtda