### PR TITLE
Split the publish tier onto an optional versioned dataset repo (#38)

### DIFF
--- a/.agents/skills/mi-ni/references/storage.md
+++ b/.agents/skills/mi-ni/references/storage.md
@@ -136,10 +136,24 @@ url = store.publish(art, f'reports/{exp}/loss.png')
 `LocalStore` returns a `file://` URL (the published view lives under the project
 store). With `MINI_STORE_BUCKET` set, `HFStore` returns a real `https://` resolve
 URL for the same handle — a server-side copy *by xet hash* (no bytes moved) to an
-extensioned path, served with a `Content-Type` from that extension. The bucket is
-**public**, so `publish` is the deliberate outward step; the durable CAS only goes
-public because we share one bucket for now (a private store + public publish bucket
-is a later split — see `todo.md`).
+extensioned path, served with a `Content-Type` from that extension.
+
+By default the CAS and the published views share one bucket, so persisting an
+artifact and publishing it land in the same (public-if-the-bucket-is) store. To keep
+the CAS **private** while published views stay public *and* gain version history, set
+a separate publish tier:
+
+```toml
+[tool.mini]
+store-bucket = "your-namespace/your-bucket"        # private CAS + refs
+publish-repo = "your-namespace/your-publish-repo"   # public, versioned dataset repo
+```
+
+With `publish-repo` set, `publish`/report-exports route to that dataset repo (a
+citation can pin to `…/resolve/<commit-sha>/…`); `put`/`get`/refs stay in the bucket.
+It costs no extra storage — Xet dedups chunks account-wide — so publishing is a
+commit, not a byte re-transfer. See [`eng/publishing.md`](../../../../eng/publishing.md)
+and issue #38 for the design.
 
 **Reports don't call `publish` directly** — they go through a report bundle
 (`use_publisher` + `asset_url`, and the publish/build split): [reports.md](./reports.md).

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,14 +40,18 @@ jobs:
 
       - name: Build Site
         # Read-only, deterministic half of publishing: build_site pulls each synced
-        # bundle from the bucket, resolves author links against this checkout, inserts
-        # one <base href> at exports/<key>/, and writes the HTML into _site. The assets
-        # stay on the bucket CDN; the agent did the export+upload (`./go publish`). A
-        # read-only HF_TOKEN suffices — this job never writes to the bucket or runs a
-        # notebook. (A report not yet published is skipped with a warning, not an error.)
+        # bundle from the publish tier (the dataset repo when MINI_PUBLISH_REPO is set,
+        # else the bucket), resolves author links against this checkout, inserts one
+        # <base href> at exports/<key>/, and writes the HTML into _site. The assets stay
+        # on the CDN; the agent did the export+upload (`./go publish`). A read-only
+        # HF_TOKEN suffices — this job never writes or runs a notebook. (A report not yet
+        # published is skipped with a warning, not an error.)
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           MINI_STORE_BUCKET: ${{ vars.MINI_STORE_BUCKET }}
+          # Set the MINI_PUBLISH_REPO repo variable to serve the site off the public
+          # dataset repo — required once the CAS bucket is flipped private (#38).
+          MINI_PUBLISH_REPO: ${{ vars.MINI_PUBLISH_REPO }}
         run: ./go build
 
       - name: Setup Pages

--- a/eng/decisions.md
+++ b/eng/decisions.md
@@ -48,7 +48,13 @@
 
 - Implicit cross-experiment memo dedup, + optional shared working volume and a
   `materialize` front door — **#37**.
-- Private-CAS / public-publish two-bucket split; citable versioned publish tier — **#38**.
+- Private-CAS / public-publish split + citable versioned publish tier — **#38**. Landed as
+  an opt-in seam: `HFStore` routes `publish`/`export_*` to a Hugging Face **dataset repo**
+  (versioned → citable) when `[tool.mini] publish-repo` is set, leaving `cas/`+`refs/` in a
+  (now privatable) bucket; unset keeps the single-store default. Rationale (why the split
+  is by *write concurrency*, and why it costs no extra storage under account-wide Xet
+  dedup) in [Publishing](./publishing.md). Remaining: provisioning (a public dataset repo +
+  flipping the bucket private) and a live round-trip against a real repo.
 - Wire the artifact store through the interactive `app.map`/`arun` path — **#39**.
 - GC across the CAS, control plane, and Volume run dirs — **#15**, shipped: `mini gc
   <name>` (both backends) and `mini gc --store` (CAS mark-and-sweep). See

--- a/eng/publishing.md
+++ b/eng/publishing.md
@@ -13,12 +13,44 @@ extensioned path; the bucket's resolve URL then sets `Content-Type` from that ex
 and serves `Content-Disposition: inline`. So one bucket is both the durable store and a
 CDN-backed asset host.
 
-Today **one public bucket** backs both the CAS and the published views, because HF
-buckets have **no per-prefix ACL** — public/private is bucket-level only. A private CAS
-+ public publish bucket is a genuine two-bucket split, and a citation-grade *versioned*
-publish tier would want a dataset repo (real git history) rather than a bucket. Both are
-deferred — **#38**; `HFStore` is kept backend-swappable so the publish tier can move
-later without touching experiment or report code.
+## Two tiers, split by write concurrency (#38)
+
+By default **one bucket** backs both the CAS and the published views. That's fine until
+you persist something that shouldn't be world-readable: HF buckets have **no per-prefix
+ACL** (public/private is bucket-level only), so a public bucket makes *every* `put`
+world-readable, not just what you `publish`. The fix is two stores — and the seam
+between them is **write concurrency**, not just visibility:
+
+| Tier | Namespaces | Writer | Concurrency | Backend |
+|---|---|---|---|---|
+| **Durable store** | `cas/<sha>`, `refs/` | workers | high, parallel | a **bucket** (no git history → concurrent writers never 412) — make it **private** |
+| **Publish tier** | `published/`, `exports/` | a driver / CI | low, single-writer | a **dataset repo** (real git history → versioned, citable) — **public** |
+
+The CAS *must* stay a bucket: that's the whole reason buckets were chosen (concurrent
+result writers would 412 on a git-backed repo's shared parent). But `publish` and report
+export are deliberate, single-writer, driver-side acts — so they can afford a git-backed
+**dataset repo**, which buys what a bucket can't:
+
+- a **public** face over a **private** CAS (the two-store split HF's bucket-level ACL forces), and
+- **versioned names with history** — a citation pins to `…/resolve/<commit-sha>/published/<path>`, which a mutable bucket path can't guarantee.
+
+So one move settles both halves of #38: point the publish tier at a dataset repo and it's
+public *and* citable.
+
+**Cost.** Not a byte more of storage. Xet chunk dedup is **account-wide**, so a blob
+published from the private CAS into the public repo references the *same* chunks —
+publishing pulls the blob local (the warm cache usually has it) and uploads, but Xet skips
+every chunk the CAS already stored, so it's a metadata + git-commit op, not a re-transfer.
+The only real deltas: public storage is best-effort quota (vs private's ~100 GB
+guaranteed), and each publish is a commit rather than the in-bucket instant by-hash copy.
+
+**Enabling it.** Set `[tool.mini] publish-repo = "<ns>/<repo>"` (or `MINI_PUBLISH_REPO`)
+and flip the existing bucket to private. Unset, everything stays in the one bucket — the
+seam is opt-in and `HFStore` routes `publish`/`export_*` on `publish_repo` alone, so no
+experiment or report code changes. Provisioning is typically just **one** new public
+dataset repo; a second public *bucket* is only needed if you want high-churn public assets
+that shouldn't be versioned (reports overwrite by name, so they don't accumulate — you
+usually don't).
 
 ## Reports are a bundle plus a `<base>` switch
 

--- a/eng/storage-backend.md
+++ b/eng/storage-backend.md
@@ -21,3 +21,8 @@ size; throughput above the floor is ~10–35 MB/s. Consequences:
 - **Keep checkpoints on the volume, not the CAS** (see
   [Non-goals](./decisions.md)) — content-addressing mutable, superseded state pays the
   floor repeatedly for nothing.
+
+The bucket holds the durable tier — `cas/<sha>` + `refs/` — and can be **private**: the
+public, versioned *publish* tier (`published/`, `exports/`) splits off onto a dataset repo
+when `publish-repo` is set, so persisting an artifact never makes its bytes world-readable.
+See [Publishing](./publishing.md) for that split (#38).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,14 @@ pages = [
 # with MINI_STORE_BUCKET. Unset → the store stays local (no network).
 # store-bucket = "your-namespace/your-bucket"
 
+# The public, versioned publish tier: a Hugging Face *dataset repo* that backs
+# `publish()` and report exports. Set this to keep the CAS bucket above private
+# (persisting an artifact never makes its bytes world-readable) while published
+# views stay public and gain git history — a citation pins to a commit sha.
+# Unset → publish/exports stay in the bucket (the single-store default). Override
+# per-shell with MINI_PUBLISH_REPO. See eng/publishing.md and issue #38.
+# publish-repo = "your-namespace/your-publish-repo"
+
 [tool.uv]
 # Dependency cooldown to mitigate risk of supply chain attacks.
 # https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns

--- a/scripts/auth_check.py
+++ b/scripts/auth_check.py
@@ -81,7 +81,7 @@ async def check_modal() -> Status:
 
 
 async def check_hf() -> Status:
-    from mini.store import store_bucket
+    from mini.store import publish_repo, store_bucket
 
     code, out, err = await _run('hf', 'auth', 'whoami')
     text = out + err
@@ -90,8 +90,17 @@ async def check_hf() -> Status:
     # `hf auth whoami` prints `user=<name>`; fall back to the first plain line.
     match = re.search(r'^\s*user[=:]\s*(\S+)', out, re.MULTILINE | re.IGNORECASE)
     user = match.group(1) if match else next((ln.strip() for ln in out.splitlines() if ln.strip()), '')
-    bucket = store_bucket()
-    parts = [p for p in (f'user {user}' if user else '', f'bucket {bucket}' if bucket else 'no store-bucket set') if p]
+    bucket, repo = store_bucket(), publish_repo()
+    parts = [
+        p
+        for p in (
+            f'user {user}' if user else '',
+            f'bucket {bucket}' if bucket else 'no store-bucket set',
+            # Only shown when set — the publish tier is opt-in (#38); unset means publish stays in the bucket.
+            f'publish-repo {repo}' if repo else '',
+        )
+        if p
+    ]
     return Status('Hugging Face', True, ', '.join(parts))
 
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -367,7 +367,8 @@ def main():
     links = prepare_dirs_and_resolver()
     store = _resolve_store()
     externalizing = isinstance(store, HFStore)
-    print(f'  asset mode: {"externalize ← " + store.bucket if externalizing else "localize (no bucket)"}')
+    tier = (store.publish_repo or store.bucket) if externalizing else None
+    print(f'  asset mode: {"externalize ← " + tier if externalizing else "localize (no bucket)"}')
     build_reports(links, store, externalizing)
     copy_assets()
     copy_md_stylesheet()

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -367,8 +367,10 @@ def main():
     links = prepare_dirs_and_resolver()
     store = _resolve_store()
     externalizing = isinstance(store, HFStore)
-    tier = (store.publish_repo or store.bucket) if externalizing else None
-    print(f'  asset mode: {"externalize ← " + tier if externalizing else "localize (no bucket)"}')
+    if isinstance(store, HFStore):  # the publish tier: its own repo if split off, else the bucket
+        print(f'  asset mode: externalize ← {store.publish_repo or store.bucket}')
+    else:
+        print('  asset mode: localize (no bucket)')
     build_reports(links, store, externalizing)
     copy_assets()
     copy_md_stylesheet()

--- a/scripts/export_reports.py
+++ b/scripts/export_reports.py
@@ -85,8 +85,9 @@ def main() -> None:
         sys.exit('No HF bucket configured — set [tool.mini] store-bucket and run `./go auth`, then retry --publish.')
     for nb in nbs:
         publish_one(nb, store)
+    target = store.publish_repo or store.bucket  # exports route to the repo when a publish tier is set (#38)
     print(
-        f'\nPublished {len(nbs)} report(s) to {store.bucket}. '
+        f'\nPublished {len(nbs)} report(s) to {target}. '
         'Trigger the Pages build to update the site (push to main, or run the "Deploy Docs" workflow).'
     )
 

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -23,6 +23,16 @@ Three properties make this the durable, shareable tier:
 Blobs are warm-cached into a local :class:`~mini.store.LocalStore` so a re-read
 (or a re-``put`` of known bytes) skips the network. The bucket stays the source
 of truth; the cache is just an accelerator.
+
+**The publish tier can live in a separate dataset repo.** ``put``/``get``/refs run
+hot and concurrent (many workers), which is why the CAS is a bucket — buckets have
+no git history, so parallel writers never conflict. ``publish`` and report exports
+run cold and single-writer (a driver or CI), so they can afford a git-backed
+Hugging Face *dataset repo*, which buys two things a bucket can't: a **public**
+face over a **private** CAS (buckets have no per-prefix ACL, so this is a genuine
+two-store split), and **versioned names** — a citation pins to a commit sha. Set
+``publish_repo`` (``[tool.mini] publish-repo``) to route publish/exports there;
+unset, they stay in the bucket. See ``eng/publishing.md`` and issue #38.
 """
 
 from __future__ import annotations
@@ -45,8 +55,20 @@ __all__ = ['HFStore']
 class HFStore(Store):
     """A :class:`~mini.store.Store` backed by a Hugging Face bucket via ``HfApi``."""
 
-    def __init__(self, bucket: str, *, cache: LocalStore, token: str | None = None):
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        cache: LocalStore,
+        token: str | None = None,
+        publish_repo: str | None = None,
+    ):
         self.bucket = bucket
+        # The public, versioned publish tier: a Hugging Face *dataset* repo (real git
+        # history → a citation pins to a commit sha) that backs publish() and report
+        # exports. ``None`` keeps both in ``bucket`` — the single-store default, which
+        # is also what makes the split opt-in and this class backend-swappable (#38).
+        self.publish_repo = publish_repo
         self._cache = cache  # local warm checkout, keyed by sha (a LocalStore)
         self._token = token or os.environ.get('HF_TOKEN')
         self._api: Any = None
@@ -87,12 +109,22 @@ class HFStore(Store):
         self.api.batch_bucket_files(self.bucket, add=[(str(src), _cas_key(sha256))])
         self._cache_blob(sha256, src)
 
-    def _read_blob(self, sha256: str, dest: Path) -> None:
+    def _local_blob(self, sha256: str) -> Path:
+        """The blob's path in the warm cache, pulled once from the CAS bucket if absent.
+
+        The single place bytes come off the bucket: :meth:`_read_blob` serves reads
+        from it, and :meth:`publish` needs a local file to hand the (separate) publish
+        repo so Xet can chunk it — the durable copy lives in the CAS, not the publish
+        tier, so publishing pulls-then-uploads rather than moving bytes server-side.
+        """
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
             blob.parent.mkdir(parents=True, exist_ok=True)
             self.api.download_bucket_files(self.bucket, files=[(_cas_key(sha256), str(blob))])
-        shutil.copyfile(blob, dest)
+        return blob
+
+    def _read_blob(self, sha256: str, dest: Path) -> None:
+        shutil.copyfile(self._local_blob(sha256), dest)
 
     def _put_tree(self, src: Path, *, name: str) -> Artifact:
         """Hash every shard locally, then upload the missing ones in **one** commit.
@@ -132,6 +164,12 @@ class HFStore(Store):
     def publish(self, art: Artifact, path: str) -> str:
         if art.kind == 'tree':
             raise ValueError('publish a single file (resolve a tree first, or publish its children)')
+        if self.publish_repo is not None:
+            return self._publish_to_repo(art, path)
+        return self._publish_to_bucket(art, path)
+
+    def _publish_to_bucket(self, art: Artifact, path: str) -> str:
+        """The single-store default: expose a CAS blob in-bucket under ``published/``."""
         info = list(self.api.get_bucket_paths_info(self.bucket, [_cas_key(art.sha256)]))
         if not info:
             raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
@@ -141,6 +179,28 @@ class HFStore(Store):
         dest = f'published/{path}'
         self.api.batch_bucket_files(self.bucket, copy=[('bucket', self.bucket, info[0].xet_hash, dest)])
         return f'https://huggingface.co/buckets/{self.bucket}/resolve/{dest}'
+
+    def _publish_to_repo(self, art: Artifact, path: str) -> str:
+        """Expose a CAS blob on the public, versioned dataset repo (see :func:`publish_repo`).
+
+        No server-side by-hash copy exists across a bucket→repo boundary, so this
+        pulls the blob from the (possibly private) CAS into the warm cache and uploads
+        it. That's not a byte re-transfer: Xet chunk dedup is account-wide, so chunks
+        the CAS already stored aren't sent again — the upload is a metadata + git-commit
+        op. The commit is what gives the publish tier history: the returned ``resolve``
+        URL tracks the branch, and a citation can pin the same path to a commit sha.
+        """
+        if not self.has(art.sha256):
+            raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
+        dest = f'published/{path}'
+        self.api.upload_file(
+            path_or_fileobj=str(self._local_blob(art.sha256)),
+            path_in_repo=dest,
+            repo_id=self.publish_repo,
+            repo_type='dataset',
+            commit_message=f'publish {path}',
+        )
+        return f'https://huggingface.co/datasets/{self.publish_repo}/resolve/main/{dest}'
 
     # -- gc --------------------------------------------------------------------
 
@@ -192,24 +252,65 @@ class HFStore(Store):
 
     def export_base(self, key: str) -> str:
         """The ``<base href>`` a published report's relative ``_assets/`` resolve against."""
+        if self.publish_repo is not None:
+            return f'https://huggingface.co/datasets/{self.publish_repo}/resolve/main/exports/{key}/'
         return f'https://huggingface.co/buckets/{self.bucket}/resolve/exports/{key}/'
 
     def sync_export(self, local_dir: Path, key: str) -> None:
-        """Mirror a report's local export dir to bucket ``exports/<key>/`` (delete stale).
+        """Mirror a report's local export dir to ``exports/<key>/`` (delete stale).
 
-        rsync-like (``sync_bucket``), so a re-export overwrites in place and drops assets
-        the report no longer references — the per-report bundle is the sync unit.
+        rsync-like — a re-export overwrites in place and drops assets the report no
+        longer references — with the per-report bundle as the sync unit. On the bucket
+        that's ``sync_bucket``; on the dataset repo it's one commit whose
+        ``delete_patterns`` prunes the bundle's now-absent files.
         """
+        if self.publish_repo is not None:
+            self.api.upload_folder(
+                folder_path=str(local_dir),
+                path_in_repo=f'exports/{key}',
+                repo_id=self.publish_repo,
+                repo_type='dataset',
+                delete_patterns='*',
+                commit_message=f'export {key}',
+            )
+            return
         self.api.sync_bucket(source=str(local_dir), dest=f'hf://buckets/{self.bucket}/exports/{key}', delete=True)
 
     def fetch_export(self, key: str, dest: Path) -> bool:
-        """Download bucket ``exports/<key>/`` into *dest*; ``False`` if nothing is synced.
+        """Download ``exports/<key>/`` into *dest*; ``False`` if nothing is synced.
 
         The build reads exports back this way — read-only, no notebook execution — so a
         report missing here just means it hasn't been ``./go publish``ed yet.
         """
+        if self.publish_repo is not None:
+            return self._fetch_export_from_repo(key, dest)
         if not self._remote_has(f'exports/{key}/index.html'):
             return False
         dest.mkdir(parents=True, exist_ok=True)
         self.api.sync_bucket(source=f'hf://buckets/{self.bucket}/exports/{key}', dest=str(dest))
+        return True
+
+    def _fetch_export_from_repo(self, key: str, dest: Path) -> bool:
+        from huggingface_hub import snapshot_download
+
+        repo = self.publish_repo
+        assert repo is not None  # only reached from fetch_export when the publish tier is a repo
+        prefix = f'exports/{key}'
+        if not self.api.file_exists(repo_id=repo, filename=f'{prefix}/index.html', repo_type='dataset'):
+            return False
+        dest.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as d:
+            snap = snapshot_download(
+                repo_id=repo,
+                repo_type='dataset',
+                allow_patterns=f'{prefix}/*',
+                local_dir=d,
+                token=self._token,
+            )
+            src = Path(snap) / prefix
+            for p in src.rglob('*'):  # lift the bundle out of its exports/<key>/ prefix into dest
+                if p.is_file():
+                    out = dest / p.relative_to(src)
+                    out.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(p, out)
         return True

--- a/src/mini/modal_apparatus.py
+++ b/src/mini/modal_apparatus.py
@@ -39,12 +39,14 @@ from mini.progress_display import RichProgressDisplay
 from mini.requirements import project_packages, uv_freeze
 from mini.runs import data_root
 from mini.store import (
+    PUBLISH_REPO_ENV,
     STORE_BUCKET_ENV,
     Artifact,
     LocalStore,
     Store,
     _cas_key,
     _hf_token,
+    publish_repo,
     store_bucket,
     store_context,
     store_for,
@@ -320,7 +322,10 @@ def _hf_store_secret() -> modal.Secret | None:
     token = _hf_token()  # env, or the cached `hf auth login`
     if not token:
         return None
-    return modal.Secret.from_dict({STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token})
+    env: dict[str, str | None] = {STORE_BUCKET_ENV: bucket, 'HF_TOKEN': token}
+    if repo := publish_repo():  # so an in-step publish() targets the same tier as the driver
+        env[PUBLISH_REPO_ENV] = repo
+    return modal.Secret.from_dict(env)
 
 
 def _modal_task_entry(blob: bytes, key: str, gen: str, dict_name: str, volume_name: str, mount_point: str) -> None:

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -76,12 +76,19 @@ __all__ = [
     'store_for',
     'project_store',
     'store_bucket',
+    'publish_repo',
     'STORE_BUCKET_ENV',
+    'PUBLISH_REPO_ENV',
 ]
 
 # Env var naming the project's Hugging Face bucket — an *override* for the
 # `[tool.mini] store-bucket` committed in pyproject.toml (see `store_bucket`).
 STORE_BUCKET_ENV = 'MINI_STORE_BUCKET'
+
+# Env var naming the project's Hugging Face *dataset repo* for the public,
+# versioned publish tier — an override for `[tool.mini] publish-repo`. Unset →
+# publish/exports stay in the (durable) bucket, as before (see `publish_repo`).
+PUBLISH_REPO_ENV = 'MINI_PUBLISH_REPO'
 
 _CHUNK = 1 << 20  # 1 MiB streaming-hash chunk
 
@@ -410,6 +417,20 @@ def store_bucket() -> str | None:
     return os.environ.get(STORE_BUCKET_ENV) or _project_config().get('store-bucket')
 
 
+def publish_repo() -> str | None:
+    """The configured Hugging Face *dataset repo* for the publish tier, or ``None``.
+
+    When set, :meth:`~mini.hf_store.HFStore.publish` and the report-export methods
+    target this public, git-backed dataset repo instead of the durable bucket — so
+    the CAS bucket can be private (persisting an artifact never makes its bytes
+    world-readable) and published views get real history (a citation pins to a
+    commit sha). Unset → publish/exports stay in the bucket, the single-store
+    default. Resolution mirrors :func:`store_bucket` (``MINI_PUBLISH_REPO`` env
+    first, else ``[tool.mini] publish-repo``); the repo id isn't a secret.
+    """
+    return os.environ.get(PUBLISH_REPO_ENV) or _project_config().get('publish-repo')
+
+
 def _hf_token() -> str | None:
     """The Hugging Face token from the env or the ``hf auth login`` cache, or ``None``."""
     if tok := os.environ.get('HF_TOKEN'):
@@ -447,7 +468,7 @@ def store_for(root: Path | str, *, cache_root: Path | str | None = None) -> Stor
         from mini.hf_store import HFStore
 
         cache = LocalStore(cache_root if cache_root is not None else root.parent / 'store-cache' / 'hf')
-        return HFStore(bucket, cache=cache, token=token)
+        return HFStore(bucket, cache=cache, token=token, publish_repo=publish_repo())
     if bucket:
         log.warning(
             'store-bucket %r is configured but no Hugging Face token was found — using the local '

--- a/tests/mini/test_hf_publish_tier.py
+++ b/tests/mini/test_hf_publish_tier.py
@@ -1,0 +1,115 @@
+"""The publish-tier split (#38): routing, not transport.
+
+``HFStore`` keeps the CAS + refs in its bucket but sends ``publish`` and report
+exports to a separate, versioned dataset repo when one is configured. These tests
+inject a fake ``HfApi`` to assert *where* each verb lands and *what* URL it returns,
+without touching the network — the live round trips stay in ``test_hf_store.py``
+(bucket) and its ``MINI_PUBLISH_REPO``-gated repo cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mini.hf_store import HFStore
+from mini.store import Artifact, LocalStore, _hash_bytes
+
+
+class _Info:
+    def __init__(self, xet_hash: str):
+        self.xet_hash = xet_hash
+
+
+class FakeApi:
+    """Records calls; ``present`` toggles whether the CAS claims to hold the blob."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.present = True
+
+    def get_bucket_paths_info(self, bucket, paths):
+        self.calls.append(('get_bucket_paths_info', bucket, tuple(paths)))
+        return [_Info('xhash')] if self.present else []
+
+    def batch_bucket_files(self, bucket, **kw):
+        self.calls.append(('batch_bucket_files', bucket, kw))
+
+    def upload_file(self, **kw):
+        self.calls.append(('upload_file', kw))
+
+    def upload_folder(self, **kw):
+        self.calls.append(('upload_folder', kw))
+
+    def file_exists(self, **kw):
+        self.calls.append(('file_exists', kw))
+        return True
+
+
+def _store(tmp_path: Path, *, publish_repo: str | None = None) -> HFStore:
+    store = HFStore('ns/bkt', cache=LocalStore(tmp_path / 'cache'), token='tok', publish_repo=publish_repo)
+    store._api = FakeApi()
+    return store
+
+
+def _cache_blob(store: HFStore, data: bytes) -> Artifact:
+    """Seed the warm cache so ``has()`` and ``_local_blob()`` resolve offline."""
+    sha = _hash_bytes(data)
+    blob = store._cache._blob_path(sha)
+    blob.parent.mkdir(parents=True, exist_ok=True)
+    blob.write_bytes(data)
+    return Artifact(sha256=sha, size=len(data), name='fig.png')
+
+
+def _verbs(store: HFStore) -> list[str]:
+    return [c[0] for c in store._api.calls]
+
+
+def test_publish_without_repo_copies_in_bucket(tmp_path: Path):
+    store = _store(tmp_path)
+    art = _cache_blob(store, b'\x89PNG')
+    url = store.publish(art, '_x/fig.png')
+    assert url == 'https://huggingface.co/buckets/ns/bkt/resolve/published/_x/fig.png'
+    assert 'batch_bucket_files' in _verbs(store)  # server-side by-hash copy, in the bucket
+    assert 'upload_file' not in _verbs(store)
+
+
+def test_publish_with_repo_uploads_to_dataset(tmp_path: Path):
+    store = _store(tmp_path, publish_repo='ns/pub')
+    art = _cache_blob(store, b'\x89PNG')  # in the CAS, so has() is satisfied from the warm cache
+    url = store.publish(art, '_x/fig.png')
+    assert url == 'https://huggingface.co/datasets/ns/pub/resolve/main/published/_x/fig.png'
+    uploads = [c[1] for c in store._api.calls if c[0] == 'upload_file']
+    assert len(uploads) == 1
+    kw = uploads[0]
+    assert kw['repo_id'] == 'ns/pub'
+    assert kw['repo_type'] == 'dataset'
+    assert kw['path_in_repo'] == 'published/_x/fig.png'
+    assert 'batch_bucket_files' not in _verbs(store)  # nothing lands in the CAS bucket
+
+
+def test_publish_with_repo_needs_the_blob_in_the_cas(tmp_path: Path):
+    store = _store(tmp_path, publish_repo='ns/pub')
+    store._api.present = False  # neither cache nor bucket holds it
+    art = Artifact(sha256='0' * 64, size=1, name='fig.png')
+    with pytest.raises(FileNotFoundError):
+        store.publish(art, '_x/fig.png')
+
+
+def test_export_routes_to_dataset_when_repo_set(tmp_path: Path):
+    store = _store(tmp_path, publish_repo='ns/pub')
+    assert store.export_base('k') == 'https://huggingface.co/datasets/ns/pub/resolve/main/exports/k/'
+    src = tmp_path / 'exp'
+    src.mkdir()
+    (src / 'index.html').write_text('x')
+    store.sync_export(src, 'k')
+    folders = [c[1] for c in store._api.calls if c[0] == 'upload_folder']
+    assert len(folders) == 1
+    assert folders[0]['path_in_repo'] == 'exports/k'
+    assert folders[0]['delete_patterns'] == '*'  # rsync-like: prune assets the report dropped
+
+
+def test_export_base_uses_bucket_without_repo(tmp_path: Path):
+    store = _store(tmp_path)
+    assert store.export_base('k') == 'https://huggingface.co/buckets/ns/bkt/resolve/exports/k/'

--- a/tests/mini/test_hf_store.py
+++ b/tests/mini/test_hf_store.py
@@ -21,10 +21,17 @@ import pytest
 from mini.store import _cas_key
 
 BUCKET = os.environ.get('MINI_STORE_BUCKET')
+PUBLISH_REPO = os.environ.get('MINI_PUBLISH_REPO')
 
 pytestmark = pytest.mark.skipif(
     not (BUCKET and os.environ.get('HF_TOKEN')),
     reason='set MINI_STORE_BUCKET + HF_TOKEN to run the HF bucket integration test',
+)
+
+# The publish-tier cases also need a (public) dataset repo — see the split in #38.
+repo_publish = pytest.mark.skipif(
+    not (BUCKET and PUBLISH_REPO and os.environ.get('HF_TOKEN')),
+    reason='also set MINI_PUBLISH_REPO to run the publish-repo integration test',
 )
 
 
@@ -109,3 +116,72 @@ def test_export_round_trips_over_the_bucket(hf, tmp_path: Path):
     assert (dest / 'index.html').read_text().endswith(tag)
     assert (dest / '_assets' / 'fig.png').read_bytes().endswith(tag.encode())
     assert store.export_base(key) == f'https://huggingface.co/buckets/{BUCKET}/resolve/exports/{key}/'
+
+
+# -- publish tier on a dataset repo (the private-CAS / public-publish split, #38) -----
+
+
+@pytest.fixture
+def hf_repo(tmp_path: Path):
+    """An HFStore whose CAS is the bucket but whose publish tier is a dataset repo.
+
+    Cleans up both sides: the ``cas/`` blobs it wrote to the bucket and the
+    ``published/`` / ``exports/`` files it committed to the repo.
+    """
+    from huggingface_hub import HfApi
+
+    from mini.hf_store import HFStore
+    from mini.store import LocalStore
+
+    assert BUCKET is not None and PUBLISH_REPO is not None  # narrowed by the repo_publish skip
+    tag = secrets.token_hex(4)
+    store = HFStore(BUCKET, cache=LocalStore(tmp_path / 'cache'), publish_repo=PUBLISH_REPO)
+    cas_created: list[str] = []
+    repo_paths: list[str] = []
+    yield store, tag, cas_created, repo_paths
+    api = HfApi(token=os.environ['HF_TOKEN'])
+    if cas_created:
+        api.batch_bucket_files(BUCKET, delete=sorted(set(cas_created)))
+    for p in sorted(set(repo_paths)):
+        try:
+            api.delete_file(path_in_repo=p, repo_id=PUBLISH_REPO, repo_type='dataset')
+        except Exception:  # a test that failed before the upload left nothing to delete
+            pass
+
+
+@repo_publish
+def test_publish_lands_on_the_dataset_repo(hf_repo):
+    store, tag, cas_created, repo_paths = hf_repo
+    png = b'\x89PNG\r\n\x1a\n' + tag.encode()
+    art = store.put(png, name='fig.png')  # into the CAS bucket
+    cas_created.append(_cas_key(art.sha256))
+    path = f'_test/{tag}/fig.png'
+    url = store.publish(art, path)  # copy-through into the public repo
+    repo_paths.append(f'published/{path}')
+
+    assert url == f'https://huggingface.co/datasets/{PUBLISH_REPO}/resolve/main/published/{path}'
+    import requests
+
+    r = requests.get(url, timeout=30)
+    assert r.status_code == 200
+    assert r.content == png  # the resolve URL serves the published bytes back
+
+
+@repo_publish
+def test_export_round_trips_over_the_repo(hf_repo, tmp_path: Path):
+    store, tag, cas_created, repo_paths = hf_repo
+    key = f'_test/{tag}/report'
+    src = tmp_path / 'export'
+    (src / '_assets').mkdir(parents=True)
+    (src / 'index.html').write_text(f'<img src="_assets/fig.png"> {tag}')
+    (src / '_assets' / 'fig.png').write_bytes(b'\x89PNG\r\n\x1a\n' + tag.encode())
+
+    assert store.fetch_export(key, tmp_path / 'miss') is False  # nothing committed yet
+    store.sync_export(src, key)
+    repo_paths += [f'exports/{key}/index.html', f'exports/{key}/_assets/fig.png']
+
+    dest = tmp_path / 'pulled'
+    assert store.fetch_export(key, dest) is True
+    assert (dest / 'index.html').read_text().endswith(tag)
+    assert (dest / '_assets' / 'fig.png').read_bytes().endswith(tag.encode())
+    assert store.export_base(key) == f'https://huggingface.co/datasets/{PUBLISH_REPO}/resolve/main/exports/{key}/'

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -18,6 +18,7 @@ from mini.store import (
     get_ref,
     get_store,
     publish,
+    publish_repo,
     put,
     set_ref,
     store_bucket,
@@ -183,6 +184,38 @@ def test_store_bucket_unset_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv('MINI_STORE_BUCKET', raising=False)
     assert store_bucket() is None
+
+
+def test_publish_repo_reads_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\npublish-repo = "ns/pub"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_PUBLISH_REPO', raising=False)
+    assert publish_repo() == 'ns/pub'
+
+
+def test_publish_repo_env_overrides_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[tool.mini]\npublish-repo = "ns/pub"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('MINI_PUBLISH_REPO', 'other/override')
+    assert publish_repo() == 'other/override'
+
+
+def test_publish_repo_unset_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / 'pyproject.toml').write_text('[project]\nname = "x"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('MINI_PUBLISH_REPO', raising=False)
+    assert publish_repo() is None
+
+
+def test_store_for_threads_publish_repo_into_the_hfstore(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from mini.hf_store import HFStore
+
+    monkeypatch.setenv('MINI_STORE_BUCKET', 'ns/bkt')
+    monkeypatch.setenv('MINI_PUBLISH_REPO', 'ns/pub')
+    monkeypatch.setattr('mini.store._hf_token', lambda: 'tok')
+    store = store_for(tmp_path / 'store')
+    assert isinstance(store, HFStore)
+    assert store.publish_repo == 'ns/pub'  # a bucket for the CAS, a repo for the publish tier
 
 
 def test_store_for_falls_back_to_local_without_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_auth_check.py
+++ b/tests/test_auth_check.py
@@ -64,13 +64,23 @@ def test_modal_failure_surfaces_reason(monkeypatch):
 def test_hf_includes_user_and_bucket(monkeypatch):
     monkeypatch.setattr(auth_check, '_run', fake_run(0, 'user=octocat'))
     monkeypatch.setattr('mini.store.store_bucket', lambda: 'octocat/data-store')
+    monkeypatch.setattr('mini.store.publish_repo', lambda: None)  # publish tier off → not shown
     status = asyncio.run(auth_check.check_hf())
     assert status.ok and status.detail == 'user octocat, bucket octocat/data-store'
+
+
+def test_hf_shows_publish_repo_when_set(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, 'user=octocat'))
+    monkeypatch.setattr('mini.store.store_bucket', lambda: 'octocat/data-store')
+    monkeypatch.setattr('mini.store.publish_repo', lambda: 'octocat/pub')
+    status = asyncio.run(auth_check.check_hf())
+    assert status.ok and status.detail == 'user octocat, bucket octocat/data-store, publish-repo octocat/pub'
 
 
 def test_hf_notes_missing_bucket(monkeypatch):
     monkeypatch.setattr(auth_check, '_run', fake_run(0, 'user=octocat'))
     monkeypatch.setattr('mini.store.store_bucket', lambda: None)
+    monkeypatch.setattr('mini.store.publish_repo', lambda: None)
     status = asyncio.run(auth_check.check_hf())
     assert status.ok and 'no store-bucket set' in status.detail
 


### PR DESCRIPTION
Route `publish` and report exports to a separate, versioned Hugging Face **dataset repo** when one is configured, so the CAS bucket can be **private** while published views stay public and gain history — both halves of #38 in one opt-in seam.

## Why

Today one bucket backs both `cas/`+`refs/` and `published/`+`exports/`, so a **public** bucket makes *every* `put()` world-readable, not just what you `publish()`. HF buckets have no per-prefix ACL, so a private CAS + public publish is a genuine two-store split.

The seam is **write concurrency**, not just visibility:

| Tier | Namespaces | Writer | Concurrency | Backend |
|---|---|---|---|---|
| Durable store | `cas/<sha>`, `refs/` | workers | high, parallel | **bucket** (no git history → no 412) → make **private** |
| Publish tier | `published/`, `exports/` | driver / CI | low, single-writer | **dataset repo** (git history → versioned, citable) → **public** |

The CAS *must* stay a bucket — that's why buckets were chosen (concurrent result writers would 412 on a git-backed shared parent). But `publish`/export are deliberate, single-writer acts, so they can afford a dataset repo, which buys a public face over a private CAS **and** versioned names (a citation pins to `…/resolve/<commit-sha>/published/<path>`).

**Cost:** no extra storage. Xet chunk dedup is account-wide, so publishing pulls the blob local and uploads, but Xet skips every chunk the CAS already stored — a metadata + git-commit op, not a re-transfer.

## What changed

- `HFStore` gains `publish_repo`; `publish`/`export_base`/`sync_export`/`fetch_export` route to the dataset repo when it's set, else the bucket (unchanged). A shared `_local_blob` helper pulls bytes from the CAS so publish can hand them to the repo.
- Config: `[tool.mini] publish-repo` / `MINI_PUBLISH_REPO`, resolved by `publish_repo()` (mirrors `store_bucket`) and threaded through `store_for` and the Modal secret, so an in-step `publish` targets the same tier as the driver.
- Docs: rewrote the publish-tier design in `eng/publishing.md`; updated `eng/storage-backend.md`, `eng/decisions.md`, and the storage skill reference.
- Tests: non-network routing/URL tests (`test_hf_publish_tier.py`) with a fake `HfApi`, config-resolution tests, and `MINI_PUBLISH_REPO`-gated live round-trips in `test_hf_store.py`.

Fully backward compatible: unset `publish-repo` and everything stays in the one bucket, no experiment or report code changes. The existing bucket integration tests still pass live against this environment's bucket.

## Remaining (needs provisioning)

- Create the public dataset repo and flip the existing bucket to private.
- Run the `MINI_PUBLISH_REPO`-gated integration cases against a real repo to confirm the resolve URL serves published bytes and the export round-trip works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmbGMKJSeAhfWB5NLrJnfn)_