### PR TITLE
GC: artifact index, Modal-backend sweep, and CAS mark-and-sweep (#15)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,70 @@
+# Handoff: issue #15 — GC for run records, Modal state, and the artifact CAS
+
+Status: **implementation complete and green; tests for the new surface + docs + issue comment still to do.**
+Delete this file before merge.
+
+## What's in this commit
+
+Three legs, all working:
+
+1. **Forward artifact index** — `_taskworker` now writes a
+   `result-<gen>.artifacts.json` sidecar (sorted blob shas from the result,
+   found by `artifact_shas()` in `store.py`, an object-graph walk pruned at
+   `_OPAQUE` types). The CAS mark phase reads these tiny files instead of
+   unpickling results; unpickle is the fallback for legacy records only.
+   This is the "fast when the store is huge" answer.
+2. **Backend-generic per-experiment gc** — `GcIO` adapter in `gc.py`
+   (`LocalGcIO` over the filesystem, `ModalGcIO` over a Modal Volume via one
+   recursive `listdir`). `Apparatus.gc_io(store)` vends the right one;
+   `mini gc <name> --app modal` now works. Modal orphan dirs are the normal
+   end state of 7-day Dict expiry — collectible by design.
+3. **CAS mark-and-sweep** — `mini gc --store [--grace 14d] [--apply]`.
+   Mark = every record (current AND superseded) across all experiments
+   (`collect_store_roots`, which peeks Modal Dicts read-only via
+   `Dict.from_name` + `hydrate`, volumes with `create=False`) plus every ref
+   (`set_ref` is the pin mechanism). Sweep = `plan_store_gc`/`apply_store_gc`
+   over `Store.list_blobs()` (implemented on LocalStore and HFStore).
+
+## Safety design (the issue's first question)
+
+Fail-closed mark: `StoreGcError` aborts the whole sweep on any RUNNING/PENDING
+task, unreadable result, or unknown `.app` backend stamp. Grace window
+(default '14d', git-style) keeps unreferenced blobs younger than the cutoff —
+covers `has()`-skip races and colleagues' unseen checkouts. Dry-run default.
+Bucket-configured-but-no-token aborts rather than silently sweeping the local
+fallback store. `HFStore.delete_blobs` purges the warm cache so `has()` can't
+lie afterwards (other machines' caches remain a documented caveat).
+
+## Verified
+
+`ruff check src tests`, `ty check src`, and
+`uv run pytest tests -q -x --ignore=tests/mini/test_hf_store.py` → 242 passed.
+(test_hf_store.py is the pre-existing network-gated suite, untouched.)
+
+## Remaining work
+
+- **Tests** (`tests/mini/test_store_gc.py`, planned in detail):
+  - `artifact_shas` walker: nested containers/dataclasses, tree children
+    included, tree-manifest sha never collected (it's not a stored blob).
+  - Sidecar e2e: a step that `put`s → sidecar exists, `result_artifacts`
+    reads it; stale sidecars swept by the attempt-files leg.
+  - LocalStore sweep e2e: unreferenced blob collected at `--grace 0d` only
+    after the superseded record is gc'd; referenced/ref-pinned/in-grace kept;
+    RUNNING record or corrupt result → `StoreGcError`; legacy no-sidecar
+    record marks via unpickle fallback.
+  - HFStore against a fake api object (SimpleNamespace entries are enough for
+    `list_bucket_tree`; assert 500-per-batch deletes + warm-cache purge).
+  - Modal leg via fakes: fake volume with `listdir`/`remove_file` +
+    `ModalRecordStore` over a plain dict; ModalGcIO plan/apply incl. orphan
+    dir from an expired Dict record.
+  - CLI: `--store` dry-run/apply; `name` + `--store` together errors.
+  - Latent pre-existing bug while you're there: `test_hf_store.py` teardown
+    appends `f'cas/{art.sha256}'` (3×) but the real key is
+    `_cas_key(sha)` = `cas/<sha[:2]>/<sha>`, so cleanup misses blobs.
+- **Docs**: storage.md section on gc/retention — pin-with-`set_ref` contract,
+  grace-window caveats for teams/multiple checkouts; update todo.md index.
+- **Issue #15 comment** answering the safety/speed questions; note scope-outs:
+  #38 interaction deferred, Dict-expiry memo-hit loss is a separate concern,
+  volume-local per-experiment `store/` is reclaimed by deleting the volume.
+- Optional: run the network-gated HF integration tests (keys are available)
+  and a Modal smoke of `mini gc <exp> --app modal`.

--- a/src/mini/__main__.py
+++ b/src/mini/__main__.py
@@ -16,7 +16,8 @@ agent (or you) can drive, poll, and gather without holding a session open:
     python -m mini logs   pipeline <key>                       # a failed task's traceback
     python -m mini explain pipeline <key>                      # why this re-ran: evidence + attempt timeline
     python -m mini cancel pipeline                             # stop in-flight tasks
-    python -m mini gc     pipeline                             # plan a storage sweep (--apply to delete)
+    python -m mini gc     pipeline                             # plan a memo-storage sweep (--apply to delete)
+    python -m mini gc     --store                              # plan an artifact-CAS sweep (--apply to delete)
 
 State is addressed by experiment NAME (one memo store per experiment). ``--app``
 picks the backend; when omitted, every verb follows the backend the experiment
@@ -34,6 +35,7 @@ from pathlib import Path
 
 from mini.apparatus import Apparatus
 from mini.experiment import Experiment, load_experiment
+from mini.gc import GRACE_DEFAULT
 from mini.local_apparatus import LocalApparatus
 from mini.memo import META_KEY, MemoStore
 from mini.orchestration import BudgetExpired, TaskFailed, retry, tick
@@ -486,28 +488,32 @@ _GC_LABEL = {
 
 
 def cmd_gc(args: argparse.Namespace) -> None:
-    """Reclaim memo storage no current read path can reach. Dry run unless ``--apply``.
+    """Reclaim storage no current read path can reach. Dry run unless ``--apply``.
 
-    Collects superseded records (with their result dirs), unreachable attempt
-    files from replaced generations, orphaned result dirs, and staged calls for
-    settled tasks. Never touches a current record — a DONE result is a future
-    memo hit, and deleting a FAILED record would silently turn a terminal
-    failure into a relaunch.
+    Two scopes: ``mini gc <name>`` sweeps one experiment's memo state
+    (superseded records with their result dirs, replaced attempt files,
+    orphaned result dirs, staged calls) on whichever backend it ran on;
+    ``mini gc --store`` mark-and-sweeps the project artifact CAS. Neither
+    touches a current record — a DONE result is a future memo hit, and
+    deleting a FAILED record would silently turn a terminal failure into a
+    relaunch.
     """
-    if _resolve_app(args.name, args) != 'local':
-        raise SystemExit(
-            'gc only supports --app local for now (#15): Modal Dict entries self-expire '
-            'after 7 days of inactivity, but Volume result dirs need a Volume-side sweep'
-        )
+    if args.store and args.name:
+        raise SystemExit('pass an experiment name or --store, not both (the store sweep is project-wide)')
+    if args.store:
+        return _gc_store(args)
+    if not args.name:
+        raise SystemExit('pass an experiment name (memo sweep) or --store (artifact CAS sweep)')
     from mini.gc import apply_gc, plan_gc
 
     apparatus = _build_apparatus(args.name, args)
     store = apparatus.memo_store()
+    io = apparatus.gc_io(store)
     recs = store.records()
-    if not recs and not (store.data_dir / '_memo').is_dir():
-        raise SystemExit(f'no tasks found for experiment {args.name!r}')
+    if not recs and not io.memo_tree():
+        raise _no_tasks(args.name, args)
     apparatus.reap_dead(store, recs)  # a vanished worker's RUNNING record must not read as alive
-    plan = plan_gc(store, recs)
+    plan = plan_gc(store, recs, io)
 
     print(f'{args.name} — gc plan:')
     for kind, label in _GC_LABEL.items():
@@ -521,7 +527,60 @@ def cmd_gc(args: argparse.Namespace) -> None:
         print('  nothing to collect')
         return
     if args.apply:
-        apply_gc(store, plan)
+        apply_gc(store, plan, io)
+        print(f'reclaimed {_human_size(plan.size)}')
+    else:
+        print(f'dry run — pass --apply to reclaim {_human_size(plan.size)}')
+
+
+def _gc_store(args: argparse.Namespace) -> None:
+    """Mark-and-sweep the project artifact store (CAS). Dry run unless ``--apply``.
+
+    Fails closed: any in-flight task, unreadable result, or unreachable
+    backend aborts the sweep with nothing deleted. Unreferenced blobs younger
+    than ``--grace`` are kept — the window that protects writers this checkout
+    can't see (an unpushed colleague's records, a ``put`` that skipped its
+    upload just before the sweep).
+    """
+    from mini.gc import StoreGcError, apply_store_gc, collect_store_roots, plan_store_gc
+    from mini.local_apparatus import LocalApparatus
+    from mini.store import _hf_token, store_bucket, store_for
+
+    if store_bucket() and not _hf_token():
+        raise SystemExit(
+            f'store-bucket {store_bucket()!r} is configured but no Hugging Face token was found — '
+            'sweeping the local fallback store instead of the real CAS would be misleading. '
+            'Run ./go auth (or set HF_TOKEN) first.'
+        )
+    store = store_for(data_root() / 'store')
+    # Settle vanished local workers first, so a crashed run's RUNNING record
+    # doesn't block the sweep forever. Modal records are reaped by their own
+    # verbs (status/watch); a stale one here aborts with a pointer to those.
+    for name in sorted(p.name for p in data_root().glob('*') if (p / '.control' / 'memo').is_dir()):
+        memo = MemoStore(data_root() / name)
+        LocalApparatus(name).reap_dead(memo)
+    try:
+        roots, notes = collect_store_roots()
+    except StoreGcError as e:
+        raise SystemExit(f'store gc aborted (nothing deleted): {e}') from e
+    try:
+        plan = plan_store_gc(store, roots, grace=duration(args.grace))
+    except NotImplementedError as e:
+        raise SystemExit(f'the configured store ({type(store).__name__}) does not support gc') from e
+
+    print(f'artifact store ({type(store).__name__}) — gc plan:')
+    print(f'  {plan.total_blobs} blob(s), {_human_size(plan.total_size)} total; {plan.roots} reachable sha(s)')
+    print(f'  referenced: {plan.referenced}')
+    for note in notes + plan.notes:
+        print(f'  kept: {note}')
+    if not plan.unreferenced:
+        print('  nothing to collect')
+        return
+    sample = ', '.join(b.sha256[:12] for b in plan.unreferenced[:6])
+    more = f', +{len(plan.unreferenced) - 6} more' if len(plan.unreferenced) > 6 else ''
+    print(f'  unreferenced: {len(plan.unreferenced)}  ({_human_size(plan.size)})  — {sample}{more}')
+    if args.apply:
+        apply_store_gc(store, plan)
         print(f'reclaimed {_human_size(plan.size)}')
     else:
         print(f'dry run — pass --apply to reclaim {_human_size(plan.size)}')
@@ -627,9 +686,17 @@ def main() -> None:
     p.set_defaults(func=cmd_cancel)
 
     p = sub.add_parser(
-        'gc', help='reclaim stale memo storage (superseded records, replaced attempts) — dry run by default'
+        'gc',
+        help="reclaim stale storage — an experiment's memo state by name, or --store for the artifact CAS "
+        '(dry run by default)',
     )
-    p.add_argument('name')
+    p.add_argument('name', nargs='?', help='experiment to sweep (omit with --store)')
+    p.add_argument('--store', action='store_true', help='mark-and-sweep the project artifact store instead')
+    p.add_argument(
+        '--grace',
+        default=GRACE_DEFAULT,
+        help=f'keep unreferenced blobs younger than this (store sweep; default {GRACE_DEFAULT})',
+    )
     p.add_argument('--apply', action='store_true', help='actually delete (default: print the plan only)')
     _add_app_flag(p)
     p.set_defaults(func=cmd_gc)

--- a/src/mini/_taskworker.py
+++ b/src/mini/_taskworker.py
@@ -9,6 +9,7 @@ outlives the orchestration tick that launched it.
 
 from __future__ import annotations
 
+import json
 import sys
 import time
 import traceback
@@ -23,7 +24,7 @@ from mini._queues import EndOfQueue
 from mini.memo import MemoStore
 from mini.progress import progress_context
 from mini.runs import RunState, compute_env
-from mini.store import Artifact, StaleWriteError, Store, store_context, store_for, store_root_for
+from mini.store import Artifact, StaleWriteError, Store, artifact_shas, store_context, store_for, store_root_for
 from mini.volume import data_dir_context
 
 
@@ -190,6 +191,11 @@ def execute_task(
             for hook in reversed(hooks):
                 hook()
             result = fn(*args)
+        # The artifact sidecar rides with the result: which blobs the result
+        # references, written even when empty ("none" beats "unknown" — the GC
+        # mark phase then never has to unpickle this result). Sidecar first, so
+        # a readable result always has its reference set alongside.
+        store.artifacts_path(key, gen).write_text(json.dumps(sorted(artifact_shas(result))))
         store.result_path(key, gen).write_bytes(cloudpickle.dumps(result))
         if commit is not None:
             commit()

--- a/src/mini/apparatus.py
+++ b/src/mini/apparatus.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Generic, Iterab
 from mini.volume import Volume
 
 if TYPE_CHECKING:
+    from mini.gc import GcIO
     from mini.memo import MemoStore
     from mini.store import Store
 
@@ -192,6 +193,16 @@ class Apparatus(ABC, Generic[V]):
         Constructing it here (rather than at call sites) lets ``tick`` stay
         backend-agnostic.
         """
+
+    def gc_io(self, store: MemoStore) -> GcIO:
+        """The I/O-plane adapter ``mini gc`` sweeps this backend through.
+
+        Local result dirs are plain files under the store's ``data_dir``;
+        ``ModalApparatus`` overrides this to sweep the Volume by path instead.
+        """
+        from mini.gc import LocalGcIO
+
+        return LocalGcIO(store)
         ...
 
     @abstractmethod

--- a/src/mini/gc.py
+++ b/src/mini/gc.py
@@ -1,4 +1,16 @@
-"""Reclaim memo-store state that no current read path can reach (``mini gc``).
+"""Reclaim storage that no current read path can reach (``mini gc``).
+
+Two sweeps, two scopes:
+
+- **Per-experiment** (``mini gc <name>``): memo-store state — records, result
+  dirs, staged calls — on either backend. Locally that's files under
+  ``.mini/<name>``; on Modal the records live in a named ``Dict`` (which
+  self-expires after 7 idle days) and the result dirs on the Volume (which
+  never expire) — the same plan logic runs over a :class:`GcIO` adapter.
+- **Project store** (``mini gc --store``): the content-addressed artifact CAS,
+  mark-and-sweep. *Mark* walks every experiment's records (both backends) and
+  the store's refs; *sweep* deletes blobs nothing reaches. See
+  :func:`collect_store_roots` for the safety posture — it fails closed.
 
 Collectibility is judged against the store's own invariants, not age or size:
 
@@ -8,44 +20,199 @@ Collectibility is judged against the store's own invariants, not age or size:
   A *current* record is never collectible — a DONE one is a future memo hit,
   and even a FAILED one is live state (deleting it would silently convert a
   terminal failure into a relaunch on the next wake).
-- A **stale attempt file** (a ``result-<gen>.pkl``/``error-<gen>.txt`` under a
-  generation the record no longer owns) is unreachable: readers resolve through
-  the record's current ``gen``, and a fenced zombie writer can't make anything
-  read it again. The one exception is the legacy ``error.txt``, which
-  ``MemoStore.error`` still falls back to when the current attempt left no
-  traceback — that stays live until the current generation writes its own.
+- A **stale attempt file** (a ``result-<gen>.pkl``/``error-<gen>.txt``/
+  ``result-<gen>.artifacts.json`` under a generation the record no longer
+  owns) is unreachable: readers resolve through the record's current ``gen``,
+  and a fenced zombie writer can't make anything read it again. The one
+  exception is the legacy ``error.txt``, which ``MemoStore.error`` still falls
+  back to when the current attempt left no traceback — that stays live until
+  the current generation writes its own.
 - An **orphaned result dir** has no record at all. Records are claimed before
-  the worker creates its dir, so this is debris, not a race.
+  the worker creates its dir, so this is debris, not a race — on Modal it is
+  also the normal end state of a Dict record that expired out from under the
+  Volume.
 - A **staged call** (``.control/memo/<key>.pkl``) is worker spawn input; it is
-  dead once its task is off RUNNING (a relaunch rewrites it).
-
-Local backend only for now. On Modal the control plane self-expires (Dict
-entries lapse after 7 days idle) but Volume result dirs persist; that sweep,
-and the artifact CAS (which has no reference index yet), are tracked in #15.
+  dead once its task is off RUNNING (a relaunch rewrites it). Modal passes the
+  call to ``spawn`` directly, so that backend stages nothing.
+- An **unreferenced blob** in the CAS is one no record's result and no ref
+  reaches, *and* older than the grace window. The window is what makes the
+  sweep safe against writers the mark phase cannot see — a checkout that
+  hasn't pushed its memo state, or a ``put`` that skipped an upload because
+  the blob already existed moments before the sweep judged it garbage.
 """
 
 from __future__ import annotations
 
 import re
 import shutil
+import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Iterable
 
 from mini.memo import MemoStore
-from mini.runs import SETTLED, RunState
+from mini.runs import SETTLED, RunState, data_root
+from mini.store import BlobStat, Store, artifact_shas
 
-__all__ = ['GcItem', 'GcPlan', 'plan_gc', 'apply_gc']
+__all__ = [
+    'GcIO',
+    'LocalGcIO',
+    'ModalGcIO',
+    'GcItem',
+    'GcPlan',
+    'plan_gc',
+    'apply_gc',
+    'StoreGcError',
+    'StoreGcPlan',
+    'collect_store_roots',
+    'plan_store_gc',
+    'apply_store_gc',
+]
 
 # The worker-written files an attempt owns; anything else in a result dir is
 # unknown, and unknown is not garbage.
-_ATTEMPT_FILE = re.compile(r'result(-\w+)?\.pkl|error(-\w+)?\.txt')
+_ATTEMPT_FILE = re.compile(r'result(-\w+)?\.pkl|result(-\w+)?\.artifacts\.json|error(-\w+)?\.txt')
+
+# Keep unreferenced blobs younger than this by default (overridable via
+# ``--grace``). Two weeks is git's prune horizon, and comfortably longer than
+# any window in which an unseen writer could have referenced an old blob.
+GRACE_DEFAULT = '14d'
+
+
+# ---------------------------------------------------------------------------
+# I/O-plane access, backend-shaped
+# ---------------------------------------------------------------------------
+
+
+class GcIO(ABC):
+    """The I/O-plane operations a memo sweep needs, decoupled from where files live.
+
+    One listing up front (``memo_tree``), deletes addressed by key + file name —
+    so the same plan/apply logic serves local disk and a Modal Volume (per-path
+    ``remove_file``; no local mount).
+    """
+
+    @abstractmethod
+    def memo_tree(self) -> dict[str, dict[str, int]]:
+        """``{key: {filename: size}}`` for every result dir under ``_memo/``.
+
+        Nested files appear under their relative path (``sub/x.bin``) — they
+        count toward sizes but never match the attempt-file pattern, so unknown
+        content is sized, not swept.
+        """
+
+    @abstractmethod
+    def staged_calls(self) -> dict[str, int]:
+        """``{key: size}`` of staged spawn inputs; empty where calls aren't staged."""
+
+    @abstractmethod
+    def delete_dir(self, key: str) -> None:
+        """Remove a whole result dir (idempotent)."""
+
+    @abstractmethod
+    def delete_files(self, key: str, names: list[str]) -> None:
+        """Remove named files within a result dir (idempotent)."""
+
+    @abstractmethod
+    def delete_call(self, key: str) -> None:
+        """Remove a staged call (idempotent)."""
+
+
+class LocalGcIO(GcIO):
+    """Plain-filesystem I/O plane: the memo store's own ``data_dir``."""
+
+    def __init__(self, store: MemoStore):
+        self._store = store
+
+    def memo_tree(self) -> dict[str, dict[str, int]]:
+        root = self._store.data_dir / '_memo'
+        if not root.is_dir():
+            return {}
+        return {
+            d.name: {p.relative_to(d).as_posix(): p.stat().st_size for p in sorted(d.rglob('*')) if p.is_file()}
+            for d in sorted(root.iterdir())
+            if d.is_dir()
+        }
+
+    def staged_calls(self) -> dict[str, int]:
+        root = self._store.root
+        if not root.is_dir():
+            return {}
+        return {p.stem: p.stat().st_size for p in sorted(root.glob('*.pkl'))}
+
+    def delete_dir(self, key: str) -> None:
+        shutil.rmtree(self._store.result_dir(key), ignore_errors=True)
+
+    def delete_files(self, key: str, names: list[str]) -> None:
+        for name in names:
+            (self._store.result_dir(key) / name).unlink(missing_ok=True)
+
+    def delete_call(self, key: str) -> None:
+        self._store._call(key).unlink(missing_ok=True)
+
+
+class ModalGcIO(GcIO):
+    """Modal-Volume I/O plane: one recursive ``listdir``, per-path ``remove_file``.
+
+    *volume* is a ``modal.Volume`` (or any duck with ``listdir``/``remove_file``
+    — a fake for tests). Import-light on purpose: constructing this never touches
+    the network; the first listing does.
+    """
+
+    def __init__(self, volume: Any):
+        self._vol = volume
+
+    def memo_tree(self) -> dict[str, dict[str, int]]:
+        import modal
+
+        tree: dict[str, dict[str, int]] = {}
+        try:
+            entries = list(self._vol.listdir('_memo', recursive=True))
+        except FileNotFoundError, modal.exception.NotFoundError:
+            return {}
+        for e in entries:
+            parts = Path(e.path).parts  # '_memo/<key>/<file...>'
+            if parts[:1] != ('_memo',) or len(parts) < 2:
+                continue
+            key = parts[1]
+            entry = tree.setdefault(key, {})
+            if len(parts) > 2 and getattr(e.type, 'name', '') == 'FILE':
+                entry['/'.join(parts[2:])] = getattr(e, 'size', 0) or 0
+        return tree
+
+    def staged_calls(self) -> dict[str, int]:
+        return {}  # Modal passes the call straight to spawn — nothing staged
+
+    def delete_dir(self, key: str) -> None:
+        self._remove(f'_memo/{key}', recursive=True)
+
+    def delete_files(self, key: str, names: list[str]) -> None:
+        for name in names:
+            self._remove(f'_memo/{key}/{name}')
+
+    def delete_call(self, key: str) -> None:
+        pass
+
+    def _remove(self, path: str, recursive: bool = False) -> None:
+        import modal
+
+        try:
+            self._vol.remove_file(path, recursive=recursive)
+        except FileNotFoundError, modal.exception.NotFoundError:
+            pass  # already gone — deletes are idempotent
+
+
+# ---------------------------------------------------------------------------
+# Per-experiment sweep
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class GcItem:
     kind: str  # 'superseded' | 'attempt-files' | 'orphan-dir' | 'staged-call'
     key: str
-    paths: list[Path]
+    names: list[str]  # files involved, for display; deletes go through GcIO by kind
     size: int
 
 
@@ -62,33 +229,29 @@ class GcPlan:
         return [i for i in self.items if i.kind == kind]
 
 
-def _size(paths: list[Path]) -> int:
-    total = 0
-    for p in paths:
-        if p.is_dir():
-            total += sum(f.stat().st_size for f in p.rglob('*') if f.is_file())
-        elif p.is_file():
-            total += p.stat().st_size
-    return total
-
-
-def plan_gc(store: MemoStore, records: list[dict] | None = None) -> GcPlan:
+def plan_gc(store: MemoStore, records: list[dict] | None = None, io: GcIO | None = None) -> GcPlan:
     """What ``apply_gc`` would delete, and why the rest stays.
 
     Call ``reap_dead`` first so a vanished worker's RUNNING record doesn't read
-    as alive. Pass *records* to reuse a snapshot already in hand.
+    as alive. Pass *records* to reuse a snapshot already in hand; pass *io* to
+    plan against a non-local I/O plane (a Modal Volume).
     """
     records = store.records() if records is None else records
+    io = io or LocalGcIO(store)
+    tree = io.memo_tree()
+    calls = io.staged_calls()
     plan = GcPlan()
-    collected = _plan_superseded(store, records, plan)
-    _plan_attempt_files(store, records, collected, plan)
-    _plan_orphan_dirs(store, records, plan)
-    _plan_staged_calls(store, records, collected, plan)
+    collected = _plan_superseded(store, records, tree, calls, plan)
+    _plan_attempt_files(store, records, tree, collected, plan)
+    _plan_orphan_dirs(records, tree, plan)
+    _plan_staged_calls(records, calls, collected, plan)
     return plan
 
 
-def _plan_superseded(store: MemoStore, records: list[dict], plan: GcPlan) -> set[str]:
-    """Whole superseded records — JSON, result dir, and staged call — gate permitting."""
+def _plan_superseded(
+    store: MemoStore, records: list[dict], tree: dict[str, dict[str, int]], calls: dict[str, int], plan: GcPlan
+) -> set[str]:
+    """Whole superseded records — record, result dir, and staged call — gate permitting."""
     current, superseded = store.split_current(records)
     if not superseded:
         return set()
@@ -108,65 +271,214 @@ def _plan_superseded(store: MemoStore, records: list[dict], plan: GcPlan) -> set
         if rec.get('state') == RunState.RUNNING:  # reap_dead left it: the worker is provably alive
             plan.kept.append(f'{key}: superseded, but its worker is still alive — cancel it first')
             continue
-        paths = [p for p in (store.result_dir(key), store._call(key)) if p.exists()]
-        plan.items.append(GcItem('superseded', key, paths, _size(paths)))
+        size = sum(tree.get(key, {}).values()) + calls.get(key, 0)
+        plan.items.append(GcItem('superseded', key, sorted(tree.get(key, {})), size))
         collected.add(key)
     return collected
 
 
-def _plan_attempt_files(store: MemoStore, records: list[dict], collected: set[str], plan: GcPlan) -> None:
+def _plan_attempt_files(
+    store: MemoStore, records: list[dict], tree: dict[str, dict[str, int]], collected: set[str], plan: GcPlan
+) -> None:
     """Attempt files no read through the record's current gen can reach."""
     for rec in records:
         key = rec['key']
-        d = store.result_dir(key)
-        if key in collected or not d.is_dir():
+        files = tree.get(key)
+        if key in collected or not files:
             continue
         gen = rec.get('gen')
-        live = {store.result_path(key, gen).name, store.error_path(key, gen).name}
-        if gen and not store.error_path(key, gen).exists():
+        live = {
+            store.result_path(key, gen).name,
+            store.error_path(key, gen).name,
+            store.artifacts_path(key, gen).name,
+        }
+        if gen and store.error_path(key, gen).name not in files:
             live.add(store.error_path(key, None).name)  # error() falls back to the legacy name
-        stale = [
-            p for p in sorted(d.iterdir()) if p.is_file() and _ATTEMPT_FILE.fullmatch(p.name) and p.name not in live
-        ]
+        stale = [n for n in sorted(files) if _ATTEMPT_FILE.fullmatch(n) and n not in live]
         if stale:
-            plan.items.append(GcItem('attempt-files', key, stale, _size(stale)))
+            plan.items.append(GcItem('attempt-files', key, stale, sum(files[n] for n in stale)))
 
 
-def _plan_orphan_dirs(store: MemoStore, records: list[dict], plan: GcPlan) -> None:
+def _plan_orphan_dirs(records: list[dict], tree: dict[str, dict[str, int]], plan: GcPlan) -> None:
     """Result dirs with no record at all (e.g. a control plane that expired out from under the volume)."""
     known = {r['key'] for r in records}
-    memo_root = store.data_dir / '_memo'
-    if not memo_root.is_dir():
-        return
-    for d in sorted(memo_root.iterdir()):
-        if d.is_dir() and d.name not in known:
-            plan.items.append(GcItem('orphan-dir', d.name, [d], _size([d])))
+    for key in sorted(tree):
+        if key not in known:
+            plan.items.append(GcItem('orphan-dir', key, sorted(tree[key]), sum(tree[key].values())))
 
 
-def _plan_staged_calls(store: MemoStore, records: list[dict], collected: set[str], plan: GcPlan) -> None:
+def _plan_staged_calls(records: list[dict], calls: dict[str, int], collected: set[str], plan: GcPlan) -> None:
     """Cloudpickled spawn inputs for tasks that are no longer running."""
     recs = {r['key']: r for r in records}
-    if not store.root.is_dir():
-        return
-    for p in sorted(store.root.glob('*.pkl')):
-        if p.stem in collected:
+    for key, size in sorted(calls.items()):
+        if key in collected:
             continue
-        if (recs.get(p.stem) or {}).get('state') != RunState.RUNNING:
-            plan.items.append(GcItem('staged-call', p.stem, [p], _size([p])))
+        if (recs.get(key) or {}).get('state') != RunState.RUNNING:
+            plan.items.append(GcItem('staged-call', key, [f'{key}.pkl'], size))
 
 
-def apply_gc(store: MemoStore, plan: GcPlan) -> None:
+def apply_gc(store: MemoStore, plan: GcPlan, io: GcIO | None = None) -> None:
     """Delete everything in *plan*.
 
     Record first, files second: a crash between the two leaves an orphaned dir,
     which the next gc collects — never the reverse (a record whose result dir
     is gone).
     """
+    io = io or LocalGcIO(store)
     for item in plan.items:
         if item.kind == 'superseded':
             store.records_backend.delete(item.key)
-        for p in item.paths:
-            if p.is_dir():
-                shutil.rmtree(p, ignore_errors=True)
-            else:
-                p.unlink(missing_ok=True)
+            io.delete_dir(item.key)
+            io.delete_call(item.key)
+        elif item.kind == 'attempt-files':
+            io.delete_files(item.key, item.names)
+        elif item.kind == 'orphan-dir':
+            io.delete_dir(item.key)
+        elif item.kind == 'staged-call':
+            io.delete_call(item.key)
+
+
+# ---------------------------------------------------------------------------
+# Project-store (CAS) mark-and-sweep
+# ---------------------------------------------------------------------------
+
+
+class StoreGcError(RuntimeError):
+    """The sweep cannot establish a safe reference set — fail closed, delete nothing."""
+
+
+@dataclass
+class StoreGcPlan:
+    unreferenced: list[BlobStat] = field(default_factory=list)  # what apply_store_gc deletes
+    total_blobs: int = 0
+    total_size: int = 0
+    referenced: int = 0
+    in_grace: int = 0
+    roots: int = 0
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def size(self) -> int:
+        return sum(b.size for b in self.unreferenced)
+
+
+def _experiment_names(root: Path) -> list[str]:
+    """Experiments with any durable trace under the data root.
+
+    ``.control/memo`` marks a local memo store; a bare ``.app`` stamp marks an
+    experiment whose state lives on another backend (Modal). ``store/``,
+    ``store-cache/`` and ``exports/`` carry neither, so they never read as
+    experiments.
+    """
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if (p / '.control' / 'memo').is_dir() or (p / '.app').is_file())
+
+
+def _memo_store_for(name: str, root: Path) -> MemoStore | None:
+    """The memo store for *name* on its stamped backend — ``None`` if the Modal
+    control plane no longer exists (expired Dict: no records, so no roots).
+    """
+    marker = root / name / '.app'
+    backend = marker.read_text().strip() if marker.is_file() else 'local'
+    if backend in ('local', ''):
+        return MemoStore(root / name)
+    if backend != 'modal':
+        raise StoreGcError(f'{name}: unknown backend {backend!r} stamped in {marker} — cannot mark its references')
+    import modal
+
+    from mini.modal_apparatus import ModalMemoStore, ModalRecordStore, control_dict_name
+    from mini.modal_volume import ModalVolume
+
+    d = modal.Dict.from_name(control_dict_name(name))  # no create_if_missing: marking must not mint state
+    try:
+        d.hydrate()
+    except modal.exception.NotFoundError:
+        return None
+    return ModalMemoStore(ModalVolume(name, create=False), ModalRecordStore(d))
+
+
+def collect_store_roots(
+    root: Path | None = None, stores: Iterable[tuple[str, MemoStore | None]] | None = None
+) -> tuple[set[str], list[str]]:
+    """Mark phase: every blob sha any experiment's records can still reach.
+
+    Fails closed (:class:`StoreGcError`) rather than under-marking:
+
+    - **An in-flight task blocks the sweep entirely.** A running worker may
+      have just seen ``has(sha) == True`` for bytes it is about to reference —
+      deleting that blob would corrupt the result it hasn't written yet.
+    - **An unreadable result blocks the sweep.** A record without an artifact
+      sidecar must be unpickled to learn its references; if that fails (moved
+      code, missing volume), its references are unknown — so nothing is safe.
+
+    *Every* record present is a root — superseded ones included. Collecting a
+    superseded record's blobs is ``mini gc <name>``'s call to make first; the
+    store sweep never second-guesses the memo layer.
+
+    Pass *stores* to mark an explicit ``(name, memo_store)`` set (tests);
+    otherwise experiments are enumerated under *root* and each is read on the
+    backend stamped at launch.
+    """
+    root = data_root() if root is None else root
+    if stores is None:
+        stores = ((name, _memo_store_for(name, root)) for name in _experiment_names(root))
+    shas: set[str] = set()
+    notes: list[str] = []
+    for name, memo in stores:
+        if memo is None:
+            notes.append(f'{name}: Modal control plane expired or absent — no records to mark')
+            continue
+        for rec in memo.records():
+            key = rec['key']
+            if rec.get('state') in (RunState.RUNNING, RunState.PENDING):
+                raise StoreGcError(
+                    f'{name}/{key} is in flight — its worker may be about to reference blobs this sweep '
+                    f'would judge unreachable. Let it settle (or reap it: mini status {name}), then re-run.'
+                )
+            listed = memo.result_artifacts(key)
+            if listed is not None:
+                shas.update(listed)
+            elif rec.get('state') == RunState.DONE:  # pre-sidecar record: the result itself is the index
+                try:
+                    shas.update(artifact_shas(memo.result(key)))
+                except Exception as exc:
+                    raise StoreGcError(
+                        f'cannot read the result of {name}/{key} to learn which blobs it references '
+                        f'({type(exc).__name__}: {exc}) — repair it or collect the record first (mini gc {name})'
+                    ) from exc
+    return shas, notes
+
+
+def plan_store_gc(store: Store, roots: set[str], *, grace: float, now: float | None = None) -> StoreGcPlan:
+    """Sweep phase: every blob outside *roots* ∪ refs and older than *grace* seconds.
+
+    Refs are resolved here (they live in the store itself), so a blob pinned by
+    ``set_ref`` survives even with no record referencing it — that's the
+    documented way to keep an artifact alive across record gc. A blob younger
+    than *grace* (or of unknown age) is never collected: it may belong to a
+    writer the mark phase couldn't see.
+    """
+    now = time.time() if now is None else now
+    roots = set(roots)
+    for name in store.list_refs():
+        if (art := store.get_ref(name)) is not None:
+            roots.update(artifact_shas(art))
+    plan = StoreGcPlan(roots=len(roots))
+    for blob in store.list_blobs():
+        plan.total_blobs += 1
+        plan.total_size += blob.size
+        if blob.sha256 in roots:
+            plan.referenced += 1
+        elif blob.modified_at is None or now - blob.modified_at < grace:
+            plan.in_grace += 1
+        else:
+            plan.unreferenced.append(blob)
+    if plan.in_grace:
+        plan.notes.append(f'{plan.in_grace} unreferenced blob(s) kept: younger than the grace window')
+    return plan
+
+
+def apply_store_gc(store: Store, plan: StoreGcPlan) -> None:
+    """Delete every blob in *plan* (and purge any warm cache of them)."""
+    store.delete_blobs([b.sha256 for b in plan.unreferenced])

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -31,9 +31,9 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Iterator
 
-from mini.store import Artifact, LocalStore, Store, _cas_key, _hash_file, _tree_sha
+from mini.store import Artifact, BlobStat, LocalStore, Store, _cas_key, _hash_file, _tree_sha
 
 __all__ = ['HFStore']
 
@@ -141,6 +141,45 @@ class HFStore(Store):
         dest = f'published/{path}'
         self.api.batch_bucket_files(self.bucket, copy=[('bucket', self.bucket, info[0].xet_hash, dest)])
         return f'https://huggingface.co/buckets/{self.bucket}/resolve/{dest}'
+
+    # -- gc --------------------------------------------------------------------
+
+    def _list_tree(self, prefix: str) -> Iterator[Any]:
+        # A prefix that has never been written is "nothing there", not an error;
+        # anything else (auth, missing bucket) must propagate — see _remote_has.
+        from huggingface_hub.errors import EntryNotFoundError
+
+        try:
+            yield from self.api.list_bucket_tree(self.bucket, prefix=prefix, recursive=True)
+        except EntryNotFoundError:
+            return
+
+    def list_blobs(self) -> Iterator[BlobStat]:
+        for entry in self._list_tree('cas'):
+            if getattr(entry, 'type', None) != 'file':
+                continue
+            sha = entry.path.rsplit('/', 1)[-1]
+            if len(sha) != 64 or not set(sha) <= set('0123456789abcdef'):
+                continue
+            ts = entry.uploaded_at or entry.mtime
+            yield BlobStat(sha, entry.size, ts.timestamp() if ts is not None else None)
+
+    def delete_blobs(self, sha256s: Iterable[str]) -> None:
+        shas = list(sha256s)
+        for i in range(0, len(shas), 500):  # one commit per chunk, not per blob
+            self.api.batch_bucket_files(self.bucket, delete=[_cas_key(s) for s in shas[i : i + 500]])
+        # Purge the warm cache too: a stale local copy would make ``has`` claim
+        # the bucket still holds bytes it no longer does, and a later ``put`` of
+        # the same content would silently skip the re-upload.
+        for s in shas:
+            self._cache._blob_path(s).unlink(missing_ok=True)
+
+    def list_refs(self) -> list[str]:
+        return sorted(
+            e.path[len('refs/') : -len('.json')]
+            for e in self._list_tree('refs')
+            if getattr(e, 'type', None) == 'file' and e.path.endswith('.json')
+        )
 
     # -- report bundles (the publish-a-report handoff) ------------------------
     #

--- a/src/mini/memo.py
+++ b/src/mini/memo.py
@@ -501,6 +501,23 @@ class MemoStore:
     def error_path(self, key: str, gen: str | None) -> Path:
         return self.result_dir(key) / (f'error-{gen}.txt' if gen else 'error.txt')
 
+    def artifacts_path(self, key: str, gen: str | None) -> Path:
+        """Where attempt *gen* records the blob shas its result references.
+
+        The worker stamps this sidecar next to the result (see
+        :func:`mini._taskworker.execute_task`), so the artifact GC can mark a
+        result's references without unpickling it — no project imports, no
+        arbitrary code, one small read per record however large the result.
+        """
+        return self.result_dir(key) / (f'result-{gen}.artifacts.json' if gen else 'result.artifacts.json')
+
+    def result_artifacts(self, key: str) -> list[str] | None:
+        """Blob shas the current result references, or ``None`` for a record
+        from before the sidecar existed (unpickle the result to find out).
+        """
+        p = self.artifacts_path(key, self._gen(key))
+        return json.loads(p.read_text()) if p.exists() else None
+
     def _gen(self, key: str) -> str | None:
         return (self.records_backend.read(key) or {}).get('gen')
 

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -12,6 +12,7 @@ Example::
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import secrets
 import time
@@ -19,7 +20,10 @@ from contextlib import asynccontextmanager, nullcontext
 from functools import wraps
 from itertools import count
 from pathlib import Path
-from typing import Any, AsyncIterator, Callable, Iterable, TypeVar, override
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Iterable, TypeVar, override
+
+if TYPE_CHECKING:
+    from mini.gc import GcIO
 
 import cloudpickle
 import modal
@@ -234,6 +238,14 @@ class ModalMemoStore(MemoStore):
                 continue
         return '(no logs)'
 
+    def result_artifacts(self, key: str) -> list[str] | None:
+        gen = self._gen(key)
+        name = f'result-{gen}.artifacts.json' if gen else 'result.artifacts.json'
+        try:
+            return json.loads(self._read_volume_bytes(f'_memo/{key}/{name}'))
+        except FileNotFoundError, modal.exception.NotFoundError:
+            return None  # pre-sidecar record: only unpickling the result reveals its refs
+
 
 class ModalVolumeStore(Store):
     """Client-side artifact :class:`~mini.store.Store` that reads blobs off the Volume.
@@ -427,6 +439,12 @@ class ModalApparatus(Apparatus[ModalVolume]):
     @override
     def memo_store(self) -> MemoStore:
         return ModalMemoStore(self.volume, ModalRecordStore.from_name(self._dict_name))
+
+    @override
+    def gc_io(self, store: MemoStore) -> GcIO:
+        from mini.gc import ModalGcIO
+
+        return ModalGcIO(self.volume._modal_volume)
 
     @override
     def store(self) -> Store:

--- a/src/mini/modal_volume.py
+++ b/src/mini/modal_volume.py
@@ -22,9 +22,11 @@ class ModalVolume(Volume):
     mount point is created by Modal automatically when the volume is attached.
     """
 
-    def __init__(self, name: str, mount_point: str = '/vol'):
+    def __init__(self, name: str, mount_point: str = '/vol', *, create: bool = True):
+        # ``create=False`` for read-only peeks (gc's mark phase): a look at an
+        # experiment's volume must not mint an empty one on Modal.
         self._mount_point = Path(mount_point)
-        self._modal_volume = modal.Volume.from_name(name, create_if_missing=True)
+        self._modal_volume = modal.Volume.from_name(name, create_if_missing=create)
 
     @property
     def path(self) -> Path:

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -42,6 +42,7 @@ store for web-reachable :meth:`~Store.publish` slots in behind the same handle.
 from __future__ import annotations
 
 import contextvars
+import gc
 import hashlib
 import json
 import logging
@@ -49,15 +50,18 @@ import mimetypes
 import os
 import shutil
 import tomllib
+import types
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator, Literal
+from typing import Any, Iterable, Iterator, Literal
 
 __all__ = [
     'Artifact',
+    'BlobStat',
+    'artifact_shas',
     'StaleWriteError',
     'Store',
     'LocalStore',
@@ -182,9 +186,49 @@ def _tree_sha(children: tuple[Artifact, ...]) -> str:
     return _hash_bytes(manifest.encode())
 
 
+# Object kinds a result's data graph never hides an Artifact behind: crossing
+# them would drag in whole modules (a callable's globals) for no extra recall.
+_OPAQUE = (types.ModuleType, types.FunctionType, types.BuiltinFunctionType, types.MethodType, types.CodeType, type)
+
+
+def artifact_shas(obj: Any) -> set[str]:
+    """Every *blob* sha reachable from *obj* — the reference set GC marks from.
+
+    Walks the full object graph (``gc.get_referents``: containers, dataclass
+    fields, instance dicts — anything a result value can nest handles in),
+    pruned at code/module/class boundaries. A tree's own sha names a manifest,
+    not a stored blob, so only ``file`` artifacts (including tree children)
+    contribute.
+    """
+    shas: set[str] = set()
+    seen: set[int] = set()
+    stack = [obj]
+    while stack:
+        o = stack.pop()
+        if isinstance(o, (str, bytes, int, float, bool, type(None))) or id(o) in seen:
+            continue
+        seen.add(id(o))
+        if isinstance(o, Artifact):
+            if o.kind == 'file':
+                shas.add(o.sha256)
+            stack.extend(o.children)
+        elif not isinstance(o, _OPAQUE):
+            stack.extend(gc.get_referents(o))
+    return shas
+
+
 # ---------------------------------------------------------------------------
 # The store
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BlobStat:
+    """One stored blob, as the GC sweep sees it (see ``Store.list_blobs``)."""
+
+    sha256: str
+    size: int
+    modified_at: float | None  # epoch seconds; None = unknown, treated as too new to sweep
 
 
 class Store(ABC):
@@ -290,6 +334,24 @@ class Store(ABC):
         """Resolve the name *name* to its artifact handle, or ``None`` if unset."""
         payload = self._read_ref(name)
         return Artifact.from_dict(json.loads(payload)) if payload is not None else None
+
+    # -- gc surface (optional capability) --------------------------------------
+    #
+    # Not abstract: only the durable backends (LocalStore, HFStore) can sweep;
+    # wrappers and read-only views (_FencedStore, ModalVolumeStore) need not
+    # pretend to. ``mini gc --store`` checks for NotImplementedError and says so.
+
+    def list_blobs(self) -> Iterator[BlobStat]:
+        """Every blob in the CAS, with size and last-modified (the sweep candidates)."""
+        raise NotImplementedError(f'{type(self).__name__} does not support gc')
+
+    def delete_blobs(self, sha256s: Iterable[str]) -> None:
+        """Remove blobs from the CAS (and any warm cache, so ``has`` cannot lie)."""
+        raise NotImplementedError(f'{type(self).__name__} does not support gc')
+
+    def list_refs(self) -> list[str]:
+        """Every ref name currently set (each is a GC root)."""
+        raise NotImplementedError(f'{type(self).__name__} does not support gc')
 
 
 @contextmanager
@@ -462,6 +524,28 @@ class LocalStore(Store):
         dest.parent.mkdir(parents=True, exist_ok=True)
         self._read_blob(art.sha256, dest)
         return dest.resolve().as_uri()
+
+    # -- gc --------------------------------------------------------------------
+
+    def list_blobs(self) -> Iterator[BlobStat]:
+        cas = self.root / 'cas'
+        if not cas.is_dir():
+            return
+        for p in sorted(cas.glob('*/*')):
+            # Only true blob names count: a .tmp from a crashed _write_blob is
+            # not part of the CAS (and never will be — the rename lost).
+            if p.is_file() and len(p.name) == 64 and set(p.name) <= set('0123456789abcdef'):
+                st = p.stat()
+                yield BlobStat(p.name, st.st_size, st.st_mtime)
+
+    def delete_blobs(self, sha256s: Iterable[str]) -> None:
+        for sha in sha256s:
+            self._blob_path(sha).unlink(missing_ok=True)
+
+    def list_refs(self) -> list[str]:
+        if not self.refs.is_dir():
+            return []
+        return sorted(p.relative_to(self.refs).as_posix()[: -len('.json')] for p in self.refs.rglob('*.json'))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mini/test_gc.py
+++ b/tests/mini/test_gc.py
@@ -169,7 +169,7 @@ def test_stale_attempt_files_swept_current_and_unknown_kept(tmp_path: Path, monk
 
     plan = plan_gc(store)
     [item] = plan.by_kind('attempt-files')
-    assert {p.name for p in item.paths} == {'result-deadbeef.pkl', 'error-deadbeef.txt', 'result.pkl'}
+    assert set(item.names) == {'result-deadbeef.pkl', 'error-deadbeef.txt', 'result.pkl'}
     apply_gc(store, plan)
 
     assert store.result(key) == 2  # current attempt intact
@@ -212,19 +212,19 @@ def test_cmd_gc_dry_run_then_apply(tmp_path: Path, monkeypatch, capsys):
 
     from mini.__main__ import cmd_gc, cmd_status
 
-    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False))
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False, store=False))
     out = capsys.readouterr().out
     assert 'dry run' in out and 'superseded' in out
     assert len(store.records()) == 3  # nothing deleted
 
