### PR TITLE
Let a publish-repo alone build the store, so CI needs only one var (#38)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,18 +40,21 @@ jobs:
 
       - name: Build Site
         # Read-only, deterministic half of publishing: build_site pulls each synced
-        # bundle from the publish tier (the dataset repo when MINI_PUBLISH_REPO is set,
-        # else the bucket), resolves author links against this checkout, inserts one
-        # <base href> at exports/<key>/, and writes the HTML into _site. The assets stay
-        # on the CDN; the agent did the export+upload (`./go publish`). A read-only
-        # HF_TOKEN suffices — this job never writes or runs a notebook. (A report not yet
-        # published is skipped with a warning, not an error.)
+        # bundle from the publish tier, resolves author links against this checkout,
+        # inserts one <base href> at exports/<key>/, and writes the HTML into _site. The
+        # assets stay on the CDN; the agent did the export+upload (`./go publish`). A
+        # read-only HF_TOKEN suffices — this job never writes or runs a notebook. (A
+        # report not yet published is skipped with a warning, not an error.)
+        #
+        # Set *whichever* variable matches your store layout — an undefined repo variable
+        # expands to '' and is treated as unset, so leaving one blank is fine:
+        #   - split store (#38): MINI_PUBLISH_REPO alone → serve exports off the public
+        #     dataset repo (the bucket can be private; the build never reads it).
+        #   - single bucket (default): MINI_STORE_BUCKET → serve exports off the bucket.
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          MINI_STORE_BUCKET: ${{ vars.MINI_STORE_BUCKET }}
-          # Set the MINI_PUBLISH_REPO repo variable to serve the site off the public
-          # dataset repo — required once the CAS bucket is flipped private (#38).
           MINI_PUBLISH_REPO: ${{ vars.MINI_PUBLISH_REPO }}
+          MINI_STORE_BUCKET: ${{ vars.MINI_STORE_BUCKET }}
         run: ./go build
 
       - name: Setup Pages

--- a/eng/publishing.md
+++ b/eng/publishing.md
@@ -83,6 +83,10 @@ Two further decisions:
   and a report accumulates no orphans (the name is also what a browser "Save as"
   suggests, since the bucket sets no `Content-Disposition`).
 - **Publish/build split by trigger.** `./go publish` (authenticated, runs the notebook,
-  writes the bucket) is the heavy half; the CI build is **read-only** — it pulls each
-  bundle, resolves links, inserts the `<base>`, and never writes the bucket or runs a
-  notebook, so a read-only token suffices.
+  writes the store) is the heavy half; the CI build is **read-only** — it pulls each
+  bundle, resolves links, inserts the `<base>`, and never writes or runs a notebook, so
+  a read-only token suffices. When the publish tier is split off (#38) the build reads
+  exports straight from the public dataset repo and never touches the CAS, so CI needs
+  only `MINI_PUBLISH_REPO` — not the (now private) bucket. `store_for` builds a CAS-less
+  store from a `publish-repo` alone for exactly this; the single-bucket default still
+  serves the build off `MINI_STORE_BUCKET`. Set whichever your store layout uses.

--- a/src/mini/hf_store.py
+++ b/src/mini/hf_store.py
@@ -57,12 +57,16 @@ class HFStore(Store):
 
     def __init__(
         self,
-        bucket: str,
+        bucket: str | None,
         *,
         cache: LocalStore,
         token: str | None = None,
         publish_repo: str | None = None,
     ):
+        # ``None`` is the publish-only store: no CAS bucket, just the dataset repo
+        # for reading/serving exports (the read-only site build, which never touches
+        # the CAS). CAS/ref operations raise via :attr:`_cas`. A publish_repo must be
+        # set in that case — ``store_for`` only builds this with a bucket *or* a repo.
         self.bucket = bucket
         # The public, versioned publish tier: a Hugging Face *dataset* repo (real git
         # history → a citation pins to a commit sha) that backs publish() and report
@@ -81,6 +85,21 @@ class HFStore(Store):
             self._api = HfApi(token=self._token)
         return self._api
 
+    @property
+    def _cas(self) -> str:
+        """The bucket backing the CAS/refs — or a clear error if this store is publish-only.
+
+        A store built from a publish-repo alone (no ``store-bucket``) can serve exports
+        but has nowhere to put/get blobs, so every CAS/ref path narrows through here.
+        """
+        if self.bucket is None:
+            raise RuntimeError(
+                'this store has no CAS bucket — it was built from a publish-repo alone '
+                '(read-only export serving). Set store-bucket (or MINI_STORE_BUCKET) to '
+                'put/get/ref against the content-addressed store.'
+            )
+        return self.bucket
+
     # -- existence / cache ----------------------------------------------------
 
     def _remote_has(self, path: str) -> bool:
@@ -90,7 +109,7 @@ class HFStore(Store):
         from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 
         try:
-            return any(True for _ in self.api.get_bucket_paths_info(self.bucket, [path]))
+            return any(True for _ in self.api.get_bucket_paths_info(self._cas, [path]))
         except EntryNotFoundError, RepositoryNotFoundError:
             return False
 
@@ -106,7 +125,7 @@ class HFStore(Store):
     def _write_blob(self, sha256: str, src: Path) -> None:
         # Reached only on a cache+remote miss (the base ``put`` checks ``has``
         # first); Xet still dedups the chunks if the bytes happen to exist.
-        self.api.batch_bucket_files(self.bucket, add=[(str(src), _cas_key(sha256))])
+        self.api.batch_bucket_files(self._cas, add=[(str(src), _cas_key(sha256))])
         self._cache_blob(sha256, src)
 
     def _local_blob(self, sha256: str) -> Path:
@@ -120,7 +139,7 @@ class HFStore(Store):
         blob = self._cache._blob_path(sha256)
         if not blob.exists():  # pull once into the warm cache, then serve locally
             blob.parent.mkdir(parents=True, exist_ok=True)
-            self.api.download_bucket_files(self.bucket, files=[(_cas_key(sha256), str(blob))])
+            self.api.download_bucket_files(self._cas, files=[(_cas_key(sha256), str(blob))])
         return blob
 
     def _read_blob(self, sha256: str, dest: Path) -> None:
@@ -141,14 +160,14 @@ class HFStore(Store):
                 add.append((str(p), _cas_key(sha)))
             self._cache_blob(sha, p)
         if add:
-            self.api.batch_bucket_files(self.bucket, add=add)  # one round trip for the set
+            self.api.batch_bucket_files(self._cas, add=add)  # one round trip for the set
         kids = tuple(children)
         return Artifact(sha256=_tree_sha(kids), size=sum(c.size for c in kids), name=name, kind='tree', children=kids)
 
     # -- refs -----------------------------------------------------------------
 
     def _write_ref(self, name: str, payload: str) -> None:
-        self.api.batch_bucket_files(self.bucket, add=[(payload.encode(), f'refs/{name}.json')])
+        self.api.batch_bucket_files(self._cas, add=[(payload.encode(), f'refs/{name}.json')])
 
     def _read_ref(self, name: str) -> str | None:
         path = f'refs/{name}.json'
@@ -156,7 +175,7 @@ class HFStore(Store):
             return None
         with tempfile.TemporaryDirectory() as d:  # cleaned up, unlike a bare mkdtemp
             tmp = Path(d) / 'ref.json'
-            self.api.download_bucket_files(self.bucket, files=[(path, str(tmp))])
+            self.api.download_bucket_files(self._cas, files=[(path, str(tmp))])
             return tmp.read_text()
 
     # -- publish --------------------------------------------------------------
@@ -170,15 +189,16 @@ class HFStore(Store):
 
     def _publish_to_bucket(self, art: Artifact, path: str) -> str:
         """The single-store default: expose a CAS blob in-bucket under ``published/``."""
-        info = list(self.api.get_bucket_paths_info(self.bucket, [_cas_key(art.sha256)]))
+        bucket = self._cas
+        info = list(self.api.get_bucket_paths_info(bucket, [_cas_key(art.sha256)]))
         if not info:
             raise FileNotFoundError(f'{art.sha256[:12]}… is not in the store — put() it before publish()')
         # Server-side copy *by xet hash*: a metadata op, no bytes moved. The
         # extensioned destination is what makes the resolve URL serve a real
         # Content-Type (a bare cas/<sha> has none).
         dest = f'published/{path}'
-        self.api.batch_bucket_files(self.bucket, copy=[('bucket', self.bucket, info[0].xet_hash, dest)])
-        return f'https://huggingface.co/buckets/{self.bucket}/resolve/{dest}'
+        self.api.batch_bucket_files(bucket, copy=[('bucket', bucket, info[0].xet_hash, dest)])
+        return f'https://huggingface.co/buckets/{bucket}/resolve/{dest}'
 
     def _publish_to_repo(self, art: Artifact, path: str) -> str:
         """Expose a CAS blob on the public, versioned dataset repo (see :func:`publish_repo`).
@@ -210,7 +230,7 @@ class HFStore(Store):
         from huggingface_hub.errors import EntryNotFoundError
 
         try:
-            yield from self.api.list_bucket_tree(self.bucket, prefix=prefix, recursive=True)
+            yield from self.api.list_bucket_tree(self._cas, prefix=prefix, recursive=True)
         except EntryNotFoundError:
             return
 
@@ -227,7 +247,7 @@ class HFStore(Store):
     def delete_blobs(self, sha256s: Iterable[str]) -> None:
         shas = list(sha256s)
         for i in range(0, len(shas), 500):  # one commit per chunk, not per blob
-            self.api.batch_bucket_files(self.bucket, delete=[_cas_key(s) for s in shas[i : i + 500]])
+            self.api.batch_bucket_files(self._cas, delete=[_cas_key(s) for s in shas[i : i + 500]])
         # Purge the warm cache too: a stale local copy would make ``has`` claim
         # the bucket still holds bytes it no longer does, and a later ``put`` of
         # the same content would silently skip the re-upload.

--- a/src/mini/store.py
+++ b/src/mini/store.py
@@ -461,20 +461,32 @@ def store_for(root: Path | str, *, cache_root: Path | str | None = None) -> Stor
     a fresh checkout before ``./go auth``) falls back to the local store with a
     warning rather than failing mid-run — the bucket name travels with the repo,
     but using it needs auth the trier doesn't have yet.
+
+    A :func:`publish_repo` alone (no bucket) also yields an :class:`HFStore`, but a
+    CAS-less one: it serves ``publish``/exports from the dataset repo and errors on
+    put/get/ref. That's the read-only site build's store — it reads exports off the
+    public repo, so CI needs only ``MINI_PUBLISH_REPO``, not the private bucket (#38).
     """
     root = Path(root)
-    bucket = store_bucket()
-    if bucket and (token := _hf_token()):
-        from mini.hf_store import HFStore
-
-        cache = LocalStore(cache_root if cache_root is not None else root.parent / 'store-cache' / 'hf')
-        return HFStore(bucket, cache=cache, token=token, publish_repo=publish_repo())
-    if bucket:
+    bucket, repo = store_bucket(), publish_repo()
+    token = _hf_token()
+    # A configured bucket needs a token (the CAS is usually private), so fall back to
+    # the local store rather than failing a fresh checkout mid-run. A publish-repo on
+    # its own needs no bucket — the read-only site build serves exports straight from
+    # the (public) dataset repo — so it's enough by itself to build the networked
+    # store, and CI can point at the repo without also naming the private bucket (#38).
+    if bucket and not token:
         log.warning(
             'store-bucket %r is configured but no Hugging Face token was found — using the local '
             'store instead. Run `./go auth` (or set HF_TOKEN) to read/write the shared bucket.',
             bucket,
         )
+        return LocalStore(root)
+    if bucket or repo:
+        from mini.hf_store import HFStore
+
+        cache = LocalStore(cache_root if cache_root is not None else root.parent / 'store-cache' / 'hf')
+        return HFStore(bucket, cache=cache, token=token, publish_repo=repo)
     return LocalStore(root)
 
 

--- a/tests/mini/test_store.py
+++ b/tests/mini/test_store.py
@@ -225,6 +225,29 @@ def test_store_for_falls_back_to_local_without_token(tmp_path: Path, monkeypatch
     assert isinstance(store_for(tmp_path / 'store'), LocalStore)
 
 
+def test_store_for_builds_a_publish_only_store_from_a_repo_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A publish-repo with no bucket → a CAS-less HFStore for read-only export serving (the CI build)."""
+    from mini.hf_store import HFStore
+
+    monkeypatch.setattr('mini.store.store_bucket', lambda: None)  # no CAS bucket configured
+    monkeypatch.setattr('mini.store.publish_repo', lambda: 'ns/pub')
+    monkeypatch.setattr('mini.store._hf_token', lambda: None)  # a public repo needs no token
+    store = store_for(tmp_path / 'store')
+    assert isinstance(store, HFStore)
+    assert store.bucket is None and store.publish_repo == 'ns/pub'
+    # It can still serve exports — that's the whole point (build reads exports off the repo).
+    assert store.export_base('demo') == 'https://huggingface.co/datasets/ns/pub/resolve/main/exports/demo/'
+
+
+def test_publish_only_store_errors_on_cas_operations(tmp_path: Path):
+    """A CAS-less store names the missing config rather than failing opaquely on the bucket call."""
+    from mini.hf_store import HFStore
+
+    store = HFStore(None, cache=LocalStore(tmp_path / 'cache'), publish_repo='ns/pub')
+    with pytest.raises(RuntimeError, match='no CAS bucket'):
+        store.list_refs()
+
+
 def test_store_for_uses_bucket_with_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from mini.hf_store import HFStore
 


### PR DESCRIPTION
Follow-up to #64. Removes a footgun the migration surfaced: the read-only site build had to name the (now private) CAS bucket just to fetch report exports it never reads from the bucket.

## What changed

`store_for` used to construct the networked `HFStore` **only** when `MINI_STORE_BUCKET` was set — `publish_repo` was read *inside* that store. So a CI build pointed only at the public dataset repo would silently fall back to `LocalStore` and fetch nothing. And once the CAS bucket goes private, keeping `MINI_STORE_BUCKET` in CI reads as "what is the build doing with the private bucket?" — when the honest answer is *nothing*.

Now:

- **`store_for` builds an `HFStore` when *either* a bucket or a publish-repo is configured.** With a publish-repo alone it's a **CAS-less store**: it serves `publish`/exports off the dataset repo and raises a clear error on `put`/`get`/ref.
- **`HFStore` accepts `bucket: str | None`.** Every CAS/ref/gc path narrows through a new `_cas` property that raises a descriptive `RuntimeError` ("this store has no CAS bucket…") instead of failing opaquely on the API call. The `publish_repo`-gated export methods are unaffected.
- **The Pages workflow forwards both `MINI_PUBLISH_REPO` and `MINI_STORE_BUCKET`**, each empty-string-safe when its repo variable is undefined. A project sets **whichever** matches its store layout — split store (#38) → `MINI_PUBLISH_REPO` alone; single-bucket default → `MINI_STORE_BUCKET`.

## Verification

- `ruff` + `ty` clean; `tests/mini/test_store.py` (+ publish-tier) pass, including two new tests: `store_for` from a repo alone yields a CAS-less `HFStore` that still resolves `export_base`, and CAS ops on it raise `no CAS bucket`.
- End-to-end: `env -u MINI_STORE_BUCKET MINI_PUBLISH_REPO=z0u/mi-ni-pub ./go build` resolves `asset mode: externalize ← z0u/mi-ni-pub` and pulls every report bundle from the repo — no bucket named, `<base>` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmbGMKJSeAhfWB5NLrJnfn)_