### PR TITLE
Add `./go auth --check` credential status probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,5 @@ This project uses `uv`, `ruff`, and `ty`.
 Also available: `fd`, `fzf`, `rg`, `bat`, `gh`. We can add more to the dev container if you have other preferred tools.
 
 For reading/editing TOML (e.g. `pyproject.toml`) from the CLI, prefer `tomlq` (part of the `yq` package) over writing a one-off Python script, e.g. `uvx --from yq tomlq '.tool.mini' pyproject.toml`. (Plain `uvx tomlq` won't work — `tomlq` is an entry point inside the `yq` package, not its own PyPI package.)
+
+Modal and Hugging Face are usually already authenticated in a web session — run `./go auth --check` to confirm what's available (fast, and prints status without echoing any token).

--- a/go
+++ b/go
@@ -88,8 +88,9 @@ case "${1:-all}" in
     *)
         # Important: heredoc indented with tab characters.
         cat <<-EOF 1>&2
-			Usage: $0 {check|lint|format|types|tests|export|open|publish|build|scrub|serve}
+			Usage: $0 {auth|check|lint|format|types|tests|export|open|publish|build|scrub|serve}
 			  install:           install dependencies (uv sync) and git hooks
+			  auth   [--check]:  set up credentials, or --check to just probe & print their status
 			  check  [...args]:  run all checks in parallel (--lint --format --typecheck --test --fix)
 			  format [...args]:  format code (ruff format)
 			  lint   [...args]:  run linters (ruff check)

--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -5,9 +5,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 URL_MODE=open
+CHECK=
 for arg in "$@"; do
-    [[ "$arg" == "--qr" ]] && URL_MODE=qr
+    case "$arg" in
+        --qr) URL_MODE=qr ;;
+        --check|--status|-c) CHECK=1 ;;
+    esac
 done
