### PR TITLE
Fence mutable-name writes against stale workers

### DIFF
--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -69,6 +69,20 @@ local = get(art, get_data_dir() / 'acts-in')
 
 See `docs/acts` (producer) and `docs/probe` (consumer) for a runnable pair.
 
+Inside a step, ref writes are **fenced on the attempt generation**: if the task
+was relaunched or cancelled while the worker ran, `set_ref`/`publish` raise
+`StaleWriteError` instead of silently overwriting the successor's name (blobs
+are immune — content-addressed writes are idempotent). Two consequences worth
+knowing:
+
+- A `StaleWriteError` in a task's traceback means the attempt was superseded —
+  nothing is wrong with the code; the current attempt owns the name.
+- A step's `set_ref` is a side effect, so it does **not** replay on a memo hit.
+  For final hand-offs, prefer returning the `Artifact` from the step and calling
+  `set_ref`/`publish` in the driver (`main`), which runs every time. In-step
+  refs are for incremental publication (e.g. best-checkpoint-so-far) — that's
+  what the fence makes safe.
+
 ## Choosing the backend (local vs. Hugging Face bucket)
 
 The backend is configuration, not code — nothing in an experiment or report

--- a/docs/gpt-sweep/experiment.py
+++ b/docs/gpt-sweep/experiment.py
@@ -136,7 +136,8 @@ def publish_curves(results: list[tuple]) -> str:
     resolve against it (the HF bucket when configured — the token rides in on the
     worker's Secret). The report then reads the curves by name, so the data lives in
     the durable store rather than a ``results.json`` in Git. Idempotent: ``put`` is
-    content-addressed and ``set_ref`` is last-writer-wins.
+    content-addressed, and ``set_ref`` is fenced on the attempt generation — only
+    the current attempt can move the name; a stale relaunch fails loudly instead.
     """
     import json
 

--- a/src/mini/__init__.py
+++ b/src/mini/__init__.py
@@ -5,7 +5,7 @@ from mini.modal_apparatus import ModalApparatus
 from mini.experiment import Experiment, load_experiment
 from mini.orchestration import MISSING, Ctx, MemoError, Pending, TaskFailed, tick
 from mini.runs import RunState
-from mini.store import Artifact, LocalStore, Store, store_context
+from mini.store import Artifact, LocalStore, StaleWriteError, Store, store_context
 from mini.volume import get_data_dir
 
 __all__ = [
@@ -17,6 +17,7 @@ __all__ = [
     'emit_metrics',
     'get_data_dir',
     'Artifact',
+    'StaleWriteError',
     'Store',
     'LocalStore',
     'store_context',

--- a/src/mini/_taskworker.py
+++ b/src/mini/_taskworker.py
@@ -23,7 +23,7 @@ from mini._queues import EndOfQueue
 from mini.memo import MemoStore
 from mini.progress import progress_context
 from mini.runs import RunState, compute_env
-from mini.store import Store, store_context, store_for, store_root_for
+from mini.store import Artifact, StaleWriteError, Store, store_context, store_for, store_root_for
 from mini.volume import data_dir_context
 
 
@@ -65,6 +65,73 @@ class _MemoSink:
         return True
 
 
+class _FencedStore(Store):
+    """The ambient store for one attempt, with mutable-name writes gen-fenced.
+
+    Record writes and results are already fenced on the attempt generation, but
+    ``set_ref`` / ``publish`` mutate *names* in the artifact store — unfenced,
+    a stale worker's name write would silently last-writer-win its successor's
+    (CAS blobs are immune, so everything else passes straight through). The name
+    lives in a different backend than the record (files/HF vs the record store),
+    so the fence is check → write → re-check rather than atomic: a supersession
+    landing *during* the write can't be prevented, but the re-check turns it from
+    silent corruption into a loud :class:`~mini.store.StaleWriteError` — and the
+    successor's own completing write then heals the name.
+    """
+
+    def __init__(self, inner: Store, memo: MemoStore, key: str, gen: str):
+        self._inner, self._memo, self._key, self._gen = inner, memo, key, gen
+
+    def _fence(self, verb: str, after: bool = False) -> None:
+        if self._memo.record(self._key).get('gen') != self._gen:
+            raise StaleWriteError(
+                f'{verb}: attempt {self._gen} of task {self._key} was superseded (relaunched or cancelled)'
+                + (" during the write — the name may briefly hold this attempt's value" if after else '')
+            )
+
+    # Fenced mutable-name verbs — everything else passes through untouched.
+
+    def set_ref(self, name: str, art: Artifact) -> None:
+        self._fence(f'set_ref({name!r})')
+        self._inner.set_ref(name, art)
+        self._fence(f'set_ref({name!r})', after=True)
+
+    def publish(self, art: Artifact, path: str) -> str:
+        self._fence(f'publish({path!r})')
+        url = self._inner.publish(art, path)
+        self._fence(f'publish({path!r})', after=True)
+        return url
+
+    def _write_ref(self, name: str, payload: str) -> None:
+        self._fence(f'set_ref({name!r})')
+        self._inner._write_ref(name, payload)
+        self._fence(f'set_ref({name!r})', after=True)
+
+    # Pass-throughs: forward the public verbs (not the shared high-level logic)
+    # so a backend's own overrides — HF batching, cache warming — stay in play.
+
+    def put(self, data: bytes | Path, *, name: str) -> Artifact:
+        return self._inner.put(data, name=name)
+
+    def get(self, art: Artifact, dest: Path) -> Path:
+        return self._inner.get(art, dest)
+
+    def get_ref(self, name: str) -> Artifact | None:
+        return self._inner.get_ref(name)
+
+    def has(self, sha256: str) -> bool:
+        return self._inner.has(sha256)
+
+    def _write_blob(self, sha256: str, src: Path) -> None:
+        self._inner._write_blob(sha256, src)
+
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        self._inner._read_blob(sha256, dest)
+
+    def _read_ref(self, name: str) -> str | None:
+        return self._inner._read_ref(name)
+
+
 def execute_task(
     store: MemoStore,
     key: str,
@@ -95,7 +162,9 @@ def execute_task(
     for ``mini.store.put`` / ``get`` inside the step. Because ``put`` uploads
     synchronously, by the time the result is written its handles already resolve —
     so the existing write → commit → DONE order extends from "the volume flushed"
-    to "the referenced blobs are durable" for free.
+    to "the referenced blobs are durable" for free. Its mutable-name verbs
+    (``set_ref`` / ``publish``) are fenced on *gen* via :class:`_FencedStore`, so
+    a stale worker fails loudly instead of clobbering a name its successor owns.
     """
 
     def record(**fields: Any) -> bool:
@@ -107,6 +176,8 @@ def execute_task(
     result_dir = store.result_dir(key)
     result_dir.mkdir(parents=True, exist_ok=True)
     sink = _MemoSink(store, key, gen)
+    if artifacts is not None and gen is not None:
+        artifacts = _FencedStore(artifacts, store, key, gen)
     # Record what we actually ran on (host/GPU/…), captured here in the worker.
     if not record(state=RunState.RUNNING, heartbeat_at=time.time(), env=compute_env()):
         return  # superseded before we even started — nothing here is wanted anymore

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -380,8 +380,10 @@ class RecordStore(ABC):
     # Conditional writes, fenced on the record's attempt generation (``gen``).
     # These defaults are read-check-write — atomic only if the backend makes them
     # so (``LocalRecordStore`` overrides under a file lock; ``modal.Dict`` has no
-    # compare-and-swap, so on Modal the fence is best-effort with a tiny window —
-    # still a vast improvement over unconditional last-writer-wins).
+    # compare-and-swap, so on Modal only the fresh-key claim is exact — via
+    # insert-if-absent, see ``ModalRecordStore.write_if`` — and the rest is
+    # best-effort with a tiny window — still a vast improvement over
+    # unconditional last-writer-wins).
 
     def write_if(self, key: str, record: dict[str, Any], gen: str | None) -> bool:
         """Replace the record iff its current ``gen`` equals *gen* (``None`` = unclaimed)."""

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -150,6 +150,27 @@ class ModalRecordStore(RecordStore):
         except KeyError:
             pass
 
+    def write_if(self, key: str, record: dict[str, Any], gen: str | None) -> bool:
+        """Gen-fenced write; the *first claim of a fresh key* is exact on Modal.
+
+        ``modal.Dict`` has no compare-and-swap, but it does have insert-if-absent
+        (``put(..., skip_if_exists=True)``) — which is exactly the shape of the
+        double-spawn race two tickers run when they both classify a never-run key
+        as launchable (``gen=None``, no record). Claiming through it makes that
+        race lose atomically. The other transitions — re-claiming a reset record
+        (present but unclaimed) or superseding gen *x* — have no matching
+        primitive, so they stay read-check-write with a tiny window.
+        """
+        if gen is None and (put := getattr(self._d, 'put', None)) is not None:
+            if put(key, record, skip_if_exists=True):
+                return True
+            cur = self.read(key)
+            if cur is None or cur.get('gen') is not None:
+                return False  # claimed (or deleted and re-claimed) in between — lose
+            # Present but unclaimed (a reset record awaiting re-run): the insert
+            # can't take it, so fall through to the read-check-write path below.
+        return super().write_if(key, record, gen)
+
 
 class ModalMemoStore(MemoStore):
     """A ``MemoStore`` whose records live in a ``modal.Dict`` and whose results

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -58,6 +58,7 @@ from typing import Iterator, Literal
 
 __all__ = [
     'Artifact',
+    'StaleWriteError',
     'Store',
     'LocalStore',
     'get_store',
@@ -81,6 +82,17 @@ STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
 
 log = logging.getLogger(__name__)
+
+
+class StaleWriteError(RuntimeError):
+    """A superseded attempt tried a mutable-name write (``set_ref`` / ``publish``).
+
+    Raised inside a step whose attempt generation is no longer current — the task
+    was relaunched or cancelled while this worker ran. CAS blobs are immune
+    (write-once-by-hash), but a name write from a stale worker would silently
+    last-writer-win its successor's, so the worker is stopped loudly instead. See
+    the fence in :func:`mini._taskworker.execute_task`.
+    """
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mini/test_apparatus.py
+++ b/tests/mini/test_apparatus.py
@@ -390,3 +390,36 @@ def test_modal_record_store_contract():
     store.write('k', {'key': 'k', 'state': 'running'})  # write resets wholesale
     assert store.read('k') == {'key': 'k', 'state': 'running'}
     assert store.keys() == ['k']
+
+
+class _FakeModalDict(dict):
+    """A dict with ``modal.Dict``'s insert-if-absent verb (`put(skip_if_exists=)`)."""
+
+    def put(self, key, value, *, skip_if_exists: bool = False) -> bool:
+        if skip_if_exists and key in self:
+            return False
+        self[key] = value
+        return True
+
+
+def test_modal_write_if_claims_fresh_key_via_insert_if_absent():
+    """The double-spawn race on a never-run key resolves atomically: the claim
+    goes through ``put(skip_if_exists=True)``, so the second ticker loses even
+    with no compare-and-swap."""
+    from mini.modal_apparatus import ModalRecordStore
+
+    store = ModalRecordStore(_FakeModalDict())
+    assert store.write_if('k', {'key': 'k', 'gen': 'a'}, None) is True
+    assert store.write_if('k', {'key': 'k', 'gen': 'b'}, None) is False  # already claimed
+    assert store.read('k') == {'key': 'k', 'gen': 'a'}
+
+
+def test_modal_write_if_reclaims_reset_record():
+    """A reset record (present but unclaimed) defeats insert-if-absent, so the
+    claim falls through to read-check-write — and still lands."""
+    from mini.modal_apparatus import ModalRecordStore
+
+    store = ModalRecordStore(_FakeModalDict({'k': {'key': 'k', 'state': None}}))
+    assert store.write_if('k', {'key': 'k', 'gen': 'a'}, None) is True
+    assert store.write_if('k', {'key': 'k', 'gen': 'c'}, 'b') is False  # fenced: wrong gen
+    assert store.write_if('k', {'key': 'k', 'gen': 'c'}, 'a') is True  # supersede gen a

--- a/tests/mini/test_memo_races.py
+++ b/tests/mini/test_memo_races.py
@@ -4,7 +4,7 @@ Two writers can share a record: a second ticker racing the first to launch, a
 reaper racing a worker's final write, or a stale worker (superseded relaunch, or
 cancelled but surviving SIGTERM) racing its successor. The generation stamp on
 attempts plus the locked local record store keep every such race from corrupting
-the record or the result.
+the record, the result, or a mutable name in the artifact store.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from mini._taskworker import execute_task
 from mini.local_apparatus import LocalApparatus
 from mini.memo import LocalRecordStore, MemoStore, task_key_parts
 from mini.runs import RunState
+from mini.store import LocalStore
 
 
 def _claim(store: MemoStore, fn, args=(1,)) -> tuple[str, str]:
@@ -102,6 +103,75 @@ def test_cancel_releases_the_generation(tmp_path: Path):
 
     assert store.update_if(key, gen, state=RunState.DONE) is False  # the survivor is fenced
     assert store.record(key)['state'] == RunState.CANCELLED
+
+
+def test_stale_worker_cannot_move_a_ref(tmp_path: Path):
+    """A worker superseded mid-run that tries ``set_ref`` fails loudly with
+    ``StaleWriteError`` — the name never moves, and the successor's write is the
+    one that resolves (issue #46: refs were the last unfenced write path)."""
+    from mini.store import put, set_ref
+
+    store = MemoStore(tmp_path / 'refs')
+    artifacts = LocalStore(tmp_path / 'store')
+    taken: dict[str, str] = {}
+
+    def sneaky(x):
+        _, taken['gen'] = _claim(store, sneaky)  # superseded mid-run
+        set_ref('best', put(b'stale', name='model.bin'))
+
+    key, old = _claim(store, sneaky)
+    execute_task(store, key, sneaky, (1,), [], artifacts=artifacts, gen=old)
+    assert artifacts.get_ref('best') is None  # the name never moved
+    assert store.record(key)['state'] == RunState.RUNNING  # FAILED fenced out too
+    assert 'StaleWriteError' in store.error_path(key, old).read_text()
+
+    def fresh(x):
+        set_ref('best', put(b'fresh', name='model.bin'))
+        return 'ok'
+
+    execute_task(store, key, fresh, (1,), [], artifacts=artifacts, gen=taken['gen'])
+    art = artifacts.get_ref('best')
+    assert art is not None
+    assert artifacts.get(art, tmp_path / 'out.bin').read_bytes() == b'fresh'
+
+
+def test_stale_worker_cannot_publish(tmp_path: Path):
+    """``publish`` is fenced like ``set_ref``: a superseded attempt cannot
+    last-writer-win a published path."""
+    from mini.store import publish, put
+
+    store = MemoStore(tmp_path / 'pub')
+    artifacts = LocalStore(tmp_path / 'store')
+
+    def sneaky(x):
+        _claim(store, sneaky)  # superseded mid-run
+        publish(put(b'stale', name='fig.png'), 'reports/fig.png')
+
+    key, old = _claim(store, sneaky)
+    execute_task(store, key, sneaky, (1,), [], artifacts=artifacts, gen=old)
+    assert not (tmp_path / 'store' / 'published' / 'reports' / 'fig.png').exists()
+    assert 'StaleWriteError' in store.error_path(key, old).read_text()
+
+
+def test_current_worker_name_writes_land(tmp_path: Path):
+    """The fence has no false positives: the attempt that owns the record can
+    ``set_ref`` and ``publish`` normally."""
+    from mini.store import publish, put, set_ref
+
+    store = MemoStore(tmp_path / 'ok')
+    artifacts = LocalStore(tmp_path / 'store')
+
+    def task(x):
+        art = put(b'good', name='model.bin')
+        set_ref('best', art)
+        return publish(art, 'reports/model.bin')
+
+    key, gen = _claim(store, task)
+    execute_task(store, key, task, (1,), [], artifacts=artifacts, gen=gen)
+    assert store.record(key)['state'] == RunState.DONE
+    assert artifacts.get_ref('best') is not None
+    assert store.result(key).startswith('file://')  # publish's URL came back as the result
+    assert (tmp_path / 'store' / 'published' / 'reports' / 'model.bin').read_bytes() == b'good'
 
 
 def test_concurrent_merges_do_not_drop_fields(tmp_path: Path):

--- a/todo.md
+++ b/todo.md
@@ -27,8 +27,10 @@ These stem from the same list in `research/design.md`:
   citable versioned publish via a dataset repo). Independent of #37; only
   matters once the template is used for work that shouldn't be world-readable
   by default.
