### PR TITLE
Cache Hugging Face downloads across Modal containers (#50)

### DIFF
--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -112,6 +112,16 @@ Auth: `./go auth` logs into Hugging Face (a fine-grained token with read+write t
 the bucket). `hf` caches it; the store and the Modal Secret read it from there, so
 `HF_TOKEN` need not be exported — the bucket name isn't a secret, only the token.
 
+## Upstream model caching (a separate tier)
+
+The artifact store holds bytes *you* produce. Upstream weights and datasets pulled
+via `from_pretrained`/`hf_hub_download` are a different tier: a **disposable read
+accelerator**, not a durable store. On Modal, every remote function mounts a shared
+`mini-hf-cache` Volume with `HF_HOME` pointing at it, so a multi-stage pipeline
+downloads a model once instead of once per container. Nothing to configure, nothing
+in your code changes, and deleting that Volume only costs re-downloads. Locally
+there's no such tier — `~/.cache/huggingface` already persists.
+
 ## Publishing to the web
 
 `publish(art, path)` is the store's outward-facing verb: it exposes a blob at a

--- a/.agents/skills/modal/SKILL.md
+++ b/.agents/skills/modal/SKILL.md
@@ -31,8 +31,9 @@ You normally don't write any `modal.Image` code. `ModalApparatus` builds the ima
 - **Pins your deps from `pyproject.toml`.** It freezes the resolved versions (`uv_freeze`, all dependency groups except `local`/`dev`) so the remote matches your lockfile. The `cuda` group is included remotely (e.g. `jax[cuda12]`) while local installs stay CPU-only — so the same code runs CPU locally and picks up the GPU when one is attached.
 - **Ships your source automatically.** It adds the project's top-level `src/` packages via `add_local_python_source(*project_packages())` — so a remote worker can `import experiment...`/`import utils...` with no manual mounting or packaging. New top-level packages under `src/` are discovered automatically.
 - **Cached by content hash**, so it only rebuilds when deps or source change. The first build can take a few minutes; later runs are near-instant cache hits.
+- **Caches Hugging Face downloads across containers.** Every remote function mounts a shared `mini-hf-cache` Volume with `HF_HOME` pointing at it, so `from_pretrained`/`hf_hub_download` in a multi-stage pipeline pulls a model once, not once per container. It's a disposable cache (deleting the Volume only costs re-downloads); locally, `~/.cache/huggingface` already persists so nothing changes.
 
-To override (extra apt/pip, a custom base), pass `.w(image=my_image)`. See `make_image`/`requirements.py` and `ModalApparatus._ensure_image`.
+To override (extra apt/pip, a custom base), pass `.w(image=my_image)`. See `make_image`/`requirements.py` and `ModalApparatus._ensure_image`. The HF cache mount and `HF_HOME` still apply with a custom image (the env var rides in a Secret, not the image).
 
 **Running in restricted environments / cloud sandboxes**
 - **TLS-inspecting proxies:** `ModalApparatus.__init__` calls `ensure_grpc_trusts_system_ca()` (`mini/_tls.py`) so Modal's gRPC trusts a corporate/sandbox proxy CA. `bin/modal` applies the same fix (via `mini._modal_cli`) before handing off to modal's own CLI, so it also works behind these proxies — prefer it over a bare `modal` install, which does *not* apply this.

--- a/research/design.md
+++ b/research/design.md
@@ -156,6 +156,26 @@ Two further decisions:
 - **`obstore` doesn't help.** It supports only S3/GCS/Azure; bridging via fsspec forfeits
   the native-Rust speed that's its whole point, and `hf_xet` already does parallel
   chunked transfer under `HfApi`. Revisit only if mini targets those clouds directly.
+- **The HF cache is a third storage tier, kept separate** (#50): Store = durable
+  project-scoped artifacts; per-experiment Volume = working dir + checkpoints (the
+  isolation boundary); HF cache = a *disposable* read accelerator for upstream weights.
+  On Modal it's one workspace-wide `mini-hf-cache` Volume with `HF_HOME` pointed at the
+  mount — which covers both HF sub-caches (`hub/` snapshots and `xet/` chunks) with zero
+  call-site changes. It's deliberately *not* routed through the `Volume` ABC or the
+  per-experiment Volume (scope mismatch), and needs no commit discipline: concurrent
+  writers at worst duplicate a download. Locally the tier doesn't exist —
+  `~/.cache/huggingface` already persists. Note the HF **hub** cache doesn't apply to
+  buckets at all (buckets aren't a repo type; `download_bucket_files` streams straight to
+  the destination) — `HFStore` has its own warm cache for that.
+- **The worker's `HFStore` warm cache lives on container-local disk, not the mounted
+  Volume** (`WORKER_STORE_CACHE`). Under the mount it was committed alongside results,
+  so every bucket artifact grew a second, redundant copy on the per-experiment Volume.
+  Ephemeral is the point: the bucket is the durable copy; the tradeoff is a bucket
+  round trip if a *later container* re-reads bytes this experiment wrote (rare — the
+  client-side cache still keeps whole files on local disk, where re-reads actually
+  happen). A cross-container sha-index (e.g. a `modal.Dict`, self-expiring ~1 week) was
+  considered and deferred: with `put` batching and Xet chunk dedup, the residual cost is
+  one existence probe per new blob per container.
 
 ## Operational constraints worth remembering
 

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -106,6 +106,38 @@ def make_image() -> modal.Image:
     )  # fmt: skip
 
 
+# The Hugging Face cache tier: one workspace-wide Volume, mounted where HF_HOME
+# points, so a multi-stage pipeline's `from_pretrained` pulls a model once — not
+# once per container (each container otherwise boots with an empty $HF_HOME).
+# One env var covers both HF sub-caches: `hub/` (model/dataset snapshots) and
+# `xet/` (transfer chunks, size-capped by hf_xet's own default). Purely a
+# disposable read accelerator, distinct from the artifact Store (durable,
+# content-addressed) and the per-experiment Volume (working dir + checkpoints):
+# no commit discipline (background commits suffice; a lost write costs one
+# re-download), concurrent writers at worst pull the same model twice, and
+# deleting the Volume is always safe. Locally this tier doesn't exist —
+# ~/.cache/huggingface already persists.
+HF_CACHE_VOLUME = 'mini-hf-cache'
+HF_CACHE_MOUNT = '/hf-cache'
+
+# Container-local root for the worker's HFStore warm cache: deliberately NOT under
+# the mounted Volume, where it would be committed alongside results and shadow
+# every bucket artifact on paid storage. Ephemeral is correct — the bucket is the
+# durable copy, and the cache only needs to outlive the container's own re-reads.
+WORKER_STORE_CACHE = Path('/tmp/mini-store-cache')
+
+
+def _attach_hf_cache(fn_kwargs: dict[str, Any]) -> None:
+    """Mount the shared HF cache Volume and point ``HF_HOME`` at it (in place).
+
+    The env var rides in a Secret rather than on the image so a user-supplied
+    ``.w(image=...)`` still gets it.
+    """
+    cache = modal.Volume.from_name(HF_CACHE_VOLUME, create_if_missing=True)
+    fn_kwargs['volumes'] = {**fn_kwargs.get('volumes', {}), HF_CACHE_MOUNT: cache}
+    fn_kwargs['secrets'] = [*fn_kwargs.get('secrets', []), modal.Secret.from_dict({'HF_HOME': HF_CACHE_MOUNT})]
+
+
 # ---------------------------------------------------------------------------
 # Memoized-orchestration backend (control plane = modal.Dict, I/O plane = Volume)
 # ---------------------------------------------------------------------------
@@ -291,7 +323,7 @@ def _modal_task_entry(blob: bytes, key: str, gen: str, dict_name: str, volume_na
 
     from mini._taskworker import execute_task
     from mini.memo import MemoStore
-    from mini.modal_apparatus import ModalRecordStore
+    from mini.modal_apparatus import WORKER_STORE_CACHE, ModalRecordStore
     from mini.store import store_for
 
     fn, args, hooks = _cp.loads(blob)
@@ -299,9 +331,11 @@ def _modal_task_entry(blob: bytes, key: str, gen: str, dict_name: str, volume_na
     volume = _modal.Volume.from_name(volume_name)
     # With MINI_STORE_BUCKET set (passed in via a Modal Secret), put/get hit the
     # shared HF bucket — so another experiment, local or remote, reads these bytes
-    # back with no shared Volume. Otherwise the CAS rides *under* the mounted
-    # Volume (committed with the result), per-experiment until #22's project Volume.
-    artifacts = store_for(Path(mount_point) / 'store')
+    # back with no shared Volume; the warm cache goes to container-local disk, not
+    # the committed Volume (see WORKER_STORE_CACHE). Otherwise the CAS rides
+    # *under* the mounted Volume (committed with the result), per-experiment until
+    # #22's project Volume.
+    artifacts = store_for(Path(mount_point) / 'store', cache_root=WORKER_STORE_CACHE)
     execute_task(store, key, fn, args, hooks, commit=volume.commit, artifacts=artifacts, gen=gen)
 
 
@@ -435,6 +469,7 @@ class ModalApparatus(Apparatus[ModalVolume]):
                 }
             if secret := _hf_store_secret():  # forward HF bucket creds so put/get hit the shared store
                 fn_kwargs['secrets'] = [*fn_kwargs.get('secrets', []), secret]
+            _attach_hf_cache(fn_kwargs)  # shared HF_HOME, so from_pretrained caches across containers
             self._memo_fn = self.app.function(serialized=True, **fn_kwargs)(_modal_task_entry)
         return self._memo_fn
 
@@ -583,6 +618,7 @@ class ModalApparatus(Apparatus[ModalVolume]):
             }
         if secret := _hf_store_secret():  # forward HF bucket creds so put/get hit the shared store
             fn_kwargs['secrets'] = [*fn_kwargs.get('secrets', []), secret]
+        _attach_hf_cache(fn_kwargs)  # shared HF_HOME, so from_pretrained caches across containers
         modal_fn = self.app.function(serialized=True, **fn_kwargs)(wrapped_fn)
         return modal_fn, startup_timeout
 
@@ -646,7 +682,12 @@ def _wrap_for_modal(
         dir_ctx = data_dir_context(data_dir) if data_dir is not None else nullcontext()
         # Build the store remotely (this fn is serialized): the CAS rides under the
         # mounted Volume, whose parent isn't shared remotely — so no store_root_for.
-        store_ctx = store_context(store_for(data_dir / 'store')) if data_dir is not None else nullcontext()
+        # The bucket path's warm cache stays off the committed Volume (WORKER_STORE_CACHE).
+        store_ctx = (
+            store_context(store_for(data_dir / 'store', cache_root=WORKER_STORE_CACHE))
+            if data_dir is not None
+            else nullcontext()
+        )
         with (
             progress_context(run_id, str(index), queue=queue, emission_interval=emission_interval),
             dir_ctx,

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -360,14 +360,19 @@ def _hf_token() -> str | None:
         return None
 
 
-def store_for(root: Path | str) -> Store:
+def store_for(root: Path | str, *, cache_root: Path | str | None = None) -> Store:
     """The project store for a given local *root* — bucket-backed if configured.
 
     When a bucket is configured (:func:`store_bucket`) *and* a Hugging Face token is
-    available, the durable store is the shared bucket (with *root* demoted to a
-    local warm cache); otherwise it's a :class:`LocalStore` rooted at *root*. One
-    switch flips every put/get/publish — in a step, a report, or a worker — from
-    on-disk to shared-and-web-reachable.
+    available, the durable store is the shared bucket, warm-cached locally at
+    *cache_root* (default: ``store-cache/hf`` beside *root*); otherwise it's a
+    :class:`LocalStore` rooted at *root*. One switch flips every put/get/publish —
+    in a step, a report, or a worker — from on-disk to shared-and-web-reachable.
+
+    Pass *cache_root* when *root*'s neighbourhood is the wrong home for cached
+    bytes: a Modal worker points it at container-local disk, so the cache isn't
+    committed to the Volume alongside results — the bucket already holds the
+    durable copy, and a committed shadow would store every artifact twice.
 
     A configured bucket with *no* token (someone trying the repo in Codespaces, or
     a fresh checkout before ``./go auth``) falls back to the local store with a
@@ -379,7 +384,8 @@ def store_for(root: Path | str) -> Store:
     if bucket and (token := _hf_token()):
         from mini.hf_store import HFStore
 
-        return HFStore(bucket, cache=LocalStore(root.parent / 'store-cache' / 'hf'), token=token)
+        cache = LocalStore(cache_root if cache_root is not None else root.parent / 'store-cache' / 'hf')
+        return HFStore(bucket, cache=cache, token=token)
     if bucket:
         log.warning(
             'store-bucket %r is configured but no Hugging Face token was found — using the local '

--- a/tests/mini/test_apparatus.py
+++ b/tests/mini/test_apparatus.py
@@ -107,9 +107,10 @@ class MockModalApp:
     def __init__(self, name: str = 'test'):
         self.name = name
         self.app_id = 'mock-app-id'  # Add app_id for newer Modal versions  # noqa
+        self.function_kwargs: dict = {}
 
     def function(self, **decorator_kwargs):
-        del decorator_kwargs
+        self.function_kwargs = decorator_kwargs
 
         def decorator(fn):
             return _MockModalFunction(fn)
@@ -243,6 +244,35 @@ def test_modal_auth_error_has_actionable_message(monkeypatch):
 
     with pytest.raises(RuntimeError, match=r'Modal authentication failed\. Run \./go auth, then try again\.'):
         asyncio.run(collect())
+
+
+def test_memo_worker_mounts_hf_cache(monkeypatch):
+    """The remote worker gets the shared HF cache Volume, with HF_HOME pointing at it.
+
+    That's what lets a multi-stage pipeline's ``from_pretrained`` reuse weights
+    across containers instead of re-downloading per container (#50).
+    """
+    from mini.modal_apparatus import HF_CACHE_MOUNT
+
+    monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
+    secrets_made: list[dict] = []
+    monkeypatch.setattr('modal.Secret.from_dict', lambda d: secrets_made.append(d) or ('secret', d))
+    app = _make_modal(monkeypatch)
+    app._memo_worker()
+    kwargs = app.app.function_kwargs  # pyrefly: ignore [missing-attribute]  (MockModalApp)
+    assert isinstance(kwargs['volumes'][HF_CACHE_MOUNT], MockModalVolume)
+    assert {'HF_HOME': HF_CACHE_MOUNT} in secrets_made
+
+
+def test_attach_hf_cache_preserves_user_mounts_and_secrets(monkeypatch):
+    from mini.modal_apparatus import HF_CACHE_MOUNT, _attach_hf_cache
+
+    monkeypatch.setattr('modal.Volume.from_name', lambda name, create_if_missing=False: MockModalVolume())
+    monkeypatch.setattr('modal.Secret.from_dict', lambda d: ('secret', d))
+    fn_kwargs = {'volumes': {'/vol': 'user-vol'}, 'secrets': ['user-secret']}
+    _attach_hf_cache(fn_kwargs)
+    assert fn_kwargs['volumes'].keys() == {'/vol', HF_CACHE_MOUNT}
+    assert fn_kwargs['secrets'] == ['user-secret', ('secret', {'HF_HOME': HF_CACHE_MOUNT})]
 
 
 def test_complex_objects_as_args(apparatus):

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -197,7 +197,20 @@ def test_store_for_uses_bucket_with_token(tmp_path: Path, monkeypatch: pytest.Mo
 
     monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
     monkeypatch.setattr('mini.store._hf_token', lambda: 'tok')
-    assert isinstance(store_for(tmp_path / 'store'), HFStore)
+    store = store_for(tmp_path / 'store')
+    assert isinstance(store, HFStore)
+    assert store._cache.root == tmp_path / 'store-cache' / 'hf'  # warm cache sits beside root by default
+
+
+def test_store_for_cache_root_moves_the_warm_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A Modal worker points the warm cache at container-local disk, off the committed Volume."""
+    from mini.hf_store import HFStore
+
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setattr('mini.store._hf_token', lambda: 'tok')
+    store = store_for(tmp_path / 'vol' / 'store', cache_root=tmp_path / 'ephemeral')
+    assert isinstance(store, HFStore)
+    assert store._cache.root == tmp_path / 'ephemeral'
 
 
 def test_get_store_raises_outside_context():

--- a/todo.md
+++ b/todo.md
@@ -33,6 +33,10 @@ PR #54), #47 (per-experiment backend memory for `--app`).
   per-path `rm` exists), so the remaining legs are the Modal Volume sweep and
   CAS refcounting — the latter's shape depends only on how #38 (bucket split?)
   lands, now that #37 is closed (no shared working store to anticipate).
+  The `mini-hf-cache` Volume (#50) barely expands this: its `xet/` half is
+  size-capped by `hf_xet`'s default, `hub/` grows only per distinct upstream
+  model, and `modal volume delete mini-hf-cache` is always a safe reset (pure
+  cache). Worth a mention in the sweep docs, not a new GC leg.
 
 **Orthogonal, no code overlap with the above:**
 


### PR DESCRIPTION
_Adds a shared HF cache Volume on Modal so multi-stage pipelines pull upstream models once, and stops the worker's artifact warm cache from double-storing blobs on the committed Volume._

Closes #50. Implements the design from [the findings comment](https://github.com/z0u/mi-ni/issues/50#issuecomment-4880047696), with one simplification (below).

**A third storage tier.** Every remote function — memo worker and interactive path — now mounts a workspace-wide `mini-hf-cache` Volume with `HF_HOME` pointing at it, so `from_pretrained`/`hf_hub_download` in a later stage reuses what an earlier stage pulled instead of re-downloading per container. One env var covers both HF sub-caches (`hub/` snapshots and `xet/` chunks). The env var rides in a Modal Secret rather than on the image, so `.w(image=...)` overrides still get it. The tier is deliberately disposable: no commit discipline (background commits suffice), concurrent writers at worst duplicate a download, and deleting the Volume is always safe. Local runs are untouched — `~/.cache/huggingface` already persists.

**The double-store fix.** On a bucket-configured Modal worker, `store_for` placed the `HFStore` warm cache at `<mount>/store-cache/hf` — on the per-experiment Volume, which the worker commits with its results. Every artifact then lived twice on paid storage: durably in the bucket, and again as a committed shadow. `store_for` grew a `cache_root` override, and both worker paths point it at container-local `/tmp` (`WORKER_STORE_CACHE`). The client-side cache is unchanged — that's where re-reads actually happen.

**Deferred:** the cross-container sha existence index (`modal.Dict`) floated in the findings. With `put` batching and Xet chunk dedup, the ephemeral cache's residual cost is one bucket probe per new blob per container — not worth the extra moving part yet. Rationale recorded in `research/design.md`; the GC impact note (small — `xet/` is size-capped by `hf_xet`, and the Volume is a safe delete) is folded into #15's entry in `todo.md`.

**Verified end-to-end on Modal**, both halves:

- *HF cache tier* (interactive path, custom image): run 1 downloaded `gpt2/config.json` via `hf_hub_download`, landing on the cache Volume; run 2 in a fresh container listed `models--gpt2` as already cached and resolved the same file with `local_files_only=True` — no network, no explicit commit. This also confirms the hub cache's symlink layout works on Modal Volumes.
- *Double-store fix* (with `MINI_STORE_BUCKET` + token forwarded): a step `put` unique bytes through the ambient store. The worker resolved to `HFStore` with its warm cache at `/tmp/mini-store-cache` (blob present there), and the Volume had **no** `store-cache/` — the old shadow's location. The client then read the artifact back from the bucket by handle, content sha-verified, with its own warm cache still at `.mini/store-cache/hf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCEH9JEJukSK4tAt9L82bJ