### PR TITLE
Clear MINI_PUBLISH_REPO alongside MINI_STORE_BUCKET in local-store tests

### DIFF
--- a/tests/mini/test_apparatus.py
+++ b/tests/mini/test_apparatus.py
@@ -255,6 +255,7 @@ def test_memo_worker_mounts_hf_cache(monkeypatch):
     from mini.modal_apparatus import HF_CACHE_MOUNT
 
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     secrets_made: list[dict] = []
     monkeypatch.setattr("modal.Secret.from_dict", lambda d: secrets_made.append(d) or ("secret", d))
     app = _make_modal(monkeypatch)
@@ -379,6 +380,7 @@ def test_interactive_local_map_resolves_ambient_store(tmp_path: Path, monkeypatc
     from mini.store import get, put
 
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)  # force a LocalStore
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     app = LocalApparatus("exp", data_dir=tmp_path / "exp")
 
     def fn(x):
@@ -398,6 +400,7 @@ def test_wrap_for_modal_binds_store_under_data_dir(tmp_path: Path, monkeypatch):
     from mini.store import LocalStore, get_store
 
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)  # force a LocalStore
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
 
     def fn():
         store = get_store()

--- a/tests/mini/test_experiments_e2e.py
+++ b/tests/mini/test_experiments_e2e.py
@@ -36,10 +36,12 @@ def _local_store_only(monkeypatch: pytest.MonkeyPatch):
     """Exercise the *local* project store, hermetically.
 
     These demos test orchestration + the on-disk store; an ambient ``MINI_STORE_BUCKET``
-    (a configured HF bucket) would divert their put/get to the network and break the
-    local-CAS assertions. The bucket backend has its own coverage in ``test_hf_store``.
+    or ``MINI_PUBLISH_REPO`` (a configured HF bucket or publish repo) would divert their
+    put/get to the network and break the local-CAS assertions. The bucket backend has
+    its own coverage in ``test_hf_store``.
     """
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
 
 
 def _drive(exp: Experiment, app: LocalApparatus, timeout: float = 60.0):

--- a/tests/mini/test_store_gc.py
+++ b/tests/mini/test_store_gc.py
@@ -140,6 +140,7 @@ def test_artifact_shas_prunes_at_callables():
 def test_sidecar_indexes_result_blobs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     app = LocalApparatus("sidecar")
     _drive(_sweep("sidecar", _put_step(), [1]), app)
 
@@ -157,6 +158,7 @@ def test_stale_sidecar_swept_as_attempt_file(tmp_path: Path, monkeypatch: pytest
     """A sidecar under a replaced generation is unreachable, so the memo sweep collects it."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     app = LocalApparatus("stale-side")
     _drive(_sweep("stale-side", _put_step(), [1]), app)
     store = app.memo_store()
@@ -241,6 +243,7 @@ def test_roots_note_expired_modal_plane():
 def test_sweep_keeps_referenced_and_ref_pinned_collects_orphan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     app = LocalApparatus("cas")
     _drive(_sweep("cas", _put_step(), [1]), app)
     store = store_for(data_root() / "store")
@@ -263,6 +266,7 @@ def test_sweep_keeps_referenced_and_ref_pinned_collects_orphan(tmp_path: Path, m
 def test_grace_window_keeps_young_blobs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     store = store_for(data_root() / "store")
     fresh = store.put(b"just written", name="fresh.bin")
 
@@ -281,6 +285,7 @@ def test_superseded_record_pins_its_blob_until_memo_gc(tmp_path: Path, monkeypat
     ``mini gc <name>`` removes the record."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     app = LocalApparatus("pin")
     _drive(_sweep("pin", _put_step(), [1, 2]), app)
     _drive(_sweep("pin", _put_step(), [1]), app)  # input 2 removed → its record superseded
@@ -448,6 +453,7 @@ def _store_ns(**kw) -> argparse.Namespace:
 def test_cmd_gc_store_dry_run_then_apply(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MINI_STORE_BUCKET", raising=False)
+    monkeypatch.delenv("MINI_PUBLISH_REPO", raising=False)
     from mini.__main__ import cmd_gc
 
     app = LocalApparatus("clistore")


### PR DESCRIPTION
`store_for()` (`src/mini/store.py`) treats a configured `publish-repo` alone as enough to build a networked `HFStore` — a CAS-less, read-only one meant for the public site build (#38 / #68). Nine tests that want a plain on-disk `LocalStore` were only clearing `MINI_STORE_BUCKET`, not `MINI_PUBLISH_REPO`. CI never sets `MINI_PUBLISH_REPO` as an ambient var, so this stayed green there — but any shell configured for `./go auth` (bucket **and** publish-repo both set) hits the read-only branch and fails on `put()`.

Affected tests, all fixed the same way (add `monkeypatch.delenv('MINI_PUBLISH_REPO', raising=False)` next to the existing `MINI_STORE_BUCKET` clear):
- `tests/mini/test_apparatus.py` (2 tests)
- `tests/mini/test_experiments_e2e.py` (1 fixture, used by all demo e2e tests)
- `tests/mini/test_store_gc.py` (6 tests)

`ruff check` passes and the full suite (298 tests) now passes locally in an environment with both `MINI_STORE_BUCKET` and `MINI_PUBLISH_REPO` set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGUXiayHxXAQFbCEfPKMBL)_