-    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=True))
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=True, store=False))
     assert 'reclaimed' in capsys.readouterr().out
     assert len(store.records()) == 2
 
     cmd_status(argparse.Namespace(name='gccli', app='local'))  # the cleaned store still reads done
     assert '—  done  (2 tasks)' in capsys.readouterr().out
 
-    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False))  # idempotent: nothing left
+    cmd_gc(argparse.Namespace(name='gccli', app='local', apply=False, store=False))  # idempotent: nothing left
     assert 'nothing to collect' in capsys.readouterr().out
 
 


### PR DESCRIPTION
Retention/GC for run records, Modal state, and the project artifact CAS (#15).

**Status: implementation complete and green (242 passed, ruff/ty clean), but tests for the new surface and docs are still pending — see `HANDOFF.md` at the repo root for the full continuation plan.** This PR was pushed mid-stream as a session handoff; the next session should pick up from that note and delete it before merge.

Three legs:

- **Forward artifact index** — task workers write a `result-<gen>.artifacts.json` sidecar listing the blob shas reachable from the result (via a new `artifact_shas()` object-graph walk), so the CAS mark phase reads tiny JSON instead of unpickling every result. Unpickling remains the fallback for legacy records. This is the "fast when the store grows large" answer.
- **Backend-generic per-experiment gc** — a `GcIO` adapter makes `mini gc <name>` work on Modal too: `LocalGcIO` over the filesystem, `ModalGcIO` over a single recursive Volume listing. Orphan dirs left behind by 7-day Modal Dict expiry are collectible by design.
- **CAS mark-and-sweep** — `mini gc --store [--grace 14d] [--apply]`. Mark from *all* records (current and superseded) across all experiments plus every ref (`set_ref` is the pin mechanism); sweep unreferenced blobs older than the grace window. Fail-closed: any RUNNING/PENDING task, unreadable result, or unknown backend stamp aborts the sweep with nothing deleted. `HFStore.delete_blobs` purges the warm cache so `has()` can't lie afterwards. Dry-run by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TKNMwyrNrQX2af6L2bXAH

---
_Generated by [Claude Code](https://claude.ai/code/session_012TKNMwyrNrQX2af6L2bXAH)_