-- #46 — fence mutable-name writes (`set_ref`/`publish`/`get_data_dir()`)
-  against stale workers.
+- #46 — fence mutable-name writes against stale workers. The `set_ref`/`publish`
+  half is done (gen-fenced ambient store in the worker; `StaleWriteError`); the
+  `get_data_dir()` half stays open only insofar as #37's shared volume would
+  make it cross-experiment.
 
 **Sequence after the above:**
 


### PR DESCRIPTION
Prevent a superseded worker from silently overwriting artifact names that its successor owns.

When a task is relaunched or cancelled while a worker runs, that worker becomes stale. Previously, if it called `set_ref` or `publish`, it would last-writer-win the name in the artifact store — silently corrupting the successor's reference. Content-addressed blob writes are immune (idempotent by hash), but names live in a different backend and had no protection.

This change introduces `_FencedStore`, a wrapper around the ambient artifact store that guards mutable-name operations (`set_ref`, `publish`, `_write_ref`) with generation checks. Before and after each name write, it verifies the attempt's generation is still current; if the task was superseded, it raises `StaleWriteError` instead of proceeding. The fence is check → write → re-check (not atomic) because names and records live in different backends, but the re-check turns a potential silent corruption into a loud error — and the successor's own completing write then heals the name.

All other store operations (blob reads/writes, `get_ref`, `has`) pass through untouched, preserving backend-specific optimizations like HF batching.

**Changes:**
- Add `StaleWriteError` exception to `mini.store`
- Implement `_FencedStore` wrapper in `mini._taskworker` that fences name writes on attempt generation
- Wrap the ambient store in `execute_task` when both `artifacts` and `gen` are provided
- Add `write_if` method to `ModalRecordStore` to handle the double-spawn race atomically via insert-if-absent
- Update documentation and tests to reflect the new safety guarantee
- Export `StaleWriteError` from `mini.__init__`

**Tests:**
- `test_stale_worker_cannot_move_a_ref`: Verifies a superseded worker's `set_ref` raises `StaleWriteError` and the name never moves
- `test_stale_worker_cannot_publish`: Verifies `publish` is similarly fenced
- `test_current_worker_name_writes_land`: Confirms the fence has no false positives — the current attempt can write normally
- `test_modal_write_if_*`: Verify the atomic claim of fresh keys on Modal via insert-if-absent

Closes #46 (mutable-name half).

https://claude.ai/code/session_01TujdbJMq2fPA9WBtU9fBCo