### PR TITLE
CLI: hint instead of a raw traceback when run/retry get a name (#57)

### DIFF
--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 import argparse
 import os
 import time
+from pathlib import Path
 
 from mini.apparatus import Apparatus
-from mini.experiment import load_experiment
+from mini.experiment import Experiment, load_experiment
 from mini.local_apparatus import LocalApparatus
 from mini.memo import META_KEY, MemoStore
 from mini.orchestration import BudgetExpired, TaskFailed, retry, tick
@@ -92,6 +93,33 @@ def _peek(name: str, backend: str) -> int:
         return sum(k != META_KEY for k in d.keys())
     except Exception:
         return 0
+
+
+def _known_names() -> list[str]:
+    """Experiment names with a memo store under the data root (as ``ls`` lists)."""
+    root = data_root()
+    if not root.exists():
+        return []
+    return sorted(p.name for p in root.glob('*') if (p / '.control' / 'memo').is_dir())
+
+
+def _load_experiment_or_hint(path: str) -> Experiment:
+    """``load_experiment``, but turn the name-vs-path mistake into a hint (#57).
+
+    ``run``/``retry`` tick the DAG, so they import the experiment module and take
+    a *file*; the read verbs (``status``/``results``/``cancel``/…) address the
+    store by *name*. Typing a name here otherwise dies in an unhandled
+    ``ImportError`` — instead, if the argument is a known experiment name, say so.
+    """
+    if not Path(path).is_file():
+        hint = ''
+        if path in _known_names():
+            hint = (
+                f'\n  {path!r} is an experiment name — status/results/cancel take names; '
+                'run/retry take the experiment file (e.g. docs/acts/experiment.py)'
+            )
+        raise SystemExit(f'no experiment file at {path!r}{hint}')
+    return load_experiment(path)
 
 
 def _no_tasks(name: str, args: argparse.Namespace, extra: str = '') -> SystemExit:
@@ -240,7 +268,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     With ``--watch``, instead drive the DAG to completion with a live progress
     bar; Ctrl-C stops watching (detached workers live on — re-run to resume).
     """
-    exp = load_experiment(args.path)
+    exp = _load_experiment_or_hint(args.path)
     apparatus = _build_apparatus(exp.name, args)
     _remember_app(exp.name, args)
     _run(exp, apparatus, args)
@@ -255,7 +283,7 @@ def cmd_retry(args: argparse.Namespace) -> None:
     stale.) Fresh DONE tasks stay memo hits — to re-run one, edit its fn or bump
     ``version=``.
     """
-    exp = load_experiment(args.path)
+    exp = _load_experiment_or_hint(args.path)
     apparatus = _build_apparatus(exp.name, args)
     _remember_app(exp.name, args)
     reset = retry(apparatus.memo_store(), key=args.key)
@@ -316,11 +344,11 @@ def _watch(exp, apparatus: Apparatus, poll: float, keep_stale: bool = False) -> 
 
 
 def cmd_ls(args: argparse.Namespace) -> None:
-    root = data_root()
-    names = sorted(p.name for p in root.glob('*') if (p / '.control' / 'memo').is_dir()) if root.exists() else []
+    names = _known_names()
     if not names:
         print('no experiments yet (run one with: python -m mini run <path>)')
         return
+    root = data_root()
     for name in names:
         store = MemoStore(root / name)
         current, stale = store.split_current(store.records())
@@ -521,7 +549,11 @@ def main() -> None:
         )
 
     def _add_run_flags(p: argparse.ArgumentParser) -> None:
-        p.add_argument('path')
+        p.add_argument(
+            'path',
+            help='the experiment file to tick, e.g. docs/acts/experiment.py '
+            '(run/retry take a file; status/results/cancel take a NAME)',
+        )
         p.add_argument('-w', '--watch', action='store_true', help='drive to completion with a live progress bar')
         p.add_argument('--poll', type=float, default=0.5, help='seconds between record polls while watching')
         _add_app_flag(p)

--- a/tests/mini/test_cli.py
+++ b/tests/mini/test_cli.py
@@ -294,3 +294,26 @@ def test_retry_cli_heals_failed_task(tmp_path: Path, monkeypatch, capsys):
     cmd_retry(ns())  # resets the failed task, then the rerun (attempt 2) succeeds
     out = capsys.readouterr().out
     assert 'retrying 1 task' in out and '✓ complete' in out
+
+
+def test_run_with_a_name_instead_of_a_file_hints_at_the_split(tmp_path: Path, monkeypatch):
+    """``run``/``retry`` take a *file*; the read verbs take a *name*. Typing a
+    known experiment name here must not die in a raw ``ImportError`` — it should
+    name the mistake and point at the verbs that take names (#57)."""
+    monkeypatch.chdir(tmp_path)  # no project marker under /tmp → store resolves under cwd
+    _drive(Experiment(name='stale-probe', main=lambda ctx: ctx.map(lambda x: x, [1])), LocalApparatus('stale-probe'))
+
+    from mini.__main__ import cmd_retry
+
+    def ns(path: str) -> argparse.Namespace:
+        return argparse.Namespace(path=path, watch=False, poll=0.05, app='local', workers=1, key=None)
+
+    with pytest.raises(SystemExit) as e:  # the name of a real experiment, at a file-taking verb
+        cmd_retry(ns('stale-probe'))
+    assert "'stale-probe' is an experiment name" in str(e.value)
+    assert 'status/results/cancel take names' in str(e.value)
+
+    with pytest.raises(SystemExit) as e:  # an unknown token → the plain missing-file error, no name hint
+        cmd_retry(ns('nope'))
+    assert "no experiment file at 'nope'" in str(e.value)
+    assert 'experiment name' not in str(e.value)


### PR DESCRIPTION
Teach the path-vs-name split at the CLI surface so a natural mistake ends in a hint, not an unhandled `ImportError`.

`run`/`retry` tick the DAG, so they import the experiment module and take a **file**; the read verbs (`status`/`results`/`cancel`/…) address the store by **name**. Typing a name at `run`/`retry` previously died in a raw traceback from `load_experiment`:

```
$ mini retry stale-probe
ImportError: cannot load experiment from stale-probe
```

This is tier 1 from #57 ("Friendly miss") — the tier worth doing regardless. Tier 2 (names everywhere) is left for later, only if the asymmetry keeps biting.

## Changes

- **Guard the load in `cmd_run`/`cmd_retry`.** `_load_experiment_or_hint` raises a clean `SystemExit` when the argument isn't a file. When it matches a known experiment name, it says so and points at the verbs that take names:
  ```
  no experiment file at 'stale-probe'
    'stale-probe' is an experiment name — status/results/cancel take names; run/retry take the experiment file (e.g. docs/acts/experiment.py)
  ```
  An unknown token gets the plain missing-file error, no misleading name hint.
- **Help text for the `path` positional**, spelling out the split (`run`/`retry` take a file; `status`/`results`/`cancel` take a NAME) — previously it had none.
- **Factored `_known_names()`** out of `cmd_ls` for the name lookup, shared by the new guard.
- **Test** covering both branches: a real experiment name → the hint; an unknown token → the plain error with no hint.

## Verification

- `uv run pytest tests/mini/test_cli.py` — 11 passed
- `uv run ruff check` / `uv run ty check` clean
- Exercised the CLI by hand: the hint fires for a known name, the plain error for an unknown token, `retry --help` shows the new help text, and `ls` still lists experiments.

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzKy71hh4m9732vFxtvTVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzKy71hh4m9732vFxtvTVZ)_