### PR TITLE
Add CITATION.cff so the repo is citable

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -19,6 +19,7 @@ jobs:
           sed -i "s|z0u/mi-ni|${REPO}|g" README.md
           sed -i '/<!-- template-only -->/,/<!-- \/template-only -->/d' README.md .github/pull_request_template.md
           rm -f LICENSE
+          rm -f CITATION.cff
           rm -f .github/workflows/template-cleanup.yml
       - name: Commit and push
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "mi-ni: a template and library for AI research"
+abstract: >-
+  A template repository and library for doing AI research: local Marimo
+  notebooks published to GitHub Pages, remote GPU compute with Modal, and
+  detached, memoized experiments driven from a stateless CLI.
+type: software
+authors:
+  - family-names: Fraser
+    given-names: Sandy
+    orcid: "https://orcid.org/0009-0001-1026-1162"
+repository-code: "https://github.com/z0u/mi-ni"
+url: "https://z0u.github.io/mi-ni/"
+license: Unlicense
+version: "2.0"
+date-released: 2026-07-08
+# doi: "10.5281/zenodo.XXXXXXX"  # add the Zenodo concept DOI once archived

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,6 @@ authors:
 repository-code: "https://github.com/z0u/mi-ni"
 url: "https://z0u.github.io/mi-ni/"
 license: Unlicense
-version: "2.0"
+version: "3.0"
 date-released: 2026-07-08
 # doi: "10.5281/zenodo.XXXXXXX"  # add the Zenodo concept DOI once archived


### PR DESCRIPTION
Add a `CITATION.cff` at the repo root so people can cite the project.

GitHub reads this file natively and renders a **"Cite this repository"** button in the sidebar that produces APA and BibTeX, kept in sync from a single source (nicer than pasting BibTeX into the README).

Field choices:
- `url` → the GitHub Pages landing page (`https://z0u.github.io/mi-ni/`)
- `repository-code` → the source repo
- `authors` → Sandy Fraser, with ORCID
- `doi` → left commented, ready for a Zenodo concept DOI if/when a release is archived

No external identifier is required for this to work; a DOI is a separate, optional follow-up via Zenodo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpJFaYRw6wc1uwzqwMhc2Q)_