### PR TITLE
Make themed figure HTML deterministic across re-exports

### DIFF
--- a/src/mini/vis/nb.py
+++ b/src/mini/vis/nb.py
@@ -164,8 +164,8 @@ def themed_figure_html(
     ``data-asset-name`` attribute on each ``<img>`` for provenance.
     """
     import base64
+    import hashlib
     import html
-    import secrets
     from io import BytesIO
 
     import matplotlib.pyplot as plt
@@ -202,7 +202,10 @@ def themed_figure_html(
     escaped_alt = html.escape(alt_text or 'Plot')
     style = f'max-width: {max_width};' if max_width is not None else ''
     escaped_style = html.escape(style)
-    class_suffix = secrets.token_hex(6)
+    # Derived from the asset name (not random) so re-exporting an unchanged report
+    # produces byte-identical HTML — a random suffix here would churn the report on
+    # every run even though the figures themselves are unchanged.
+    class_suffix = hashlib.sha256(asset_name.encode()).hexdigest()[:12]
     figure_class = f'mini-themed-figure-{class_suffix}'
     no_explicit_theme_selector = (
         'body:not([data-theme="dark"]):not([data-theme="light"])'


### PR DESCRIPTION
Investigated whether reports/figures change from run to run for no real reason (which would cause unnecessary churn in the HFStore).

**Findings:**
- Matplotlib PNG bytes are deterministic across runs (verified empirically) — no embedded creation date, just a `Software: Matplotlib version X` tag that only changes when matplotlib itself is upgraded.
- `themed_figure_html()` in `src/mini/vis/nb.py` picked a random CSS class suffix (`secrets.token_hex(6)`) on every render. That suffix is baked into the report's exported HTML, so re-exporting an *unchanged* report produced different HTML bytes every single time — pure churn, unrelated to the actual figure content.
- Verified with `marimo export html` on `docs/themed.py`: before the fix, two back-to-back exports differed only in the random class names; after the fix, the exports are byte-for-byte identical.

**Fix:** derive the class suffix from the asset's name (`hashlib.sha256(name)[:12]`) instead of `secrets.token_hex`, so the same figure always gets the same class.

This is independent of #64 (the CAS/publish-tier split) — it only touches figure HTML generation, not the store backend, so it applies cleanly regardless of which storage PR lands first.

## Test plan
- [x] `uv run pytest tests/` — 268 passed
- [x] `uv run ruff check` / `uv run ty check` on the changed file
- [x] Exported `docs/themed.py` twice with `marimo export html` before and after the fix — confirmed byte-identical output after the fix (previously differed on every export)


---
_Generated by [Claude Code](https://claude.ai/code/session_01T6PDiUjxXm28evTDisEq2c)_