+
+# `--check`: just probe the tokens (in parallel) and print their statuses —
+# no interactive setup, no secrets echoed. Handy for confirming Modal/HF are
+# already authenticated without poking the raw tools.
+if [[ -n "$CHECK" ]]; then
+    exec uv run "$SCRIPT_DIR/auth_check.py"
+fi
 
 intercept() {
     uv run "$SCRIPT_DIR/intercept_urls.py" "--$URL_MODE" "$@"

--- a/scripts/auth_check.py
+++ b/scripts/auth_check.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Fast, non-interactive credential status check (`./go auth --check`).
+
+Agents (and humans) often don't realise Modal and Hugging Face are already
+authenticated in a fresh shell — and poking at the raw tools to find out can
+spill a token into a transcript. This runs each provider's real CLI
+concurrently and reports only whether the credential works plus safe metadata
+(workspace, bucket, user); never the secret itself.
+
+Every probe runs with stdin closed and a timeout, so an unauthenticated tool
+reports "not logged in" instead of blocking on a prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import sys
+from asyncio.subprocess import DEVNULL, PIPE
+from collections.abc import Callable, Coroutine
+from typing import Any
+from dataclasses import dataclass
+
+
+@dataclass
+class Status:
+    label: str
+    ok: bool
+    detail: str = ''
+
+    def line(self) -> str:
+        mark = '✅' if self.ok else '❌'
+        return f'  {mark} {self.label:<18} {self.detail}'.rstrip()
+
+
+async def _run(*cmd: str, timeout: float = 15.0) -> tuple[int, str, str]:
+    """Run *cmd*, returning ``(returncode, stdout, stderr)``.
+
+    Closes stdin so a tool that would prompt fails fast, and kills the child on
+    timeout. A missing binary is reported as code 127 (like a shell would).
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(*cmd, stdin=DEVNULL, stdout=PIPE, stderr=PIPE)
+    except FileNotFoundError, PermissionError:
+        return 127, '', 'not installed'
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return -1, '', f'timed out after {timeout:g}s'
+    return proc.returncode or 0, out.decode('utf-8', 'replace'), err.decode('utf-8', 'replace')
+
+
+def _fail_reason(code: int, out: str, err: str) -> str:
+    """A short reason for a failed probe, preferring the tool's own message."""
+    if err.strip() == 'not installed':
+        return 'not installed'
+    # hf prints a version "Hint:" to stderr even on success — skip those.
+    for line in (err + '\n' + out).splitlines():
+        line = line.strip()
+        if line and not line.lower().startswith('hint:') and 'warning:' not in line.lower():
+            return line
+    return f'exit {code}'
+
+
+# -- per-provider probes -----------------------------------------------------
+#
+# Each returns a Status. The token itself is never included in `detail`.
+
+
+async def check_modal() -> Status:
+    code, out, err = await _run('modal', 'token', 'info')
+    if code != 0:
+        return Status('Modal', False, _fail_reason(code, out, err))
+    # The line reads "Workspace: <name> (<internal-id>)"; keep the name, drop the id.
+    match = re.search(r'^\s*Workspace:\s*(\S+)', out, re.MULTILINE)
+    workspace = match.group(1) if match else ''
+    return Status('Modal', True, f'workspace {workspace}' if workspace else 'authenticated')
+
+
+async def check_hf() -> Status:
+    from mini.store import store_bucket
+
+    code, out, err = await _run('hf', 'auth', 'whoami')
+    text = out + err
+    if code != 0 or 'not logged in' in text.lower():
+        return Status('Hugging Face', False, 'not logged in — run ./go auth')
+    # `hf auth whoami` prints `user=<name>`; fall back to the first plain line.
+    match = re.search(r'^\s*user[=:]\s*(\S+)', out, re.MULTILINE | re.IGNORECASE)
+    user = match.group(1) if match else next((ln.strip() for ln in out.splitlines() if ln.strip()), '')
+    bucket = store_bucket()
+    parts = [p for p in (f'user {user}' if user else '', f'bucket {bucket}' if bucket else 'no store-bucket set') if p]
+    return Status('Hugging Face', True, ', '.join(parts))
+
+
+async def check_wandb() -> Status:
+    code, out, err = await _run('wandb', 'status')
+    if code != 0:
+        return Status('Weights & Biases', False, _fail_reason(code, out, err))
+    match = re.search(r'\{.*\}', out + err, re.DOTALL)
+    settings = json.loads(match.group()) if match else {}
+    if not settings.get('api_key'):
+        return Status('Weights & Biases', False, 'no API key — run ./go auth')
+    entity = settings.get('entity')
+    return Status('Weights & Biases', True, f'entity {entity}' if entity else 'authenticated')
+
+
+async def check_github() -> Status:
+    code, out, err = await _run('gh', 'auth', 'status')
+    text = out + err
+    if code != 0:
+        return Status('GitHub', False, 'not installed' if 'not installed' in err else 'not logged in — run ./go auth')
+    match = re.search(r'account (\S+)', text)
+    return Status('GitHub', True, f'account {match.group(1)}' if match else 'authenticated')
+
+
+async def check_claude() -> Status:
+    code, out, err = await _run('claude', 'auth', 'status')
+    if code != 0:
+        return Status(
+            'Claude Code', False, 'not installed' if 'not installed' in err else 'not logged in — run ./go auth'
+        )
+    return Status('Claude Code', True, 'authenticated')
+
+
+def _relevant_checks() -> list[Callable[[], Coroutine[Any, Any, Status]]]:
+    """The probes worth running in this environment.
+
+    Modal and Hugging Face (the resources agents miss) always run. The other two
+    are context-dependent:
+
+    - Skip GitHub on Claude Code for the web (``CLAUDE_CODE_REMOTE``): there GitHub
+      is reached through the MCP tools, ``gh`` isn't installed, and the network
+      policy blocks its API — so a ❌ would be noise, not signal.
+    - Skip the Claude Code check when Claude itself is the caller (``CLAUDECODE``):
+      its own auth is irrelevant to the run.
+    """
+    checks: list[Callable[[], Coroutine[Any, Any, Status]]] = [check_modal, check_hf, check_wandb]
+    if os.environ.get('CLAUDE_CODE_REMOTE') != 'true':
+        checks.append(check_github)
+    if not os.environ.get('CLAUDECODE'):
+        checks.append(check_claude)
+    return checks
+
+
+async def _gather() -> list[Status]:
+    return list(await asyncio.gather(*(check() for check in _relevant_checks())))
+
+
+def main() -> int:
+    print('Checking credentials…\n', file=sys.stderr)
+    statuses = asyncio.run(_gather())
+    for status in statuses:
+        print(status.line())
+    return 0 if all(s.ok for s in statuses) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_auth_check.py
+++ b/tests/test_auth_check.py
@@ -1,0 +1,146 @@
+"""Tests for the credential status probe (`./go auth --check`).
+
+The parsing helpers are pure; the per-provider checks shell out through a single
+`_run`, so we drive them by swapping in a fake that returns canned tool output.
+"""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    'auth_check', Path(__file__).resolve().parent.parent / 'scripts' / 'auth_check.py'
+)
+assert _SPEC and _SPEC.loader
+auth_check = importlib.util.module_from_spec(_SPEC)
+sys.modules['auth_check'] = auth_check  # so @dataclass can resolve the module by name
+_SPEC.loader.exec_module(auth_check)
+
+
+def fake_run(code: int, out: str = '', err: str = ''):
+    """A stand-in for `_run` that ignores the command and returns canned output."""
+
+    async def _run(*cmd: str, timeout: float = 15.0):
+        return code, out, err
+
+    return _run
+
+
+# -- pure helpers ------------------------------------------------------------
+
+
+def test_fail_reason_skips_noise():
+    # A version hint and a uv warning shouldn't masquerade as the failure reason.
+    err = 'warning: UV_NATIVE_TLS is deprecated\nHint: a new version is available\nNot logged in'
+    assert auth_check._fail_reason(1, '', err) == 'Not logged in'
+
+
+def test_fail_reason_falls_back_to_exit_code():
+    assert auth_check._fail_reason(2, '', '') == 'exit 2'
+
+
+def test_status_line_marks_and_trims():
+    assert auth_check.Status('Modal', True, 'workspace acme').line() == '  ✅ Modal              workspace acme'
+    assert auth_check.Status('Modal', True, '').line() == '  ✅ Modal'
+    assert auth_check.Status('Modal', False, 'nope').line().startswith('  ❌')
+
+
+# -- per-provider probes -----------------------------------------------------
+
+
+def test_modal_reports_workspace_without_id(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, 'Workspace: acme-corp (ac-1a2b)\nUser: someone'))
+    status = asyncio.run(auth_check.check_modal())
+    assert status.ok and status.detail == 'workspace acme-corp'
+
+
+def test_modal_failure_surfaces_reason(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(1, '', 'Token missing'))
+    status = asyncio.run(auth_check.check_modal())
+    assert not status.ok and status.detail == 'Token missing'
+
+
+def test_hf_includes_user_and_bucket(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, 'user=octocat'))
+    monkeypatch.setattr('mini.store.store_bucket', lambda: 'octocat/data-store')
+    status = asyncio.run(auth_check.check_hf())
+    assert status.ok and status.detail == 'user octocat, bucket octocat/data-store'
+
+
+def test_hf_notes_missing_bucket(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, 'user=octocat'))
+    monkeypatch.setattr('mini.store.store_bucket', lambda: None)
+    status = asyncio.run(auth_check.check_hf())
+    assert status.ok and 'no store-bucket set' in status.detail
+
+
+def test_hf_not_logged_in(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(1, '', 'Not logged in'))
+    status = asyncio.run(auth_check.check_hf())
+    assert not status.ok
+
+
+def test_wandb_reads_entity_from_json(monkeypatch):
+    out = '{\n  "api_key": "secret",\n  "entity": "acme"\n}'
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, out))
+    status = asyncio.run(auth_check.check_wandb())
+    assert status.ok and status.detail == 'entity acme'
+
+
+def test_wandb_null_api_key_is_failure(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, '{"api_key": null, "entity": null}'))
+    status = asyncio.run(auth_check.check_wandb())
+    assert not status.ok and 'no API key' in status.detail
+
+
+def test_github_extracts_account(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(0, '', '✓ Logged in to github.com account octocat (keyring)'))
+    status = asyncio.run(auth_check.check_github())
+    assert status.ok and status.detail == 'account octocat'
+
+
+def test_missing_binary_reports_not_installed(monkeypatch):
+    monkeypatch.setattr(auth_check, '_run', fake_run(127, '', 'not installed'))
+    status = asyncio.run(auth_check.check_github())
+    assert not status.ok and status.detail == 'not installed'
+
+
+# -- environment-aware selection ---------------------------------------------
+
+
+def test_all_checks_run_by_default(monkeypatch):
+    monkeypatch.delenv('CLAUDE_CODE_REMOTE', raising=False)
+    monkeypatch.delenv('CLAUDECODE', raising=False)
+    assert auth_check._relevant_checks() == [
+        auth_check.check_modal,
+        auth_check.check_hf,
+        auth_check.check_wandb,
+        auth_check.check_github,
+        auth_check.check_claude,
+    ]
+
+
+def test_github_skipped_on_the_web(monkeypatch):
+    # On Claude Code for the web GitHub goes through MCP tools, not `gh`.
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', 'true')
+    monkeypatch.delenv('CLAUDECODE', raising=False)
+    assert auth_check.check_github not in auth_check._relevant_checks()
+    assert auth_check.check_claude in auth_check._relevant_checks()
+
+
+def test_claude_check_skipped_when_claude_is_the_caller(monkeypatch):
+    monkeypatch.delenv('CLAUDE_CODE_REMOTE', raising=False)
+    monkeypatch.setenv('CLAUDECODE', '1')
+    assert auth_check.check_claude not in auth_check._relevant_checks()
+    assert auth_check.check_github in auth_check._relevant_checks()
+
+
+def test_web_agent_runs_only_service_checks(monkeypatch):
+    monkeypatch.setenv('CLAUDE_CODE_REMOTE', 'true')
+    monkeypatch.setenv('CLAUDECODE', '1')
+    assert auth_check._relevant_checks() == [
+        auth_check.check_modal,
+        auth_check.check_hf,
+        auth_check.check_wandb,
+    ]


