### PR TITLE
Set blame.ignoreRevsFile automatically in ./go install

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -42,6 +42,15 @@ if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
     fi
 fi
 
+# Skip mechanical reformats in `git blame` (see .git-blame-ignore-revs). The web
+# image never runs `./go install` (which sets this for local checkouts), and the
+# config is repo-local so it can't be committed. It's instant, so do it here,
+# synchronously, before the async handoff — blame is then correct immediately.
+if [[ -d .git ]]; then
+    git config --local blame.ignoreRevsFile .git-blame-ignore-revs \
+        && log 'configured blame.ignoreRevsFile' || true
+fi
+
 # Everything below is slow; run it in the background so the session starts now.
 # `uv run` syncs on demand anyway, so the worst case is the first command
 # re-doing work this hook is also doing.

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,5 @@
 # Mechanical reformats — skipped by `git blame` (see `git blame --ignore-revs-file`).
-# Configure once: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+# `./go install` wires this up locally; GitHub honours it by default.
 
 # Switch Python string quote style from single to double
 91d519ebde7931ab1fcee857b3b4b0cd0aaa3aec

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,6 +42,11 @@ if [[ -d "$HOOKS_DST" ]]; then
         ln -sf "../../scripts/hooks/$name" "$HOOKS_DST/$name"
         echo "Installed git hook: $name"
     done
+
+    # Skip mechanical reformats in `git blame`. GitHub honours this file by
+    # default, but a local clone needs the config set (it can't be committed).
+    git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+    echo "Configured blame.ignoreRevsFile"
 fi
 
 echo "✅ Installation complete"


### PR DESCRIPTION
Make `git config blame.ignoreRevsFile .git-blame-ignore-revs` automatic in local checkouts.

GitHub honours `.git-blame-ignore-revs` by default, but a local clone needs the config set, and git can't commit repo-local config. So it was a manual "configure once" step. This folds it into `./go install` next to the git-hook setup — the devcontainer's `post-create.sh` runs `./go install`, and so does anyone setting up locally, so `git blame` skips the mechanical reformats without anyone having to remember the command.

The setting lives inside the existing `[[ -d .git/hooks ]]` guard, so it's a no-op when there's no git dir, and `git config --local` is idempotent on re-runs.

Also refreshed the header comment in `.git-blame-ignore-revs` to point at `./go install` instead of the manual command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6Bi2bGJdKUnkznert3X3P)_