### PR TITLE
Document tomlq as the preferred CLI tool for TOML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,5 @@ When creating PRs, omit the **Checklist** and **Copyright Dedication** sections 
 This project uses `uv`, `ruff`, and `ty`.
 
 Also available: `fd`, `fzf`, `rg`, `bat`, `gh`. We can add more to the dev container if you have other preferred tools.
+
+For reading/editing TOML (e.g. `pyproject.toml`) from the CLI, prefer `tomlq` (part of the `yq` package) over writing a one-off Python script, e.g. `tomlq '.tool.mini' pyproject.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,4 @@ This project uses `uv`, `ruff`, and `ty`.
 
 Also available: `fd`, `fzf`, `rg`, `bat`, `gh`. We can add more to the dev container if you have other preferred tools.
 
-For reading/editing TOML (e.g. `pyproject.toml`) from the CLI, prefer `tomlq` (part of the `yq` package) over writing a one-off Python script, e.g. `tomlq '.tool.mini' pyproject.toml`.
+For reading/editing TOML (e.g. `pyproject.toml`) from the CLI, prefer `tomlq` (part of the `yq` package) over writing a one-off Python script, e.g. `uvx --from yq tomlq '.tool.mini' pyproject.toml`. (Plain `uvx tomlq` won't work — `tomlq` is an entry point inside the `yq` package, not its own PyPI package.)


### PR DESCRIPTION
## Summary
- Notes in the Environment section of `AGENTS.md` that `tomlq` (part of the `yq` package) is already available and preferred over one-off Python scripts for reading/editing TOML files like `pyproject.toml`.

## Test plan
- N/A — documentation-only change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTWJrkLpF3F14q6ifQvXoY)_