### PR DESCRIPTION
A fast, non-interactive way to see which credentials are present and working — without echoing any secret.

Agents (and humans) often don't realise Modal and Hugging Face are already authenticated in a fresh shell, and poking at the raw tools to find out tends to spill a token into the transcript. `./go auth --check` (also `--status` / `-c`) runs each provider's real CLI concurrently and prints only whether the credential works plus safe metadata — never the token itself. In a web agent session:

```
  ✅ Modal              workspace xyz
  ✅ Hugging Face       user xyz, bucket xyz/store
  ❌ Weights & Biases   no API key — run ./go auth
```

Details:

- **Real tools, in parallel.** Each probe (`modal token info`, `hf auth whoami`, `wandb status`, plus `gh`/`claude` where relevant) is spawned concurrently via asyncio, so the whole check runs in ~1–2s (dominated by `uv run` startup) rather than serially. Presence-sniffing token files would be faster still, but would duplicate each tool's notion of "where's my credential" and drift; calling the tool is the source of truth.
- **No leaks.** Probes run with stdin closed and a timeout, so an unauthenticated tool reports "not logged in" instead of blocking on a prompt, and only parsed metadata (Modal workspace, HF user + configured `store-bucket`, WandB entity, GitHub account) reaches the output — the raw tool output (which can contain the key) never does.
- **Context-aware.** On Claude Code for the web (`CLAUDE_CODE_REMOTE`), the GitHub probe is skipped — there GitHub is reached through the MCP tools, `gh` isn't installed, and the network policy blocks its API, so a ❌ would be noise. When Claude itself is the caller (`CLAUDECODE`), the Claude Code auth probe is skipped as irrelevant. Modal and HF — the resources agents most often miss — always run.
- **Documented in AGENTS.md** so it's in-context from the first turn: Modal/HF are usually already authenticated in a web session, and `./go auth --check` is the safe way to confirm what's available.
- **Composable.** Exit code is non-zero when any credential that was checked is missing.

`scripts/auth_check.py` holds the logic; `auth.sh` short-circuits to it on `--check` before the interactive setup flow. Parsing helpers, per-provider probes, and the environment-aware selection are unit-tested (`tests/test_auth_check.py`) by swapping in canned tool output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8wjgKzcJaPWnVWRrXrU7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8wjgKzcJaPWnVWRrXrU7R)_